### PR TITLE
WIP Hackdays method dispatch

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2213,11 +2213,15 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                 struct rb_kwarg_call_data *cd_kw = &kw_calls[ISEQ_COMPILE_DATA(iseq)->ci_kw_index++];
                                 cd_kw->ci_kw = *((struct rb_call_info_with_kwarg *)source_ci);
                                 cd = (struct rb_call_data *)cd_kw;
+                                cd->cc.orig_argc = cd->ci.orig_argc;
+                                cd->cc.flag = cd->ci.flag;
                                 assert(ISEQ_COMPILE_DATA(iseq)->ci_kw_index <= body->ci_kw_size);
                             }
                             else {
                                 cd = &body->call_data[ISEQ_COMPILE_DATA(iseq)->ci_index++];
                                 cd->ci = *source_ci;
+                                cd->cc.orig_argc = cd->ci.orig_argc;
+                                cd->cc.flag = cd->ci.flag;
                                 assert(ISEQ_COMPILE_DATA(iseq)->ci_index <= body->ci_size);
                             }
 
@@ -10320,6 +10324,8 @@ ibf_load_ci_entries(const struct ibf_load *load,
         calls[i].ci.mid = ibf_load_id(load, mid_index);
         calls[i].ci.flag = (unsigned int)ibf_load_small_value(load, &reading_pos);
         calls[i].ci.orig_argc = (int)ibf_load_small_value(load, &reading_pos);
+        calls[i].cc.flag = calls[i].ci.flag;
+        calls[i].cc.orig_argc = calls[i].ci.orig_argc;
     }
 
     for (i = 0; i < ci_kw_size; i++) {
@@ -10328,6 +10334,8 @@ ibf_load_ci_entries(const struct ibf_load *load,
         kw_calls[i].ci_kw.ci.mid = ibf_load_id(load, mid_index);
         kw_calls[i].ci_kw.ci.flag = (unsigned int)ibf_load_small_value(load, &reading_pos);
         kw_calls[i].ci_kw.ci.orig_argc = (int)ibf_load_small_value(load, &reading_pos);
+        kw_calls[i].ci_kw.ci.flag = kw_calls[i].ci_kw.ci.flag;
+        kw_calls[i].ci_kw.ci.orig_argc = kw_calls[i].ci_kw.ci.orig_argc;
 
         int keyword_len = (int)ibf_load_small_value(load, &reading_pos);
 

--- a/compile.c
+++ b/compile.c
@@ -2215,6 +2215,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                 cd = (struct rb_call_data *)cd_kw;
                                 cd->cc.orig_argc = cd->ci.orig_argc;
                                 cd->cc.flag = cd->ci.flag;
+                                cd->cc.mid = cd->ci.mid;
                                 assert(ISEQ_COMPILE_DATA(iseq)->ci_kw_index <= body->ci_kw_size);
                             }
                             else {
@@ -2222,6 +2223,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                 cd->ci = *source_ci;
                                 cd->cc.orig_argc = cd->ci.orig_argc;
                                 cd->cc.flag = cd->ci.flag;
+                                cd->cc.mid = cd->ci.mid;
                                 assert(ISEQ_COMPILE_DATA(iseq)->ci_index <= body->ci_size);
                             }
 
@@ -10326,6 +10328,7 @@ ibf_load_ci_entries(const struct ibf_load *load,
         calls[i].ci.orig_argc = (int)ibf_load_small_value(load, &reading_pos);
         calls[i].cc.flag = calls[i].ci.flag;
         calls[i].cc.orig_argc = calls[i].ci.orig_argc;
+        calls[i].cc.mid = calls[i].ci.mid;
     }
 
     for (i = 0; i < ci_kw_size; i++) {
@@ -10334,8 +10337,9 @@ ibf_load_ci_entries(const struct ibf_load *load,
         kw_calls[i].ci_kw.ci.mid = ibf_load_id(load, mid_index);
         kw_calls[i].ci_kw.ci.flag = (unsigned int)ibf_load_small_value(load, &reading_pos);
         kw_calls[i].ci_kw.ci.orig_argc = (int)ibf_load_small_value(load, &reading_pos);
-        kw_calls[i].ci_kw.ci.flag = kw_calls[i].ci_kw.ci.flag;
-        kw_calls[i].ci_kw.ci.orig_argc = kw_calls[i].ci_kw.ci.orig_argc;
+        kw_calls[i].cc.flag = kw_calls[i].ci_kw.ci.flag;
+        kw_calls[i].cc.orig_argc = kw_calls[i].ci_kw.ci.orig_argc;
+        kw_calls[i].cc.mid = kw_calls[i].ci_kw.ci.mid;
 
         int keyword_len = (int)ibf_load_small_value(load, &reading_pos);
 

--- a/insns.def
+++ b/insns.def
@@ -778,7 +778,7 @@ send
 // attr rb_snum_t sp_inc = sp_inc_of_sendish(&cd->ci);
 // attr rb_snum_t comptime_sp_inc = sp_inc_of_sendish(ci);
 {
-    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), &cd->ci, blockiseq, false);
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), &cd->cc, blockiseq, false);
     val = vm_sendish(ec, GET_CFP(), cd, bh, vm_search_method_wrap);
 
     if (val == Qundef) {
@@ -884,7 +884,7 @@ invokesuper
 // attr rb_snum_t sp_inc = sp_inc_of_sendish(&cd->ci);
 // attr rb_snum_t comptime_sp_inc = sp_inc_of_sendish(ci);
 {
-    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), &cd->ci, blockiseq, true);
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), &cd->cc, blockiseq, true);
     val = vm_sendish(ec, GET_CFP(), cd, bh, vm_search_super_method);
 
     if (val == Qundef) {

--- a/internal.h
+++ b/internal.h
@@ -2359,6 +2359,7 @@ struct rb_call_cache {
                   struct rb_control_frame_struct *cfp,
                   struct rb_calling_info *calling,
                   struct rb_call_data *cd);
+    /* cache call info argc and flags in the 4 byte cache line padding */
     short int orig_argc;
     short int flag;
     union {

--- a/internal.h
+++ b/internal.h
@@ -2341,7 +2341,7 @@ struct rb_call_cache {
         (CACHELINE
          - sizeof(rb_serial_t)                                   /* method_state */
          - sizeof(struct rb_callable_method_entry_struct *)      /* me */
-         - sizeof(struct rb_callable_method_definition_struct *) /* def */
+         - sizeof(ID)                                            /* mid */
          - sizeof(enum method_missing_reason)                    /* aux */
          - sizeof(VALUE (*)(                                     /* call */
                struct rb_execution_context_struct *e,
@@ -2353,7 +2353,7 @@ struct rb_call_cache {
 
     /* inline cache: values */
     const struct rb_callable_method_entry_struct *me;
-    const struct rb_method_definition_struct *def;
+    ID mid;
 
     VALUE (*call)(struct rb_execution_context_struct *ec,
                   struct rb_control_frame_struct *cfp,

--- a/internal.h
+++ b/internal.h
@@ -2359,7 +2359,8 @@ struct rb_call_cache {
                   struct rb_control_frame_struct *cfp,
                   struct rb_calling_info *calling,
                   struct rb_call_data *cd);
-
+    short int orig_argc;
+    short int flag;
     union {
         unsigned int index; /* used by ivar */
         enum method_missing_reason method_missing_reason; /* used by method_missing */
@@ -2369,8 +2370,8 @@ STATIC_ASSERT(cachelined, sizeof(struct rb_call_cache) <= CACHELINE);
 struct rb_call_info {
     /* fixed at compile time */
     ID mid;
-    unsigned int flag;
-    int orig_argc;
+    unsigned short int flag;
+    short int orig_argc;
 };
 struct rb_call_data {
     struct rb_call_cache cc;

--- a/internal.h
+++ b/internal.h
@@ -2360,8 +2360,8 @@ struct rb_call_cache {
                   struct rb_calling_info *calling,
                   struct rb_call_data *cd);
     /* cache call info argc and flags in the 4 byte cache line padding */
-    short int orig_argc;
-    short int flag;
+    unsigned short int orig_argc;
+    unsigned short int flag;
     union {
         unsigned int index; /* used by ivar */
         enum method_missing_reason method_missing_reason; /* used by method_missing */
@@ -2372,7 +2372,7 @@ struct rb_call_info {
     /* fixed at compile time */
     ID mid;
     unsigned short int flag;
-    short int orig_argc;
+    unsigned short int orig_argc;
 };
 struct rb_call_data {
     struct rb_call_cache cc;

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -100,7 +100,7 @@ fastpath_applied_iseq_p(const CALL_INFO ci, const CALL_CACHE cc, const rb_iseq_t
     return iseq != NULL
         && !(ci->flag & VM_CALL_KW_SPLAT) && rb_simple_iseq_p(iseq) // Top of vm_callee_setup_arg. In this case, opt_pc is 0.
         && ci->orig_argc == iseq->body->param.lead_num // exclude argument_arity_error (assumption: `calling->argc == ci->orig_argc` in send insns)
-        && vm_call_iseq_optimizable_p(ci, cc); // CC_SET_FASTPATH condition
+        && vm_call_iseq_optimizable_p(cc); // CC_SET_FASTPATH condition
 }
 
 static int

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -59,7 +59,7 @@
                 fprintf(f, "    {\n");
                 fprintf(f, "        struct rb_calling_info calling;\n");
 % if insn.name == 'send'
-                fprintf(f, "        calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, (CALL_INFO)0x%"PRIxVALUE", (rb_iseq_t *)0x%"PRIxVALUE", FALSE);\n", (VALUE)ci, (VALUE)blockiseq);
+                fprintf(f, "        calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, (CALL_CACHE)0x%"PRIxVALUE", (rb_iseq_t *)0x%"PRIxVALUE", FALSE);\n", (VALUE)cc_copy, (VALUE)blockiseq);
 % else
                 fprintf(f, "        calling.block_handler = VM_BLOCK_HANDLER_NONE;\n");
 % end

--- a/vm_args.c
+++ b/vm_args.c
@@ -1191,9 +1191,9 @@ refine_sym_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
 
 static VALUE
 vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
-                          const struct rb_call_info *ci, const rb_iseq_t *blockiseq, const int is_super)
+                          const struct rb_call_cache *cc, const rb_iseq_t *blockiseq, const int is_super)
 {
-    if (ci->flag & VM_CALL_ARGS_BLOCKARG) {
+    if (cc->flag & VM_CALL_ARGS_BLOCKARG) {
 	VALUE block_code = *(--reg_cfp->sp);
 
 	if (NIL_P(block_code)) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1095,6 +1095,7 @@ enum vm_call_flag_bits {
     VM_CALL_SUPER_bit,          /* super */
     VM_CALL_ZSUPER_bit,         /* zsuper */
     VM_CALL_OPT_SEND_bit,       /* internal flag */
+    VM_CALL_REFINED_bit,        /* refined */
     VM_CALL__END
 };
 
@@ -1110,6 +1111,7 @@ enum vm_call_flag_bits {
 #define VM_CALL_SUPER           (0x01 << VM_CALL_SUPER_bit)
 #define VM_CALL_ZSUPER          (0x01 << VM_CALL_ZSUPER_bit)
 #define VM_CALL_OPT_SEND        (0x01 << VM_CALL_OPT_SEND_bit)
+#define VM_CALL_REFINED         (0x01 << VM_CALL_REFINED_bit)
 
 enum vm_special_object_type {
     VM_SPECIAL_OBJECT_VMCORE = 1,

--- a/vm_core.h
+++ b/vm_core.h
@@ -250,8 +250,8 @@ struct rb_call_info_with_kwarg {
 struct rb_calling_info {
     VALUE block_handler;
     VALUE recv;
-    int argc;
-    int kw_splat;
+    short int argc;
+    short int kw_splat;
 };
 
 struct rb_kwarg_call_data {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1095,7 +1095,7 @@ enum vm_call_flag_bits {
     VM_CALL_SUPER_bit,          /* super */
     VM_CALL_ZSUPER_bit,         /* zsuper */
     VM_CALL_OPT_SEND_bit,       /* internal flag */
-    VM_CALL_REFINED_bit,        /* refined */
+    VM_CALL_UNREFINED_bit,        /* refined */
     VM_CALL__END
 };
 
@@ -1111,7 +1111,7 @@ enum vm_call_flag_bits {
 #define VM_CALL_SUPER           (0x01 << VM_CALL_SUPER_bit)
 #define VM_CALL_ZSUPER          (0x01 << VM_CALL_ZSUPER_bit)
 #define VM_CALL_OPT_SEND        (0x01 << VM_CALL_OPT_SEND_bit)
-#define VM_CALL_REFINED         (0x01 << VM_CALL_REFINED_bit)
+#define VM_CALL_UNREFINED       (0x01 << VM_CALL_UNREFINED_bit)
 
 enum vm_special_object_type {
     VM_SPECIAL_OBJECT_VMCORE = 1,

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -47,7 +47,7 @@ rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
 {
     struct rb_calling_info calling = { Qundef, recv, argc, kw_splat, };
     struct rb_call_info ci = { id, (kw_splat ? VM_CALL_KW_SPLAT : 0), argc, };
-    struct rb_call_cache cc = { 0, { 0, }, me, me->def, vm_call_general, { 0, }, };
+    struct rb_call_cache cc = { 0, { 0, }, me, me->def, vm_call_general, argc, ci.flag, { 0, }, };
     struct rb_call_data cd = { cc, ci, };
     return vm_call0_body(ec, &calling, &cd, argv);
 }

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -47,7 +47,7 @@ rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
 {
     struct rb_calling_info calling = { Qundef, recv, argc, kw_splat, };
     struct rb_call_info ci = { id, (kw_splat ? VM_CALL_KW_SPLAT : 0), argc, };
-    struct rb_call_cache cc = { 0, { 0, }, me, me->def, vm_call_general, argc, ci.flag, { 0, }, };
+    struct rb_call_cache cc = { 0, { 0, }, me, id, vm_call_general, argc, ci.flag, { 0, }, };
     struct rb_call_data cd = { cc, ci, };
     return vm_call0_body(ec, &calling, &cd, argv);
 }
@@ -180,7 +180,8 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, struc
 	    }
 	    else if (cc->me->def->body.refined.orig_me) {
 		cc->me = refined_method_callable_without_refinement(cc->me);
-		goto again;
+		cc->flag |= VM_CALL_REFINED;
+        goto again;
 	    }
 
 	    super_class = RCLASS_SUPER(super_class);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1451,8 +1451,8 @@ calccall(const struct rb_call_data *cd, const rb_callable_method_entry_t *me)
      * explicit receiver" is the only situation we have to check here.  A
      * formerly-private method now publicised is an absolutely safe thing.
      * Calling a private method without specifying a receiver is also safe. */
-    else if ((METHOD_ENTRY_VISI(cc->me) != METHOD_VISI_PUBLIC) &&
-             !(cc->flag & VM_CALL_FCALL)) {
+    else if (UNLIKELY((METHOD_ENTRY_VISI(cc->me) != METHOD_VISI_PUBLIC) &&
+             !(cc->flag & VM_CALL_FCALL))) {
         RB_DEBUG_COUNTER_INC(mc_miss_by_visi);
         return vm_call_general;
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1432,7 +1432,6 @@ __attribute__((__artificial__))
 static inline vm_call_handler
 calccall(const struct rb_call_data *cd, const rb_callable_method_entry_t *me)
 {
-    const struct rb_call_info *ci = &cd->ci;
     const struct rb_call_cache *cc = &cd->cc;
 
     if (UNLIKELY(!me)) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3022,7 +3022,6 @@ vm_call_method_nome(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct 
 static inline VALUE
 vm_call_method(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, struct rb_call_data *cd)
 {
-    const struct rb_call_info *ci = &cd->ci;
     struct rb_call_cache *cc = &cd->cc;
 
     VM_ASSERT(callable_method_entry_p(cc->me));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2249,7 +2249,6 @@ static inline VALUE
 vm_call_iseq_setup_2(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, struct rb_call_data *cd,
 		     int opt_pc, int param_size, int local_size)
 {
-    const struct rb_call_info *ci = &cd->ci;
     const struct rb_call_cache *cc = &cd->cc;
 
     if (LIKELY(!(cc->flag & VM_CALL_TAILCALL))) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2113,7 +2113,6 @@ vm_call_iseq_setup_kwparm_nokwarg(rb_execution_context_t *ec, rb_control_frame_t
                                   struct rb_calling_info *calling,
                                   struct rb_call_data *cd)
 {
-    const struct rb_call_info *MAYBE_UNUSED(ci) = &cd->ci;
     const struct rb_call_cache *cc = &cd->cc;
 
     VM_ASSERT((cc->flag & VM_CALL_KWARG) == 0);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4009,7 +4009,6 @@ vm_sendish(
         struct rb_call_data *cd,
         VALUE recv))
 {
-    const CALL_INFO ci = &cd->ci;
     const CALL_CACHE cc = &cd->cc;
     VALUE val;
     int argc = cc->orig_argc;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4012,10 +4012,6 @@ vm_sendish(
     const CALL_INFO ci = &cd->ci;
     const CALL_CACHE cc = &cd->cc;
     VALUE val;
-    if (UNLIKELY(cc->me == NULL)) {
-        cc->orig_argc = ci->orig_argc;
-        cc->flag = ci->flag;
-    }
     int argc = cc->orig_argc;
     VALUE recv = TOPN(argc);
     struct rb_calling_info calling;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1985,8 +1985,7 @@ CALLER_SETUP_ARG(struct rb_control_frame_struct *restrict cfp,
 
 static inline void
 CALLER_REMOVE_EMPTY_KW_SPLAT(struct rb_control_frame_struct *restrict cfp,
-                             struct rb_calling_info *restrict calling,
-                             const struct rb_call_info *restrict ci)
+                             struct rb_calling_info *restrict calling)
 {
     if (UNLIKELY(calling->kw_splat)) {
         /* This removes the last Hash object if it is empty.
@@ -2149,7 +2148,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
         if (LIKELY(rb_simple_iseq_p(iseq))) {
             rb_control_frame_t *cfp = ec->cfp;
             CALLER_SETUP_ARG(cfp, calling, ci);
-            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling, ci);
+            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling);
 
             if (calling->argc != iseq->body->param.lead_num) {
                 argument_arity_error(ec, iseq, calling->argc, iseq->body->param.lead_num, iseq->body->param.lead_num);
@@ -2161,7 +2160,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
         else if (rb_iseq_only_optparam_p(iseq)) {
             rb_control_frame_t *cfp = ec->cfp;
             CALLER_SETUP_ARG(cfp, calling, ci);
-            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling, ci);
+            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling);
 
             const int lead_num = iseq->body->param.lead_num;
             const int opt_num = iseq->body->param.opt_num;
@@ -2533,7 +2532,7 @@ vm_call_cfunc(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb
 
     CALLER_SETUP_ARG(reg_cfp, calling, ci);
     empty_kw_splat = calling->kw_splat;
-    CALLER_REMOVE_EMPTY_KW_SPLAT(reg_cfp, calling, ci);
+    CALLER_REMOVE_EMPTY_KW_SPLAT(reg_cfp, calling);
     if (empty_kw_splat && calling->kw_splat) {
         empty_kw_splat = 0;
     }
@@ -2935,7 +2934,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
             rb_warn_keyword_to_last_hash(ec, calling, ci, NULL);
         }
         else {
-            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling, ci);
+            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling);
         }
 
 	rb_check_arity(calling->argc, 1, 1);
@@ -2945,7 +2944,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
 
       case VM_METHOD_TYPE_IVAR:
         CALLER_SETUP_ARG(cfp, calling, ci);
-        CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling, ci);
+        CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling);
 	rb_check_arity(calling->argc, 0, 0);
 	cc->aux.index = 0;
         CC_SET_FASTPATH(cc, vm_call_ivar, !(cc->flag & VM_CALL_ARGS_SPLAT));
@@ -3271,7 +3270,7 @@ vm_callee_setup_block_arg(rb_execution_context_t *ec, struct rb_calling_info *ca
             rb_warn_keyword_to_last_hash(ec, calling, ci, iseq);
         }
         else {
-            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling, ci);
+            CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling);
         }
 
 	if (arg_setup_type == arg_setup_block &&
@@ -3372,7 +3371,7 @@ vm_invoke_ifunc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     int argc;
     int kw_splat = calling->kw_splat;
     CALLER_SETUP_ARG(ec->cfp, calling, ci);
-    CALLER_REMOVE_EMPTY_KW_SPLAT(ec->cfp, calling, ci);
+    CALLER_REMOVE_EMPTY_KW_SPLAT(ec->cfp, calling);
     if (kw_splat && !calling->kw_splat) {
         kw_splat = 2;
     }

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -238,17 +238,18 @@ THROW_DATA_CONSUMED_SET(struct vm_throw_data *obj)
     }
 }
 
-#define IS_ARGS_SPLAT(ci)   ((ci)->flag & VM_CALL_ARGS_SPLAT)
-#define IS_ARGS_KEYWORD(ci) ((ci)->flag & VM_CALL_KWARG)
-#define IS_ARGS_KW_SPLAT(ci) ((ci)->flag & VM_CALL_KW_SPLAT)
-#define IS_ARGS_KW_OR_KW_SPLAT(ci) ((ci)->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT))
+// Macro argument can be either rb_call_info or rb_call_cache
+#define IS_ARGS_SPLAT(c)   ((c)->flag & VM_CALL_ARGS_SPLAT)
+#define IS_ARGS_KEYWORD(c) ((c)->flag & VM_CALL_KWARG)
+#define IS_ARGS_KW_SPLAT(c) ((c)->flag & VM_CALL_KW_SPLAT)
+#define IS_ARGS_KW_OR_KW_SPLAT(c) ((c)->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT))
 
 /* If this returns true, an optimized function returned by `vm_call_iseq_setup_func`
    can be used as a fastpath. */
 static bool
-vm_call_iseq_optimizable_p(const struct rb_call_info *ci, const struct rb_call_cache *cc)
+vm_call_iseq_optimizable_p( const struct rb_call_cache *cc)
 {
-    return !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) &&
+    return !IS_ARGS_SPLAT(cc) && !IS_ARGS_KEYWORD(cc) &&
         !(METHOD_ENTRY_VISI(cc->me) == METHOD_VISI_PROTECTED);
 }
 


### PR DESCRIPTION
On digging a little deeper in a Intel VTune Amplifier profiler I noticed the memory bound line referencing argc on the `rb_call_info` struct.

![before](https://user-images.githubusercontent.com/379/70671705-d7c4bb80-1c74-11ea-8622-74824b85ae68.png)

Looking at the struct layout in master we have:

```
lourens@CarbonX1:~/src/ruby/trunk$ pahole -C rb_call_info ./miniruby
struct rb_call_info {
	ID                         mid;                  /*     0     8 */
	unsigned int               flag;                 /*     8     4 */
	int                        orig_argc;            /*    12     4 */

	/* size: 16, cachelines: 1, members: 3 */
	/* last cacheline: 16 bytes */
};
lourens@CarbonX1:~/src/ruby/trunk$ pahole -C rb_call_cache ./miniruby
struct rb_call_cache {
	rb_serial_t                method_state;         /*     0     8 */
	rb_serial_t                class_serial[3];      /*     8    24 */
	const struct rb_callable_method_entry_struct  * me; /*    32     8 */
	const struct rb_method_definition_struct  * def; /*    40     8 */
	VALUE                      (*call)(struct rb_execution_context_struct *, struct rb_control_frame_struct *, struct rb_calling_info *, struct rb_call_data *); /*    48     8 */
	union {
		unsigned int       index;                /*    56     4 */
		enum method_missing_reason method_missing_reason; /*    56     4 */
	} aux;                                           /*    56     4 */

	/* size: 64, cachelines: 1, members: 6 */
	/* padding: 4 */
};
lourens@CarbonX1:~/src/ruby/trunk$ pahole -C rb_call_data ./miniruby
struct rb_call_data {
	struct rb_call_cache cc;                         /*     0    64 */

	/* XXX last struct has 4 bytes of padding */

	/* --- cacheline 1 boundary (64 bytes) --- */
	struct rb_call_info ci;                          /*    64    16 */

	/* size: 80, cachelines: 2, members: 2 */
	/* paddings: 1, sum paddings: 4 */
	/* last cacheline: 16 bytes */
};
```

Conclusions:

* `rb_call_data` is a wrapper / container for both the inline method cache and the "static" `rb_call_info` struct (ideally should be qualified as `const`, but it changes state at runtime and hydrating from dumped bytecode is complicated otherwise)
* This looks like the classic hot / cold struct split, HOWEVER only the inline method call cache fits into a single cache line with the whole call info struct spilling over into the next.
* If we look at `rb_call_cache` layout, there's 4 bytes of padding up for grabs to cache additional concerns
* A skim through the VM source revealed that the `orig_argc` and `flag` members are referenced regularly at runtime, with a bit of chicken and egg going on with this hot / cold struct container split.

Approaches taken:

* Given the set of flags currently used being minimal, a 2 byte `short int` would suffice for a `flag` member mirroring the `flag` member on `rb_call_info`
* Given the maximum number of arguments ruby supports is 16 (update: for cfuncs only, max 65k using `unsigned short int`, see https://github.com/Shopify/ruby/pull/3#issuecomment-564944999), a 2 byte `short int` would also work for mirroring `orig_argc` from the call info to the cache struct.
* The 4 byte padding is perfect for this.

Layout after:

```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C rb_call_info ./miniruby
struct rb_call_info {
	ID                         mid;                  /*     0     8 */
	short unsigned int         flag;                 /*     8     2 */
	short int                  orig_argc;            /*    10     2 */

	/* size: 16, cachelines: 1, members: 3 */
	/* padding: 4 */
	/* last cacheline: 16 bytes */
};
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C rb_call_cache ./miniruby
struct rb_call_cache {
	rb_serial_t                method_state;         /*     0     8 */
	rb_serial_t                class_serial[3];      /*     8    24 */
	const struct rb_callable_method_entry_struct  * me; /*    32     8 */
	const struct rb_method_definition_struct  * def; /*    40     8 */
	VALUE                      (*call)(struct rb_execution_context_struct *, struct rb_control_frame_struct *, struct rb_calling_info *, struct rb_call_data *); /*    48     8 */
	short int                  orig_argc;            /*    56     2 */
	short int                  flag;                 /*    58     2 */
	union {
		unsigned int       index;                /*    60     4 */
		enum method_missing_reason method_missing_reason; /*    60     4 */
	} aux;                                           /*    60     4 */

	/* size: 64, cachelines: 1, members: 8 */
};
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C rb_call_data ./miniruby
struct rb_call_data {
	struct rb_call_cache cc;                         /*     0    64 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	struct rb_call_info ci;                          /*    64    16 */

	/* XXX last struct has 4 bytes of padding */

	/* size: 80, cachelines: 2, members: 2 */
	/* paddings: 1, sum paddings: 4 */
	/* last cacheline: 16 bytes */
};
```

Conclusions:

* I tried to shrink the call info struct's ints to short ints, but it doesn't make a size difference to the struct, cause well, padding.
* Therefore the containing call data struct also doesn't change in size (I'll revert this)
* We do however end up with a nice fully packed `rb_call_cache` struct and managed to sneak the `flag` and `orig_argc` in.

Direction of this optimization:

* Try to use a single cache line for most call and cache data specific operations
* Needs to also be backwards compatible with dumped bytecode (dumped as call info, hydrated as call data and the cache member needs to reflect the new flag and argc members too)
* Reduce locals referencing `rb_call_info` structs in some of the `vm_` (hot, supports iseqs directly) functions
* Allow `flag` checks to be interchangeable with either `rb_call_info` or `rb_cache_info` as they both have the same member and not all helper methods pass call data OR call cache as arguments.
* This approach does not clobber the mjit implementation

I'll do some further testing tomorrow.