### PR TITLE
Add gdbm dependencies to ruby builds with dbm.so

### DIFF
--- a/debian/control.erb
+++ b/debian/control.erb
@@ -4,7 +4,7 @@ Source: <%= package.name %>
 Section: ruby
 Priority: optional
 Maintainer: Shopify Ops <ops@shopify.com>
-Build-Depends: debhelper (>= 7.3), autoconf, bison, build-essential, devscripts, equivs, libreadline-gplv2-dev | libreadline-dev, ruby1.9.3|ruby, libssl-dev (>= 0.9.6b), libyaml-dev, zlib1g-dev, systemtap-sdt-dev, libffi-dev
+Build-Depends: debhelper (>= 7.3), autoconf, bison, build-essential, devscripts, equivs, libreadline-gplv2-dev | libreadline-dev, ruby1.9.3|ruby, libssl-dev (>= 0.9.6b), libyaml-dev, zlib1g-dev, systemtap-sdt-dev, libffi-dev, libgdbm3, libgdbm-dev
 Standards-Version: 3.9.4
 Homepage: https://github.com/Shopify/ruby
 Vcs-Git: git://github.com/Shopify/ruby.git


### PR DESCRIPTION
@shivnagarajan @csfrancis 

This does seem to make more sense.