### PR TITLE
test gc change

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -1174,6 +1174,7 @@ size_t rb_obj_memsize_of(VALUE);
 #define RB_OBJ_GC_FLAGS_MAX 5
 size_t rb_obj_gc_flags(VALUE, ID[], size_t);
 void rb_gc_mark_values(long n, const VALUE *values);
+void rb_gc_fork_promote(void);
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/process.c
+++ b/process.c
@@ -3678,6 +3678,7 @@ rb_f_fork(VALUE obj)
 
     rb_secure(2);
 
+    rb_gc_fork_promote();
     switch (pid = rb_fork_ruby(NULL)) {
       case 0:
 	rb_thread_atfork();


### PR DESCRIPTION
Just some simple changes to handle the COW issues in ruby .

essentially we gc_mark the objects at fork time. We promote the objects to "old" objects in the parent, before fork.

I added a simple environment variable to enable the behaviour. 

some simple tests.

Stock ruby 2.1.6

```ruby
shiv@build-deb-shiv-57953.ec2:~ $ ruby mem.rb
ruby version 2.1.6
   time   pid message             shared    private
 4.008s 113416 Parent pre GC           68          0
 4.008s 113418 Child  pre GC           68          0
 8.014s 113416 Parent post GC           5         62
 8.092s 113418 Child  post GC           5         66
```

Ruby 2.2.3 without the changes

```ruby
shiv@build-deb-shiv-57953.ec2:~ $ /usr/lib/shopify-ruby/2.2.3-shopifyshivgctest3/bin/ruby ./mem.rb
ruby version 2.2.3
   time   pid message             shared    private
 4.008s 113454 Parent pre GC           70          0
 4.008s 113456 Child  pre GC           70          0
 8.014s 113454 Parent post GC           4         66
 8.093s 113456 Child  post GC           4         67
```

ruby 223. with the environment variable enabled

```ruby
shiv@build-deb-shiv-57953.ec2:~ $ GC_FORK_PROMOTE=1 /usr/lib/shopify-ruby/2.2.3-shopifyshivgctest3/bin/ruby ./mem.rb
ruby version 2.2.3
   time   pid message             shared    private
 4.044s 113471 Parent pre GC           70          2
 4.044s 113473 Child  pre GC           70          2
 8.051s 113471 Parent post GC          63          8
 8.094s 113473 Child  post GC          63          8
shiv@build-deb-shiv-57953.ec2:~ $
```

ruby 223 with the nakayoshi fork enabled.

```ruby
shiv@build-deb-shiv-57953.ec2:~ $ /usr/lib/shopify-ruby/2.2.3-shopifyshivgctest3/bin/ruby ./mem_nf.rb
ruby version 2.2.3
   time   pid message             shared    private
 4.089s 113728 Parent pre GC           70          0
 4.089s 113730 Child  pre GC           70          0
 8.040s 113730 Child  post GC          63          8
 8.096s 113728 Parent post GC           0         71
```

Second test

```ruby
shiv@build-deb-shiv-57953.ec2:~ $ ruby ~/mem1.rb
created 4194305 objects, consumed: 160 MB
before gc: {:total_mem=>"60387", :used_mem=>"4583", :free_mem=>"55803"}
before gc: {:total_mem=>"60387", :used_mem=>"4582", :free_mem=>"55804"}
before gc: {:total_mem=>"60387", :used_mem=>"4583", :free_mem=>"55803"}
before gc: {:total_mem=>"60387", :used_mem=>"4585", :free_mem=>"55802"}
before gc: {:total_mem=>"60387", :used_mem=>"4586", :free_mem=>"55801"}
before gc: {:total_mem=>"60387", :used_mem=>"4587", :free_mem=>"55800"}
before gc: {:total_mem=>"60387", :used_mem=>"4587", :free_mem=>"55799"}
before gc: {:total_mem=>"60387", :used_mem=>"4587", :free_mem=>"55799"}
before gc: {:total_mem=>"60387", :used_mem=>"4588", :free_mem=>"55798"}
before gc: {:total_mem=>"60387", :used_mem=>"4588", :free_mem=>"55798"}
after gc :{:total_mem=>"60387", :used_mem=>"4859", :free_mem=>"55528"}
after gc :{:total_mem=>"60387", :used_mem=>"4859", :free_mem=>"55528"}
after gc :{:total_mem=>"60387", :used_mem=>"4858", :free_mem=>"55528"}
after gc :{:total_mem=>"60387", :used_mem=>"4858", :free_mem=>"55528"}
after gc :{:total_mem=>"60387", :used_mem=>"4857", :free_mem=>"55529"}
after gc :{:total_mem=>"60387", :used_mem=>"4857", :free_mem=>"55529"}
after gc :{:total_mem=>"60387", :used_mem=>"4857", :free_mem=>"55529"}
after gc :{:total_mem=>"60387", :used_mem=>"4858", :free_mem=>"55529"}
after gc :{:total_mem=>"60387", :used_mem=>"4858", :free_mem=>"55529"}
after gc :{:total_mem=>"60387", :used_mem=>"4858", :free_mem=>"55529"}
after terminate all processes: {:total_mem=>"60387", :used_mem=>"4594", :free_mem=>"55793"}
shiv@build-deb-shiv-57953.ec2:~ $

```

Stock 223

```ruby
shiv@build-deb-shiv-57953.ec2:~ $ /usr/lib/shopify-ruby/2.2.3-shopifyshivgctest3/bin/ruby ./mem1.rb created 4194304 objects, consumed: 160 MB
before gc: {:total_mem=>"60387", :used_mem=>"4589", :free_mem=>"55797"}
before gc: {:total_mem=>"60387", :used_mem=>"4590", :free_mem=>"55797"}
before gc: {:total_mem=>"60387", :used_mem=>"4590", :free_mem=>"55797"}
before gc: {:total_mem=>"60387", :used_mem=>"4591", :free_mem=>"55796"}
before gc: {:total_mem=>"60387", :used_mem=>"4592", :free_mem=>"55795"}
before gc: {:total_mem=>"60387", :used_mem=>"4592", :free_mem=>"55795"}
before gc: {:total_mem=>"60387", :used_mem=>"4593", :free_mem=>"55794"}
before gc: {:total_mem=>"60387", :used_mem=>"4593", :free_mem=>"55793"}
before gc: {:total_mem=>"60387", :used_mem=>"4594", :free_mem=>"55793"}
before gc: {:total_mem=>"60387", :used_mem=>"4594", :free_mem=>"55793"}
after gc :{:total_mem=>"60387", :used_mem=>"5547", :free_mem=>"54840"}
after gc :{:total_mem=>"60387", :used_mem=>"5548", :free_mem=>"54839"}
after gc :{:total_mem=>"60387", :used_mem=>"5548", :free_mem=>"54839"}
after gc :{:total_mem=>"60387", :used_mem=>"5548", :free_mem=>"54838"}
after gc :{:total_mem=>"60387", :used_mem=>"5548", :free_mem=>"54838"}
after gc :{:total_mem=>"60387", :used_mem=>"5549", :free_mem=>"54838"}
after gc :{:total_mem=>"60387", :used_mem=>"5548", :free_mem=>"54838"}
after gc :{:total_mem=>"60387", :used_mem=>"5548", :free_mem=>"54838"}
after gc :{:total_mem=>"60387", :used_mem=>"5550", :free_mem=>"54837"}
after gc :{:total_mem=>"60387", :used_mem=>"5550", :free_mem=>"54837"}
after terminate all processes: {:total_mem=>"60387", :used_mem=>"4596", :free_mem=>"55791"}
shiv@build-deb-shiv-57953.ec2:~ $

```

223 with environment variable

```ruby

shiv@build-deb-shiv-57953.ec2:~ $ GC_FORK_PROMOTE=1 /usr/lib/shopify-ruby/2.2.3-shopifyshivgctest3/bin/ruby ./mem1.rb
created 4194304 objects, consumed: 160 MB
before gc: {:total_mem=>"60387", :used_mem=>"4591", :free_mem=>"55795"}
before gc: {:total_mem=>"60387", :used_mem=>"4597", :free_mem=>"55790"}
before gc: {:total_mem=>"60387", :used_mem=>"4602", :free_mem=>"55785"}
before gc: {:total_mem=>"60387", :used_mem=>"4606", :free_mem=>"55781"}
before gc: {:total_mem=>"60387", :used_mem=>"4611", :free_mem=>"55775"}
before gc: {:total_mem=>"60387", :used_mem=>"4617", :free_mem=>"55770"}
before gc: {:total_mem=>"60387", :used_mem=>"4622", :free_mem=>"55765"}
before gc: {:total_mem=>"60387", :used_mem=>"4626", :free_mem=>"55760"}
before gc: {:total_mem=>"60387", :used_mem=>"4631", :free_mem=>"55755"}
before gc: {:total_mem=>"60387", :used_mem=>"4635", :free_mem=>"55752"}
after gc :{:total_mem=>"60387", :used_mem=>"4641", :free_mem=>"55746"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55745"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55745"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55745"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55745"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55745"}
after gc :{:total_mem=>"60387", :used_mem=>"4643", :free_mem=>"55744"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55744"}
after gc :{:total_mem=>"60387", :used_mem=>"4643", :free_mem=>"55744"}
after gc :{:total_mem=>"60387", :used_mem=>"4642", :free_mem=>"55744"}
after terminate all processes: {:total_mem=>"60387", :used_mem=>"4597", :free_mem=>"55790"}
shiv@build-deb-shiv-57953.ec2:~ $

```

223 with nakayoshi fork

```ruby

shiv@build-deb-shiv-57953.ec2:~ $ /usr/lib/shopify-ruby/2.2.3-shopifyshivgctest3/bin/ruby ./mem1_nf.rb
created 4194304 objects, consumed: 160 MB
before gc: {:total_mem=>"60387", :used_mem=>"4593", :free_mem=>"55794"}
before gc: {:total_mem=>"60387", :used_mem=>"4593", :free_mem=>"55794"}
before gc: {:total_mem=>"60387", :used_mem=>"4594", :free_mem=>"55793"}
before gc: {:total_mem=>"60387", :used_mem=>"4595", :free_mem=>"55792"}
before gc: {:total_mem=>"60387", :used_mem=>"4595", :free_mem=>"55792"}
before gc: {:total_mem=>"60387", :used_mem=>"4597", :free_mem=>"55790"}
before gc: {:total_mem=>"60387", :used_mem=>"4597", :free_mem=>"55790"}
before gc: {:total_mem=>"60387", :used_mem=>"4598", :free_mem=>"55789"}
before gc: {:total_mem=>"60387", :used_mem=>"4599", :free_mem=>"55788"}
before gc: {:total_mem=>"60387", :used_mem=>"4600", :free_mem=>"55787"}
after gc :{:total_mem=>"60387", :used_mem=>"4646", :free_mem=>"55741"}
after gc :{:total_mem=>"60387", :used_mem=>"4646", :free_mem=>"55741"}
after gc :{:total_mem=>"60387", :used_mem=>"4646", :free_mem=>"55741"}
after gc :{:total_mem=>"60387", :used_mem=>"4647", :free_mem=>"55740"}
after gc :{:total_mem=>"60387", :used_mem=>"4646", :free_mem=>"55741"}
after gc :{:total_mem=>"60387", :used_mem=>"4646", :free_mem=>"55741"}
after gc :{:total_mem=>"60387", :used_mem=>"4647", :free_mem=>"55740"}
after gc :{:total_mem=>"60387", :used_mem=>"4647", :free_mem=>"55740"}
after gc :{:total_mem=>"60387", :used_mem=>"4647", :free_mem=>"55740"}
after gc :{:total_mem=>"60387", :used_mem=>"4647", :free_mem=>"55740"}
after terminate all processes: {:total_mem=>"60387", :used_mem=>"4600", :free_mem=>"55787"}
shiv@build-deb-shiv-57953.ec2:~ $

```

@csfrancis @camilo @rafaelfranca 

Maybe I can try and push these changes upstream, they seem general enough. 