### PR TITLE
Build a ruby that can be used with herokuish buildpacks, with dtrace probes enabled.

### DIFF
--- a/.shopify-build/ruby.yml
+++ b/.shopify-build/ruby.yml
@@ -38,6 +38,29 @@ steps:
 - <<: *package_builder
   label: Build xenial debs
   container: xenial
+- label: Build source tarball for buildpacks # similar to https://github.com/hone/docker-heroku-ruby-builder/blob/master/build.rb
+  container: trusty # to build for cedar, see https://github.com/heroku/heroku-buildpack-ruby/blob/f16fbb6cdd08b52af1149140b14619c5f14262c7/lib/language_pack/base.rb#L20
+  timeout: 15m
+  run:
+  - apt-get update
+  - apt-get install -y git openssh-client
+  - apt-get install -y autoconf bison build-essential equivs devscripts libreadline-dev libssl-dev libyaml-dev zlib1g-dev libffi-dev libgdbm3 libgdbm-dev # lifted from debian control file
+  - apt-get install -y systemtap-sdt-dev # needed for --enable-dtrace to work, which is (currently) the main point of doing this build
+  - apt-get install -y ruby2.0
+  - update-alternatives --install /usr/bin/ruby ruby2.0 /usr/bin/ruby2.0 10
+  - git clone git@github.com:shopify/ruby.git
+  - cd ruby
+  - git fetch --tags
+  - git checkout v2_5_1
+  - autoconf
+  - mkdir -p /tmp/rubybuild /artifacts
+  - ./configure --enable-dtrace debugflags="-g3 -ggdb" --prefix=/tmp/rubybuild
+  - make -j$(nproc)
+  - make install
+  - cd /tmp/rubybuild
+  - tar -czf /artifacts/ruby-2.5.1.tar.gz *
+  artifact_paths:
+  - /artifacts
 
 - block: "Publish debs"
 


### PR DESCRIPTION
Per our discussion on slack, this should build a ruby that is compatible with herokuish buildpacks, and follows similar steps to https://github.com/hone/docker-heroku-ruby-builder/blob/master/build.rb

The main thing that makes this worth building, vs the heroku one, is that the `systemtap-sdt-dev` package adds the files that trick the ruby build into thinking that dtrace exists on the system and is supported, which is what enables the USDT probes within the ruby VM.

With these enabled, we can get a bunch of interesting data out of the ruby VM with bpftrace, which has basically the same functionality as dtrace. 

I'm wondering if I should roll-up these steps into a separate script to make the shopify-build file a bit cleaner.

Right now this ships the tarball up to GCS, which is honestly good enough for "publishing". I have hardcoded this to 2.5.1 right now because I don't really understand the branch-based flow... pointers on that would be handy.

I still need to test out if the build artifact actually works with a herokuish buildpack, and if the resulting image works with bpftrace. If those don't work, then there's no point in doing any of this.

As a sidenote - looks like our debian packages already install the stub package needed to have dtrace enabled, so that's cool!