### PR TITLE
[WIP] Deduplicate Regexp literals (take 2)

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -62,6 +62,13 @@ class TestRegexp < Test::Unit::TestCase
     Regexp.union("a", "a")
   end
 
+  def test_literal_deduplication
+    assert_same(/a/, /a/)
+    refute_same(/a/, /a/m)
+    refute_same(/a/, Regexp.new('a'))
+    assert_equal(/a/, Regexp.new('a'))
+  end
+
   def test_to_s
     assert_equal '(?-mix:\x00)', Regexp.new("\0").to_s
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -634,6 +634,7 @@ typedef struct rb_vm_struct {
 
     VALUE *defined_strings;
     st_table *frozen_strings;
+    VALUE regexp_literals_cache;
 
     const struct rb_builtin_function *builtin_function_table;
     int builtin_inline_index;


### PR DESCRIPTION
Ruby ticket: https://bugs.ruby-lang.org/issues/16557

Real world application contain many duplicated Regexp literals.

From a rails/console in Redmine:

```
>> ObjectSpace.each_object(Regexp).count
=> 6828
>> ObjectSpace.each_object(Regexp).uniq.count
=> 4162
>> ObjectSpace.each_object(Regexp).to_a.map { |r| ObjectSpace.memsize_of(r) }.sum
=> 4611957 # 4.4 MB total
>> ObjectSpace.each_object(Regexp).to_a.map { |r| ObjectSpace.memsize_of(r) }.sum - ObjectSpace.each_object(Regexp).to_a.uniq.map { |r| ObjectSpace.memsize_of(r) }.sum
=> 1490601 # 1.42 MB could be saved
```

Here's the to 10 duplicated regexps in Redmine:

```
147: /"/
107: /\s+/
103: //
89: /\n/
83: /'/
76: /\s+/m
37: /\d+/
35: /\[/
33: /./
33: /\\./
```

Any empty Rails application will have a similar amount of regexps.

Since https://bugs.ruby-lang.org/issues/16377 made literal regexps frozen, it is possible to deduplicate literal regexps without changing any semantic.

This patch is heavily inspired by the `frozen_strings` table, but applied to literal regexps.