### PR TITLE
Remove the uninitialized instance variable warning

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1816,7 +1816,7 @@ class TestModule < Test::Unit::TestCase
 
   def test_uninitialized_instance_variable
     a = AttrTest.new
-    assert_warning(/instance variable @ivar not initialized/) do
+    assert_warning '' do
       assert_nil(a.ivar)
     end
     a.instance_variable_set(:@ivar, 42)

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -543,7 +543,6 @@ vm_getivar(VALUE obj, ID id, IC ic, rb_call_info_t *ci, int is_attr)
 	}
 
 	if (UNLIKELY(val == Qundef)) {
-	    if (!is_attr) rb_warning("instance variable %s not initialized", rb_id2name(id));
 	    val = Qnil;
 	}
 	return val;


### PR DESCRIPTION
Silly idea:

@rafaelfranca pointed out that `ruby -w` is unusable since there is so much "uninitialized instance variable" warnings, but still contains interesting warnings about deprecations.

It's not really realistic to cleanup the codebase to get rid of theses, since it's quite idiomatic to consider undefined as `nil`. So maybe we could simply silence them?

@rafaelfranca @csfrancis @camilo thoughts?

