### PR TITLE
[WIP] Deduplicate Regexp literals

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -86,6 +86,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/rational.h"
+#include "internal/re.h"
 #include "internal/sanitizers.h"
 #include "internal/struct.h"
 #include "internal/symbol.h"
@@ -2710,11 +2711,8 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         }
 	break;
       case T_REGEXP:
-	if (RANY(obj)->as.regexp.ptr) {
-	    onig_free(RANY(obj)->as.regexp.ptr);
-            RB_DEBUG_COUNTER_INC(obj_regexp_ptr);
-	}
-	break;
+          rb_reg_free(obj);
+          break;
       case T_DATA:
 	if (DATA_PTR(obj)) {
 	    int free_immediately = FALSE;

--- a/internal/re.h
+++ b/internal/re.h
@@ -14,6 +14,7 @@
 
 /* re.c */
 VALUE rb_reg_compile(VALUE str, int options, const char *sourcefile, int sourceline);
+void rb_reg_free(VALUE re);
 VALUE rb_reg_check_preprocess(VALUE);
 long rb_reg_search0(VALUE, VALUE, long, int, int);
 VALUE rb_reg_match_p(VALUE re, VALUE str, long pos);

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -115,6 +115,7 @@ int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
 MJIT_STATIC VALUE ruby_vm_special_exception_copy(VALUE);
 PUREFUNC(st_table *rb_vm_fstring_table(void));
+PUREFUNC(st_table *rb_vm_regexp_literals_table(void));
 
 MJIT_SYMBOL_EXPORT_BEGIN
 VALUE vm_exec(struct rb_execution_context_struct *, int); /* used in JIT-ed code */

--- a/re.c
+++ b/re.c
@@ -2980,7 +2980,8 @@ reg_lit_update_callback(st_data_t *key, st_data_t *value, st_data_t arg, int exi
         FL_SET(re, REG_LITERAL);
         rb_obj_freeze(re);
 
-        *key = *value = *new_re = re;
+        *key = *new_re = re;
+        *value = RREGEXP_SRC(re);
         return ST_CONTINUE;
     }
 }

--- a/re.c
+++ b/re.c
@@ -13,12 +13,15 @@
 
 #include <ctype.h>
 
+#include "debug_counter.h"
 #include "encindex.h"
+#include "gc.h"
 #include "internal.h"
 #include "internal/error.h"
 #include "internal/hash.h"
 #include "internal/imemo.h"
 #include "internal/re.h"
+#include "internal/vm.h"
 #include "regint.h"
 #include "ruby/encoding.h"
 #include "ruby/re.h"
@@ -2956,20 +2959,90 @@ rb_reg_new(const char *s, long len, int options)
     return rb_enc_reg_new(s, len, rb_ascii8bit_encoding(), options);
 }
 
+static int
+reg_lit_update_callback(st_data_t *key, st_data_t *value, st_data_t arg, int existing)
+{
+    VALUE *new_re = (VALUE *)arg;
+    VALUE re = (VALUE)*key;
+
+    if (existing) {
+        /* because of lazy sweep, str may be unmarked already and swept
+        * at next time */
+
+        if (rb_objspace_garbage_object_p(re)) {
+            *new_re = Qundef;
+            return ST_DELETE;
+        }
+
+        *new_re = re;
+        return ST_STOP;
+    } else {
+        FL_SET(re, REG_LITERAL);
+        rb_obj_freeze(re);
+
+        *key = *value = *new_re = re;
+        return ST_CONTINUE;
+    }
+}
+
+
+static st_index_t
+reg_hash(VALUE re)
+{
+    st_index_t hashval;
+    hashval = RREGEXP_PTR(re)->options;
+    hashval = rb_hash_uint(hashval, rb_memhash(RREGEXP_SRC_PTR(re), RREGEXP_SRC_LEN(re)));
+    return rb_hash_end(hashval);
+}
+
+/*
+ * call-seq:
+ *   rxp.hash   -> integer
+ *
+ * Produce a hash based on the text and options of this regular expression.
+ *
+ * See also Object#hash.
+ */
+
+static VALUE
+rb_reg_hash(VALUE re)
+{
+    rb_reg_check(re);
+    st_index_t hashval = reg_hash(re);
+    return ST2FIX(hashval);
+}
+
 VALUE
 rb_reg_compile(VALUE str, int options, const char *sourcefile, int sourceline)
 {
-    VALUE re = rb_reg_alloc();
+    VALUE re, ret;
     onig_errmsg_buffer err = "";
+    st_table *regexp_literals = rb_vm_regexp_literals_table();
 
     if (!str) str = rb_str_new(0,0);
+    re = rb_reg_alloc();
     if (rb_reg_initialize_str(re, str, options, err, sourcefile, sourceline) != 0) {
-	rb_set_errinfo(rb_reg_error_desc(str, options, err));
-	return Qnil;
+        rb_set_errinfo(rb_reg_error_desc(str, options, err));
+        return Qnil;
     }
-    FL_SET(re, REG_LITERAL);
-    rb_obj_freeze(re);
-    return re;
+
+    do {
+        ret = re;
+        st_update(regexp_literals, (st_data_t)re,
+        reg_lit_update_callback, (st_data_t)&ret);
+    } while (ret == Qundef);
+    return ret;
+}
+
+void
+rb_reg_free(VALUE re) {
+    if (FL_TEST(re, REG_LITERAL)) {
+        st_data_t regexp_literal = (st_data_t)re;
+        st_delete(rb_vm_regexp_literals_table(), &regexp_literal, NULL);
+    }
+
+    onig_free(RREGEXP_PTR(re));
+    RB_DEBUG_COUNTER_INC(obj_regexp_ptr);
 }
 
 static VALUE reg_cache;
@@ -2985,34 +3058,24 @@ rb_reg_regcomp(VALUE str)
     return reg_cache = rb_reg_new_str(str, 0);
 }
 
-static st_index_t reg_hash(VALUE re);
-/*
- * call-seq:
- *   rxp.hash   -> integer
- *
- * Produce a hash based on the text and options of this regular expression.
- *
- * See also Object#hash.
- */
-
-static VALUE
-rb_reg_hash(VALUE re)
+static int
+reg_cmp(VALUE re1, VALUE re2)
 {
-    st_index_t hashval = reg_hash(re);
-    return ST2FIX(hashval);
+    if (re1 == re2) return 0;
+
+    if (!RB_TYPE_P(re2, T_REGEXP)) return 1;
+    if (FL_TEST(re1, KCODE_FIXED) != FL_TEST(re2, KCODE_FIXED)) return 1;
+    if (RREGEXP_PTR(re1)->options != RREGEXP_PTR(re2)->options) return 1;
+    if (RREGEXP_SRC_LEN(re1) != RREGEXP_SRC_LEN(re2)) return 1;
+    if (ENCODING_GET(re1) != ENCODING_GET(re2)) return 1;
+
+    return memcmp(RREGEXP_SRC_PTR(re1), RREGEXP_SRC_PTR(re2), RREGEXP_SRC_LEN(re1));
 }
 
-static st_index_t
-reg_hash(VALUE re)
-{
-    st_index_t hashval;
-
-    rb_reg_check(re);
-    hashval = RREGEXP_PTR(re)->options;
-    hashval = rb_hash_uint(hashval, rb_memhash(RREGEXP_SRC_PTR(re), RREGEXP_SRC_LEN(re)));
-    return rb_hash_end(hashval);
-}
-
+const struct st_hash_type rb_regexp_literal_hash_type = {
+    reg_cmp,
+    reg_hash,
+};
 
 /*
  *  call-seq:
@@ -3035,14 +3098,7 @@ rb_reg_equal(VALUE re1, VALUE re2)
     if (re1 == re2) return Qtrue;
     if (!RB_TYPE_P(re2, T_REGEXP)) return Qfalse;
     rb_reg_check(re1); rb_reg_check(re2);
-    if (FL_TEST(re1, KCODE_FIXED) != FL_TEST(re2, KCODE_FIXED)) return Qfalse;
-    if (RREGEXP_PTR(re1)->options != RREGEXP_PTR(re2)->options) return Qfalse;
-    if (RREGEXP_SRC_LEN(re1) != RREGEXP_SRC_LEN(re2)) return Qfalse;
-    if (ENCODING_GET(re1) != ENCODING_GET(re2)) return Qfalse;
-    if (memcmp(RREGEXP_SRC_PTR(re1), RREGEXP_SRC_PTR(re2), RREGEXP_SRC_LEN(re1)) == 0) {
-	return Qtrue;
-    }
-    return Qfalse;
+    return reg_cmp(re1, re2) == 0 ? Qtrue : Qfalse;
 }
 
 /*

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -62,6 +62,13 @@ class TestRegexp < Test::Unit::TestCase
     Regexp.union("a", "a")
   end
 
+  def test_literal_deduplication
+    assert_same(/a/, /a/)
+    refute_same(/a/, /a/m)
+    refute_same(/a/, Regexp.new('a'))
+    assert_equal(/a/, Regexp.new('a'))
+  end
+
   def test_to_s
     assert_equal '(?-mix:\x00)', Regexp.new("\0").to_s
 

--- a/vm.c
+++ b/vm.c
@@ -2241,6 +2241,7 @@ rb_vm_update_references(void *ptr)
     if (ptr) {
         rb_vm_t *vm = ptr;
         rb_gc_update_tbl_refs(vm->frozen_strings);
+        rb_gc_update_tbl_refs(vm->regexp_literals);
     }
 }
 
@@ -2353,6 +2354,10 @@ ruby_vm_destruct(rb_vm_t *vm)
 	if (vm->frozen_strings) {
 	    st_free_table(vm->frozen_strings);
 	    vm->frozen_strings = 0;
+	}
+	if (vm->regexp_literals) {
+	    st_free_table(vm->regexp_literals);
+	    vm->regexp_literals = 0;
 	}
 	rb_vm_gvl_destroy(vm);
 	RB_ALTSTACK_FREE(vm->main_altstack);
@@ -3310,6 +3315,7 @@ rb_vm_set_progname(VALUE filename)
 }
 
 extern const struct st_hash_type rb_fstring_hash_type;
+extern const struct st_hash_type rb_regexp_literal_hash_type;
 
 void
 Init_BareVM(void)
@@ -3345,6 +3351,7 @@ Init_vm_objects(void)
     vm->mark_object_ary = rb_ary_tmp_new(128);
     vm->loading_table = st_init_strtable();
     vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 1000);
+    vm->regexp_literals = st_init_table_with_size(&rb_regexp_literal_hash_type, 1000);
 }
 
 /* top self */
@@ -3404,6 +3411,12 @@ st_table *
 rb_vm_fstring_table(void)
 {
     return GET_VM()->frozen_strings;
+}
+
+st_table *
+rb_vm_regexp_literals_table(void)
+{
+    return GET_VM()->regexp_literals;
 }
 
 #if VM_COLLECT_USAGE_DETAILS

--- a/vm.c
+++ b/vm.c
@@ -2296,7 +2296,7 @@ rb_vm_mark(void *ptr)
 	rb_hook_list_mark(&vm->global_hooks);
 
 	rb_gc_mark_values(RUBY_NSIG, vm->trap_list.cmd);
-
+        rb_mark_tbl_no_pin(vm->regexp_literals);
         mjit_mark();
     }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -662,6 +662,7 @@ typedef struct rb_vm_struct {
 
     VALUE *defined_strings;
     st_table *frozen_strings;
+    st_table *regexp_literals;
 
     const struct rb_builtin_function *builtin_function_table;
     int builtin_inline_index;


### PR DESCRIPTION
Real world application contain many duplicated Regexp literals.

From a rails/console in Redmine:

```
>> ObjectSpace.each_object(Regexp).count
=> 6828
>> ObjectSpace.each_object(Regexp).uniq.count
=> 4162
>> ObjectSpace.each_object(Regexp).to_a.map { |r| ObjectSpace.memsize_of(r) }.sum
=> 4611957 # 4.4 MB total
>> ObjectSpace.each_object(Regexp).to_a.map { |r| ObjectSpace.memsize_of(r) }.sum - ObjectSpace.each_object(Regexp).to_a.uniq.map { |r| ObjectSpace.memsize_of(r) }.sum
=> 1490601 # 1.42 MB could be saved
```

Here's the to 10 duplicated regexps in Redmine:

```
147: /"/
107: /\s+/
103: //
89: /\n/
83: /'/
76: /\s+/m
37: /\d+/
35: /\[/
33: /./
33: /\\./
```