### PR TITLE
Initial Vestige support for Ruby 2.2.3

### DIFF
--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -82,6 +82,10 @@ VALUE rb_tracearg_return_value(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_raised_exception(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_object(rb_trace_arg_t *trace_arg);
 
+#if VESTIGE_STATS
+rb_vestige_stats_t * rb_tracearg_gc_stats(rb_trace_arg_t *trace_arg);
+#endif /* VESTIGE_STATS */
+
 /* Postponed Job API */
 typedef void (*rb_postponed_job_func_t)(void *arg);
 int rb_postponed_job_register(unsigned int flags, rb_postponed_job_func_t func, void *data);

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -28,6 +28,10 @@ extern "C" {
 
 #include "defines.h"
 
+#if VESTIGE_STATS
+#include "vestige_stats.h"
+#endif /* VESTIGE_STATS */
+
 #define NORETURN_STYLE_NEW 1
 #ifndef NORETURN
 # define NORETURN(x) x

--- a/include/ruby/vestige_stats.h
+++ b/include/ruby/vestige_stats.h
@@ -1,0 +1,66 @@
+#ifndef VESTIGE_STATS_H
+#define VESTIGE_STATS_H 1
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+struct rb_vestige_stats_struct {
+    /* String representation of the tracing event */
+    const char * event;
+    /* Allow event-specific key/value pairs, keep
+     * everything in plain-old-C for speed. */
+    size_t size;
+    const char ** keys;
+    const char ** vals;
+};
+
+typedef struct rb_vestige_stats_struct rb_vestige_stats_t;
+
+/* Various stats helpers */
+
+#define VESTIGE_STATS_GENERATE_ENUM(ENUM) ENUM,
+#define VESTIGE_STATS_GENERATE_STR(STRING) #STRING,
+#define VESTIGE_STATS_GENERATE_NULL(ELEMENT) NULL,
+#define VESTIGE_STATS_SIZE() (int) (sizeof vestige_stats_keys / sizeof (char*))
+#define VESTIGE_STATS_UPDATE(entry, value) vestige_stats_vals[entry] = value
+
+#define VESTIGE_STATS_ENUM(GEN_FUNC) \
+    enum GC_VESTIGE_STATS_ENUM { \
+	GEN_FUNC(VESTIGE_STATS_GENERATE_ENUM) \
+    }
+
+#define VESTIGE_STATS_ARR_ELEM(NAME) NAME,
+
+#define VESTIGE_STATS_ARR(NAME, GEN_FUNC, ELEM_FUNC) \
+    static const char * NAME[] = \
+    { \
+	GEN_FUNC(ELEM_FUNC) \
+    }
+
+#define VESTIGE_STATS_KEYS(GEN_FUNC) VESTIGE_STATS_ARR(vestige_stats_keys, GEN_FUNC, VESTIGE_STATS_GENERATE_STR)
+#define VESTIGE_STATS_VALS(GEN_FUNC) VESTIGE_STATS_ARR(vestige_stats_vals, GEN_FUNC, VESTIGE_STATS_GENERATE_NULL)
+
+#define VESTIGE_STATS_SETUP(GEN_FUNC, STATS) \
+    VESTIGE_STATS_ENUM(GEN_FUNC); \
+    VESTIGE_STATS_KEYS(GEN_FUNC); \
+    VESTIGE_STATS_VALS(GEN_FUNC); \
+    STATS.size = VESTIGE_STATS_SIZE(); \
+    STATS.vals = &vestige_stats_vals[0]; \
+    STATS.keys = &vestige_stats_keys[0]
+
+#define VESTIGE_STATS_DUMP(stats) \
+    for(int i = 0; i < stats->size; i++) { \
+	fprintf(stderr, "Key '%s' -> Value '%s'\n", stats->keys[i], stats->vals[i]); \
+    }
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
+#endif /* VESTIGE_STATS_H */

--- a/vm_core.h
+++ b/vm_core.h
@@ -457,6 +457,9 @@ typedef struct rb_vm_struct {
 
 #if defined(ENABLE_VM_OBJSPACE) && ENABLE_VM_OBJSPACE
     struct rb_objspace *objspace;
+#if VESTIGE_STATS
+    rb_vestige_stats_t *gc_stats;
+#endif /* VESTIGE_STATS */
 #endif
 
     /*

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -871,6 +871,23 @@ rb_tracearg_object(rb_trace_arg_t *trace_arg)
     return trace_arg->data;
 }
 
+#if VESTIGE_STATS
+rb_vestige_stats_t *
+rb_tracearg_gc_stats(rb_trace_arg_t *trace_arg)
+{
+    if (trace_arg->event & (RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT)) {
+	/* ok */
+    }
+    else {
+	rb_raise(rb_eRuntimeError, "not supported by this event");
+    }
+    if (trace_arg->data == NULL) {
+	rb_bug("tp_attr_gc_stats: unreachable");
+    }
+    return (rb_vestige_stats_t *) trace_arg->data;
+}
+#endif /* VESTIGE_STATS */
+
 /*
  * Type of event
  *


### PR DESCRIPTION
Description:

* Added initial support for Vestige, use 'make CFLAGS="-DVESTIGE_STATS=1" when building MRI to enable support.
* Without specifying the flag above **no changes** will be compiled into the Ruby build.
* Added `rb_tracearg_gc_stats` getter for `GC_ENTER` and `GC_EXIT` events.
* Added extra tracing information for GC kickoff, marking, and sweeping phases.

Notes:

* Vestige can be used with an unmodified VM, but tracing information will not be as detailed (or useful).
* The goals of these changes are minimal impact on the VM, optional compile-time inclusion, and easy, safe ability to populate an arbitrary number of statistics with a constant memory cost and low runtime cost (e.g. no dynamic allocation).
* The stats API is oriented around publishing arbitrary key/value pairs to remove all logic/interpretation burdens from the Vestige gem.
* Note use of macro-generated enums to permit safe indexing into statistics arrays by name.

r: @fbogsany