### PR TITLE
Remove backtracing cleaning on Delegator methods

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -76,16 +76,13 @@ class Delegator < BasicObject
   def method_missing(m, *args, &block)
     r = true
     target = self.__getobj__ {r = false}
-    begin
-      if r && target.respond_to?(m)
-        target.__send__(m, *args, &block)
-      elsif ::Kernel.respond_to?(m, true)
-        ::Kernel.instance_method(m).bind(self).(*args, &block)
-      else
-        super(m, *args, &block)
-      end
-    ensure
-      $@.delete_if {|t| %r"\A#{Regexp.quote(__FILE__)}:(?:#{[__LINE__-7, __LINE__-5, __LINE__-3].join('|')}):"o =~ t} if $@
+
+    if r && target.respond_to?(m)
+      target.__send__(m, *args, &block)
+    elsif ::Kernel.respond_to?(m, true)
+      ::Kernel.instance_method(m).bind(self).(*args, &block)
+    else
+      super(m, *args, &block)
     end
   end
 
@@ -339,11 +336,7 @@ end
 def Delegator.delegating_block(mid) # :nodoc:
   lambda do |*args, &block|
     target = self.__getobj__
-    begin
-      target.__send__(mid, *args, &block)
-    ensure
-      $@.delete_if {|t| /\A#{Regexp.quote(__FILE__)}:#{__LINE__-2}:/o =~ t} if $@
-    end
+    target.__send__(mid, *args, &block)
   end
 end
 


### PR DESCRIPTION
This improve the performance in 18 times when the delegated method raises some exception and in 15% for the success case.

Here a benchmark result with a simpler script: (The backtrace have less than 10 items)

```
require 'delegate'
require 'benchmark/ips'

class Foo
  def name
    'foo'
  end

  def bla
    raise
  end
end

class Bar < DelegateClass(Foo)
end

bar = Bar.new(Foo.new)

Benchmark.ips do |b|
  b.report('default') { bar.name }
  b.report('default raising') { bar.bla rescue nil }
end
```

Before this patch:

```
$ ruby delegator_test.rb
Calculating -------------------------------------
             default    42.999k i/100ms
     default raising     1.456k i/100ms
-------------------------------------------------
             default      1.232M (± 9.9%) i/s -      6.106M
     default raising     14.399k (±13.6%) i/s -     71.344k
```

With this patch:

```
$ ruby delegator_test.rb
Calculating -------------------------------------
             default    49.024k i/100ms
     default raising    19.308k i/100ms
-------------------------------------------------
             default      1.484M (± 8.0%) i/s -      7.403M
     default raising    263.340k (± 8.0%) i/s -      1.313M
```

We could expect more performance difference in a huge application since their backtracers are bigger.

This changes the output of the exception from:

```
delegator_test.rb:18:in `bla': unhandled exception
    from delegator_test.rb:43:in `<main>'
```

To:

```
delegator_test.rb:18:in `bla': unhandled exception
    from /opt/ruby/lib/delegate.rb:340:in `block in delegating_block'
    from delegator_test.rb:43:in `<main>'
```

This patch is important because Rails 4.2 use Delegator in some critical paths.

From our production application this backtrace cleaner was one of the top 3 most CPU consuming calls. Here is the output of stackprof.

```
block (2 levels) in Delegator.delegating_block (/usr/lib/shopify-ruby/2.1.6-shopify2/lib/ruby/2.1.0/delegate.rb:345)
  samples:  1228 self (5.2%)  /   1228 total (5.2%)
  callers:
    1228  (  100.0%)  block in Delegator.delegating_block
  code:
 1228    (5.2%) /  1228   (5.2%)  |   345  |       $@.delete_if {|t| /\A#{Regexp.quote(__FILE__)}:#{__LINE__-2}:/o =~ t} if $@
                                  |   346  |     end
```

@tmm1 I believe the performance improvement justify a patch for ruby/ruby but want to hear your thoughts first. Do you think we could get it upstream?
