### PR TITLE
Make Thread#to_s consistent with Method and Proc to_s

### DIFF
--- a/spec/ruby/core/thread/shared/to_s.rb
+++ b/spec/ruby/core/thread/shared/to_s.rb
@@ -1,0 +1,13 @@
+describe :thread_to_s, shared: true do
+  sep = ruby_version_is("2.7") ? " " : "@"
+
+  describe "for a thread created with Thread.new" do
+    it "returns a description including file and line number" do
+      Thread.new { "hello" }.send(@method).should =~ /^#<Thread:([^ ]*?)#{sep}#{Regexp.escape __FILE__}:#{__LINE__ } \w+>$/
+    end
+
+    it "has a binary encoding" do
+      Thread.new { "hello" }.send(@method).encoding.should == Encoding::BINARY
+    end
+  end
+end

--- a/spec/ruby/core/thread/to_s_spec.rb
+++ b/spec/ruby/core/thread/to_s_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'shared/to_s'
 
-describe "Thread#inspect" do
-  it_behaves_like :thread_to_s, :inspect
+describe "Thread#to_s" do
+  it_behaves_like :thread_to_s, :to_s
 end

--- a/thread.c
+++ b/thread.c
@@ -3180,7 +3180,7 @@ rb_thread_to_s(VALUE thread)
         rb_str_catf(str, "@%"PRIsVALUE, target_th->name);
     }
     if ((loc = threadptr_invoke_proc_location(target_th)) != Qnil) {
-        rb_str_catf(str, "@%"PRIsVALUE":%"PRIsVALUE,
+        rb_str_catf(str, " %"PRIsVALUE":%"PRIsVALUE,
                     RARRAY_AREF(loc, 0), RARRAY_AREF(loc, 1));
         rb_gc_force_recycle(loc);
     }


### PR DESCRIPTION
Fix for: https://bugs.ruby-lang.org/issues/16412

This makes `Thread#to_s` consistent with the other objects displaying a source location.