### PR TITLE
Tie lifetime of uJIT blocks to iseqs

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1902,6 +1902,7 @@ ast.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ast.$(OBJEXT): {$(VPATH)}builtin.h
 ast.$(OBJEXT): {$(VPATH)}config.h
+ast.$(OBJEXT): {$(VPATH)}darray.h
 ast.$(OBJEXT): {$(VPATH)}defines.h
 ast.$(OBJEXT): {$(VPATH)}encoding.h
 ast.$(OBJEXT): {$(VPATH)}id.h
@@ -2273,6 +2274,7 @@ builtin.$(OBJEXT): {$(VPATH)}builtin.c
 builtin.$(OBJEXT): {$(VPATH)}builtin.h
 builtin.$(OBJEXT): {$(VPATH)}builtin_binary.inc
 builtin.$(OBJEXT): {$(VPATH)}config.h
+builtin.$(OBJEXT): {$(VPATH)}darray.h
 builtin.$(OBJEXT): {$(VPATH)}defines.h
 builtin.$(OBJEXT): {$(VPATH)}id.h
 builtin.$(OBJEXT): {$(VPATH)}intern.h
@@ -2464,6 +2466,7 @@ class.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 class.$(OBJEXT): {$(VPATH)}class.c
 class.$(OBJEXT): {$(VPATH)}config.h
 class.$(OBJEXT): {$(VPATH)}constant.h
+class.$(OBJEXT): {$(VPATH)}darray.h
 class.$(OBJEXT): {$(VPATH)}defines.h
 class.$(OBJEXT): {$(VPATH)}encoding.h
 class.$(OBJEXT): {$(VPATH)}id.h
@@ -2839,6 +2842,7 @@ compile.$(OBJEXT): {$(VPATH)}builtin.h
 compile.$(OBJEXT): {$(VPATH)}compile.c
 compile.$(OBJEXT): {$(VPATH)}config.h
 compile.$(OBJEXT): {$(VPATH)}constant.h
+compile.$(OBJEXT): {$(VPATH)}darray.h
 compile.$(OBJEXT): {$(VPATH)}debug_counter.h
 compile.$(OBJEXT): {$(VPATH)}defines.h
 compile.$(OBJEXT): {$(VPATH)}encindex.h
@@ -3230,6 +3234,7 @@ cont.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 cont.$(OBJEXT): {$(VPATH)}config.h
 cont.$(OBJEXT): {$(VPATH)}cont.c
+cont.$(OBJEXT): {$(VPATH)}darray.h
 cont.$(OBJEXT): {$(VPATH)}debug_counter.h
 cont.$(OBJEXT): {$(VPATH)}defines.h
 cont.$(OBJEXT): {$(VPATH)}eval_intern.h
@@ -3422,6 +3427,7 @@ debug.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 debug.$(OBJEXT): {$(VPATH)}config.h
+debug.$(OBJEXT): {$(VPATH)}darray.h
 debug.$(OBJEXT): {$(VPATH)}debug.c
 debug.$(OBJEXT): {$(VPATH)}debug_counter.h
 debug.$(OBJEXT): {$(VPATH)}defines.h
@@ -5055,6 +5061,7 @@ error.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 error.$(OBJEXT): {$(VPATH)}builtin.h
 error.$(OBJEXT): {$(VPATH)}config.h
 error.$(OBJEXT): {$(VPATH)}constant.h
+error.$(OBJEXT): {$(VPATH)}darray.h
 error.$(OBJEXT): {$(VPATH)}defines.h
 error.$(OBJEXT): {$(VPATH)}encoding.h
 error.$(OBJEXT): {$(VPATH)}error.c
@@ -5257,6 +5264,7 @@ eval.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 eval.$(OBJEXT): {$(VPATH)}config.h
 eval.$(OBJEXT): {$(VPATH)}constant.h
+eval.$(OBJEXT): {$(VPATH)}darray.h
 eval.$(OBJEXT): {$(VPATH)}debug_counter.h
 eval.$(OBJEXT): {$(VPATH)}defines.h
 eval.$(OBJEXT): {$(VPATH)}encoding.h
@@ -5682,6 +5690,7 @@ gc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 gc.$(OBJEXT): {$(VPATH)}builtin.h
 gc.$(OBJEXT): {$(VPATH)}config.h
 gc.$(OBJEXT): {$(VPATH)}constant.h
+gc.$(OBJEXT): {$(VPATH)}darray.h
 gc.$(OBJEXT): {$(VPATH)}debug.h
 gc.$(OBJEXT): {$(VPATH)}debug_counter.h
 gc.$(OBJEXT): {$(VPATH)}defines.h
@@ -5892,6 +5901,7 @@ golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 golf_prelude.$(OBJEXT): {$(VPATH)}config.h
+golf_prelude.$(OBJEXT): {$(VPATH)}darray.h
 golf_prelude.$(OBJEXT): {$(VPATH)}defines.h
 golf_prelude.$(OBJEXT): {$(VPATH)}golf_prelude.c
 golf_prelude.$(OBJEXT): {$(VPATH)}golf_prelude.rb
@@ -6819,6 +6829,7 @@ iseq.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 iseq.$(OBJEXT): {$(VPATH)}builtin.h
 iseq.$(OBJEXT): {$(VPATH)}config.h
 iseq.$(OBJEXT): {$(VPATH)}constant.h
+iseq.$(OBJEXT): {$(VPATH)}darray.h
 iseq.$(OBJEXT): {$(VPATH)}debug_counter.h
 iseq.$(OBJEXT): {$(VPATH)}defines.h
 iseq.$(OBJEXT): {$(VPATH)}encoding.h
@@ -7027,6 +7038,7 @@ load.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 load.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 load.$(OBJEXT): {$(VPATH)}config.h
 load.$(OBJEXT): {$(VPATH)}constant.h
+load.$(OBJEXT): {$(VPATH)}darray.h
 load.$(OBJEXT): {$(VPATH)}defines.h
 load.$(OBJEXT): {$(VPATH)}dln.h
 load.$(OBJEXT): {$(VPATH)}encoding.h
@@ -8233,6 +8245,7 @@ miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 miniinit.$(OBJEXT): {$(VPATH)}builtin.h
 miniinit.$(OBJEXT): {$(VPATH)}config.h
+miniinit.$(OBJEXT): {$(VPATH)}darray.h
 miniinit.$(OBJEXT): {$(VPATH)}defines.h
 miniinit.$(OBJEXT): {$(VPATH)}dir.rb
 miniinit.$(OBJEXT): {$(VPATH)}encoding.h
@@ -8472,6 +8485,7 @@ mjit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 mjit.$(OBJEXT): {$(VPATH)}config.h
 mjit.$(OBJEXT): {$(VPATH)}constant.h
+mjit.$(OBJEXT): {$(VPATH)}darray.h
 mjit.$(OBJEXT): {$(VPATH)}debug.h
 mjit.$(OBJEXT): {$(VPATH)}debug_counter.h
 mjit.$(OBJEXT): {$(VPATH)}defines.h
@@ -8688,6 +8702,7 @@ mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 mjit_compile.$(OBJEXT): {$(VPATH)}builtin.h
 mjit_compile.$(OBJEXT): {$(VPATH)}config.h
 mjit_compile.$(OBJEXT): {$(VPATH)}constant.h
+mjit_compile.$(OBJEXT): {$(VPATH)}darray.h
 mjit_compile.$(OBJEXT): {$(VPATH)}debug_counter.h
 mjit_compile.$(OBJEXT): {$(VPATH)}defines.h
 mjit_compile.$(OBJEXT): {$(VPATH)}id.h
@@ -8885,6 +8900,7 @@ node.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 node.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 node.$(OBJEXT): {$(VPATH)}config.h
 node.$(OBJEXT): {$(VPATH)}constant.h
+node.$(OBJEXT): {$(VPATH)}darray.h
 node.$(OBJEXT): {$(VPATH)}defines.h
 node.$(OBJEXT): {$(VPATH)}id.h
 node.$(OBJEXT): {$(VPATH)}id_table.h
@@ -9865,6 +9881,7 @@ proc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 proc.$(OBJEXT): {$(VPATH)}config.h
+proc.$(OBJEXT): {$(VPATH)}darray.h
 proc.$(OBJEXT): {$(VPATH)}defines.h
 proc.$(OBJEXT): {$(VPATH)}encoding.h
 proc.$(OBJEXT): {$(VPATH)}eval_intern.h
@@ -10068,6 +10085,7 @@ process.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 process.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 process.$(OBJEXT): {$(VPATH)}config.h
 process.$(OBJEXT): {$(VPATH)}constant.h
+process.$(OBJEXT): {$(VPATH)}darray.h
 process.$(OBJEXT): {$(VPATH)}debug_counter.h
 process.$(OBJEXT): {$(VPATH)}defines.h
 process.$(OBJEXT): {$(VPATH)}dln.h
@@ -10275,6 +10293,7 @@ ractor.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ractor.$(OBJEXT): {$(VPATH)}builtin.h
 ractor.$(OBJEXT): {$(VPATH)}config.h
 ractor.$(OBJEXT): {$(VPATH)}constant.h
+ractor.$(OBJEXT): {$(VPATH)}darray.h
 ractor.$(OBJEXT): {$(VPATH)}debug.h
 ractor.$(OBJEXT): {$(VPATH)}debug_counter.h
 ractor.$(OBJEXT): {$(VPATH)}defines.h
@@ -12203,6 +12222,7 @@ ruby.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ruby.$(OBJEXT): {$(VPATH)}config.h
 ruby.$(OBJEXT): {$(VPATH)}constant.h
+ruby.$(OBJEXT): {$(VPATH)}darray.h
 ruby.$(OBJEXT): {$(VPATH)}debug_counter.h
 ruby.$(OBJEXT): {$(VPATH)}defines.h
 ruby.$(OBJEXT): {$(VPATH)}dln.h
@@ -12397,6 +12417,7 @@ scheduler.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 scheduler.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 scheduler.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 scheduler.$(OBJEXT): {$(VPATH)}config.h
+scheduler.$(OBJEXT): {$(VPATH)}darray.h
 scheduler.$(OBJEXT): {$(VPATH)}defines.h
 scheduler.$(OBJEXT): {$(VPATH)}encoding.h
 scheduler.$(OBJEXT): {$(VPATH)}id.h
@@ -12749,6 +12770,7 @@ signal.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 signal.$(OBJEXT): {$(VPATH)}config.h
+signal.$(OBJEXT): {$(VPATH)}darray.h
 signal.$(OBJEXT): {$(VPATH)}debug_counter.h
 signal.$(OBJEXT): {$(VPATH)}defines.h
 signal.$(OBJEXT): {$(VPATH)}encoding.h
@@ -13698,6 +13720,7 @@ struct.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 struct.$(OBJEXT): {$(VPATH)}builtin.h
 struct.$(OBJEXT): {$(VPATH)}config.h
+struct.$(OBJEXT): {$(VPATH)}darray.h
 struct.$(OBJEXT): {$(VPATH)}defines.h
 struct.$(OBJEXT): {$(VPATH)}encoding.h
 struct.$(OBJEXT): {$(VPATH)}id.h
@@ -14087,6 +14110,7 @@ thread.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 thread.$(OBJEXT): {$(VPATH)}config.h
+thread.$(OBJEXT): {$(VPATH)}darray.h
 thread.$(OBJEXT): {$(VPATH)}debug.h
 thread.$(OBJEXT): {$(VPATH)}debug_counter.h
 thread.$(OBJEXT): {$(VPATH)}defines.h
@@ -14851,6 +14875,7 @@ ujit_codegen.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ujit_codegen.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ujit_codegen.$(OBJEXT): {$(VPATH)}builtin.h
 ujit_codegen.$(OBJEXT): {$(VPATH)}config.h
+ujit_codegen.$(OBJEXT): {$(VPATH)}darray.h
 ujit_codegen.$(OBJEXT): {$(VPATH)}debug_counter.h
 ujit_codegen.$(OBJEXT): {$(VPATH)}defines.h
 ujit_codegen.$(OBJEXT): {$(VPATH)}id.h
@@ -15242,6 +15267,7 @@ ujit_core.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ujit_core.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ujit_core.$(OBJEXT): {$(VPATH)}builtin.h
 ujit_core.$(OBJEXT): {$(VPATH)}config.h
+ujit_core.$(OBJEXT): {$(VPATH)}darray.h
 ujit_core.$(OBJEXT): {$(VPATH)}debug_counter.h
 ujit_core.$(OBJEXT): {$(VPATH)}defines.h
 ujit_core.$(OBJEXT): {$(VPATH)}id.h
@@ -15439,6 +15465,7 @@ ujit_iface.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ujit_iface.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ujit_iface.$(OBJEXT): {$(VPATH)}builtin.h
 ujit_iface.$(OBJEXT): {$(VPATH)}config.h
+ujit_iface.$(OBJEXT): {$(VPATH)}darray.h
 ujit_iface.$(OBJEXT): {$(VPATH)}debug_counter.h
 ujit_iface.$(OBJEXT): {$(VPATH)}defines.h
 ujit_iface.$(OBJEXT): {$(VPATH)}id.h
@@ -15819,6 +15846,7 @@ variable.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 variable.$(OBJEXT): {$(VPATH)}config.h
 variable.$(OBJEXT): {$(VPATH)}constant.h
+variable.$(OBJEXT): {$(VPATH)}darray.h
 variable.$(OBJEXT): {$(VPATH)}debug_counter.h
 variable.$(OBJEXT): {$(VPATH)}defines.h
 variable.$(OBJEXT): {$(VPATH)}encoding.h
@@ -16017,6 +16045,7 @@ version.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 version.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 version.$(OBJEXT): {$(VPATH)}builtin.h
 version.$(OBJEXT): {$(VPATH)}config.h
+version.$(OBJEXT): {$(VPATH)}darray.h
 version.$(OBJEXT): {$(VPATH)}debug_counter.h
 version.$(OBJEXT): {$(VPATH)}defines.h
 version.$(OBJEXT): {$(VPATH)}id.h
@@ -16229,6 +16258,7 @@ vm.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm.$(OBJEXT): {$(VPATH)}builtin.h
 vm.$(OBJEXT): {$(VPATH)}config.h
 vm.$(OBJEXT): {$(VPATH)}constant.h
+vm.$(OBJEXT): {$(VPATH)}darray.h
 vm.$(OBJEXT): {$(VPATH)}debug_counter.h
 vm.$(OBJEXT): {$(VPATH)}defines.h
 vm.$(OBJEXT): {$(VPATH)}defs/opt_operand.def
@@ -16445,6 +16475,7 @@ vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}config.h
+vm_backtrace.$(OBJEXT): {$(VPATH)}darray.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}debug.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}defines.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}encoding.h
@@ -16636,6 +16667,7 @@ vm_dump.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_dump.$(OBJEXT): {$(VPATH)}config.h
 vm_dump.$(OBJEXT): {$(VPATH)}constant.h
+vm_dump.$(OBJEXT): {$(VPATH)}darray.h
 vm_dump.$(OBJEXT): {$(VPATH)}defines.h
 vm_dump.$(OBJEXT): {$(VPATH)}gc.h
 vm_dump.$(OBJEXT): {$(VPATH)}id.h
@@ -16827,6 +16859,7 @@ vm_sync.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_sync.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_sync.$(OBJEXT): {$(VPATH)}config.h
 vm_sync.$(OBJEXT): {$(VPATH)}constant.h
+vm_sync.$(OBJEXT): {$(VPATH)}darray.h
 vm_sync.$(OBJEXT): {$(VPATH)}debug_counter.h
 vm_sync.$(OBJEXT): {$(VPATH)}defines.h
 vm_sync.$(OBJEXT): {$(VPATH)}gc.h
@@ -17027,6 +17060,7 @@ vm_trace.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_trace.$(OBJEXT): {$(VPATH)}builtin.h
 vm_trace.$(OBJEXT): {$(VPATH)}config.h
+vm_trace.$(OBJEXT): {$(VPATH)}darray.h
 vm_trace.$(OBJEXT): {$(VPATH)}debug.h
 vm_trace.$(OBJEXT): {$(VPATH)}debug_counter.h
 vm_trace.$(OBJEXT): {$(VPATH)}defines.h

--- a/darray.h
+++ b/darray.h
@@ -1,5 +1,5 @@
-#ifndef RUBY_DARY_H
-#define RUBY_DARY_H
+#ifndef RUBY_DARRAY_H
+#define RUBY_DARRAY_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -12,39 +12,39 @@
 // NULL is a valid empty dynamic array.
 //
 // Example:
-//      rb_dary(char) char_array = NULL;
-//      if (!rb_dary_append(&char_array, 'e')) abort();
-//      printf("pushed %c\n", *rb_dary_ref(char_array, 0));
-//      rb_dary_free(char_array);
+//      rb_darray(char) char_array = NULL;
+//      if (!rb_darray_append(&char_array, 'e')) abort();
+//      printf("pushed %c\n", *rb_darray_ref(char_array, 0));
+//      rb_darray_free(char_array);
 //
-#define rb_dary(T) struct { rb_dary_meta_t meta; T data[]; } *
+#define rb_darray(T) struct { rb_darray_meta_t meta; T data[]; } *
 
 // Copy an element out of the array. Warning: not bounds checked.
 //
-// T rb_dary_get(rb_dary(T) ary, int32_t idx);
+// T rb_darray_get(rb_darray(T) ary, int32_t idx);
 //
-#define rb_dary_get(ary, idx) ((ary)->data[(idx)])
+#define rb_darray_get(ary, idx) ((ary)->data[(idx)])
 
 // Assign to an element. Warning: not bounds checked.
 //
-// void rb_dary_set(rb_dary(T) ary, int32_t idx, T element);
+// void rb_darray_set(rb_darray(T) ary, int32_t idx, T element);
 //
-#define rb_dary_set(ary, idx, element) ((ary)->data[(idx)] = (element))
+#define rb_darray_set(ary, idx, element) ((ary)->data[(idx)] = (element))
 
 // Get a pointer to an element. Warning: not bounds checked.
 //
-// T *rb_dary_ref(rb_dary(T) ary, int32_t idx);
+// T *rb_darray_ref(rb_darray(T) ary, int32_t idx);
 //
-#define rb_dary_ref(ary, idx) (&((ary)->data[(idx)]))
+#define rb_darray_ref(ary, idx) (&((ary)->data[(idx)]))
 
 // Copy a new element into the array. Return 1 on success and 0 on failure.
 // ptr_to_ary is evaluated multiple times.
 //
-// bool rb_dary_append(rb_dary(T) *ptr_to_ary, T element);
+// bool rb_darray_append(rb_darray(T) *ptr_to_ary, T element);
 //
-#define rb_dary_append(ptr_to_ary, element) ( \
-    rb_dary_ensure_space((ptr_to_ary)) ? (    \
-        rb_dary_set(*(ptr_to_ary),         \
+#define rb_darray_append(ptr_to_ary, element) ( \
+    rb_darray_ensure_space((ptr_to_ary)) ? (    \
+        rb_darray_set(*(ptr_to_ary),         \
                     (*(ptr_to_ary))->meta.size, \
                     (element)),            \
         ++((*(ptr_to_ary))->meta.size),       \
@@ -53,59 +53,59 @@
 
 // Iterate over items of the array in a for loop
 //
-#define rb_dary_foreach(ary, idx_name, elem_ptr_var) \
-    for (int idx_name = 0; idx_name < rb_dary_size(ary) && ((elem_ptr_var) = rb_dary_ref(ary, idx_name)); ++idx_name)
+#define rb_darray_foreach(ary, idx_name, elem_ptr_var) \
+    for (int idx_name = 0; idx_name < rb_darray_size(ary) && ((elem_ptr_var) = rb_darray_ref(ary, idx_name)); ++idx_name)
 
-typedef struct rb_dary_meta {
+typedef struct rb_darray_meta {
     int32_t size;
     int32_t capa;
-} rb_dary_meta_t;
+} rb_darray_meta_t;
 
 // Get the size of the dynamic array.
 //
 static inline int32_t
-rb_dary_size(const void *ary)
+rb_darray_size(const void *ary)
 {
-    const rb_dary_meta_t *meta = ary;
+    const rb_darray_meta_t *meta = ary;
     return meta ? meta->size : 0;
 }
 
 // Get the capacity of the dynamic array.
 //
 static inline int32_t
-rb_dary_capa(const void *ary)
+rb_darray_capa(const void *ary)
 {
-    const rb_dary_meta_t *meta = ary;
+    const rb_darray_meta_t *meta = ary;
     return meta ? meta->capa : 0;
 }
 
 // Free the dynamic array.
 //
 static inline void
-rb_dary_free(void *ary)
+rb_darray_free(void *ary)
 {
     free(ary);
 }
 
 // Remove the last element of the array.
 //
-#define rb_dary_pop_back(ary) ((ary)->meta.size--)
+#define rb_darray_pop_back(ary) ((ary)->meta.size--)
 
 // Internal macro
 // Ensure there is space for one more element. Return 1 on success and 0 on failure.
 // `ptr_to_ary` is evaluated multiple times.
-#define rb_dary_ensure_space(ptr_to_ary) ( \
-    (rb_dary_capa(*(ptr_to_ary)) > rb_dary_size(*(ptr_to_ary))) ? \
+#define rb_darray_ensure_space(ptr_to_ary) ( \
+    (rb_darray_capa(*(ptr_to_ary)) > rb_darray_size(*(ptr_to_ary))) ? \
         1 : \
-        rb_dary_double(ptr_to_ary, sizeof((*(ptr_to_ary))->data[0])))
+        rb_darray_double(ptr_to_ary, sizeof((*(ptr_to_ary))->data[0])))
 
 // Internal function
 static inline int 
-rb_dary_double(void *ptr_to_ary, size_t element_size)
+rb_darray_double(void *ptr_to_ary, size_t element_size)
 {
-    rb_dary_meta_t **ptr_to_ptr_to_meta = ptr_to_ary;
-    const rb_dary_meta_t *meta = *ptr_to_ptr_to_meta;
-    int32_t current_capa = rb_dary_capa(meta);
+    rb_darray_meta_t **ptr_to_ptr_to_meta = ptr_to_ary;
+    const rb_darray_meta_t *meta = *ptr_to_ptr_to_meta;
+    int32_t current_capa = rb_darray_capa(meta);
 
     int32_t new_capa;
     // Calculate new capacity
@@ -123,7 +123,7 @@ rb_dary_double(void *ptr_to_ary, size_t element_size)
     size_t new_buffer_size = element_size * (size_t)new_capa + sizeof(*meta);
     if (new_buffer_size <= current_buffer_size) return 0;
 
-    rb_dary_meta_t *doubled_ary = realloc(*ptr_to_ptr_to_meta, new_buffer_size);
+    rb_darray_meta_t *doubled_ary = realloc(*ptr_to_ptr_to_meta, new_buffer_size);
     if (!doubled_ary) return 0;
 
     if (meta == NULL) {
@@ -138,4 +138,4 @@ rb_dary_double(void *ptr_to_ary, size_t element_size)
     return 1;
 }
 
-#endif /* RUBY_DARY_H */
+#endif /* RUBY_DARRAY_H */

--- a/dary.h
+++ b/dary.h
@@ -1,0 +1,141 @@
+#ifndef RUBY_DARY_H
+#define RUBY_DARY_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+// Type for a dynamic array. Use to declare a dynamic array.
+// It is a pointer so it fits in st_table nicely. Designed
+// to be fairly type-safe.
+//
+// NULL is a valid empty dynamic array.
+//
+// Example:
+//      rb_dary(char) char_array = NULL;
+//      if (!rb_dary_append(&char_array, 'e')) abort();
+//      printf("pushed %c\n", *rb_dary_ref(char_array, 0));
+//      rb_dary_free(char_array);
+//
+#define rb_dary(T) struct { rb_dary_meta_t meta; T data[]; } *
+
+// Copy an element out of the array. Warning: not bounds checked.
+//
+// T rb_dary_get(rb_dary(T) ary, int32_t idx);
+//
+#define rb_dary_get(ary, idx) ((ary)->data[(idx)])
+
+// Assign to an element. Warning: not bounds checked.
+//
+// void rb_dary_set(rb_dary(T) ary, int32_t idx, T element);
+//
+#define rb_dary_set(ary, idx, element) ((ary)->data[(idx)] = (element))
+
+// Get a pointer to an element. Warning: not bounds checked.
+//
+// T *rb_dary_ref(rb_dary(T) ary, int32_t idx);
+//
+#define rb_dary_ref(ary, idx) (&((ary)->data[(idx)]))
+
+// Copy a new element into the array. Return 1 on success and 0 on failure.
+// ptr_to_ary is evaluated multiple times.
+//
+// bool rb_dary_append(rb_dary(T) *ptr_to_ary, T element);
+//
+#define rb_dary_append(ptr_to_ary, element) ( \
+    rb_dary_ensure_space((ptr_to_ary)) ? (    \
+        rb_dary_set(*(ptr_to_ary),         \
+                    (*(ptr_to_ary))->meta.size, \
+                    (element)),            \
+        ++((*(ptr_to_ary))->meta.size),       \
+        1                                     \
+    ) : 0)
+
+// Iterate over items of the array in a for loop
+//
+#define rb_dary_foreach(ary, idx_name, elem_ptr_var) \
+    for (int idx_name = 0; idx_name < rb_dary_size(ary) && ((elem_ptr_var) = rb_dary_ref(ary, idx_name)); ++idx_name)
+
+typedef struct rb_dary_meta {
+    int32_t size;
+    int32_t capa;
+} rb_dary_meta_t;
+
+// Get the size of the dynamic array.
+//
+static inline int32_t
+rb_dary_size(const void *ary)
+{
+    const rb_dary_meta_t *meta = ary;
+    return meta ? meta->size : 0;
+}
+
+// Get the capacity of the dynamic array.
+//
+static inline int32_t
+rb_dary_capa(const void *ary)
+{
+    const rb_dary_meta_t *meta = ary;
+    return meta ? meta->capa : 0;
+}
+
+// Free the dynamic array.
+//
+static inline void
+rb_dary_free(void *ary)
+{
+    free(ary);
+}
+
+// Remove the last element of the array.
+//
+#define rb_dary_pop_back(ary) ((ary)->meta.size--)
+
+// Internal macro
+// Ensure there is space for one more element. Return 1 on success and 0 on failure.
+// `ptr_to_ary` is evaluated multiple times.
+#define rb_dary_ensure_space(ptr_to_ary) ( \
+    (rb_dary_capa(*(ptr_to_ary)) > rb_dary_size(*(ptr_to_ary))) ? \
+        1 : \
+        rb_dary_double(ptr_to_ary, sizeof((*(ptr_to_ary))->data[0])))
+
+// Internal function
+static inline int 
+rb_dary_double(void *ptr_to_ary, size_t element_size)
+{
+    rb_dary_meta_t **ptr_to_ptr_to_meta = ptr_to_ary;
+    const rb_dary_meta_t *meta = *ptr_to_ptr_to_meta;
+    int32_t current_capa = rb_dary_capa(meta);
+
+    int32_t new_capa;
+    // Calculate new capacity
+    if (current_capa == 0) {
+        new_capa = 1;
+    }
+    else {
+        int64_t doubled = 2 * (int64_t)current_capa;
+        new_capa = (int32_t)doubled;
+        if (new_capa != doubled) return 0;
+    }
+
+    // Calculate new buffer size
+    size_t current_buffer_size = element_size * (size_t)current_capa + (meta ? sizeof(*meta) : 0);
+    size_t new_buffer_size = element_size * (size_t)new_capa + sizeof(*meta);
+    if (new_buffer_size <= current_buffer_size) return 0;
+
+    rb_dary_meta_t *doubled_ary = realloc(*ptr_to_ptr_to_meta, new_buffer_size);
+    if (!doubled_ary) return 0;
+
+    if (meta == NULL) {
+        // First allocation. Initialize size. On subsequence allocations
+        // realloc takes care of carrying over the size.
+        doubled_ary->size = 0;
+    }
+
+    doubled_ary->capa = new_capa;
+
+    *ptr_to_ptr_to_meta = doubled_ary;
+    return 1;
+}
+
+#endif /* RUBY_DARY_H */

--- a/ext/coverage/depend
+++ b/ext/coverage/depend
@@ -165,6 +165,7 @@ coverage.o: $(top_srcdir)/ccan/check_type/check_type.h
 coverage.o: $(top_srcdir)/ccan/container_of/container_of.h
 coverage.o: $(top_srcdir)/ccan/list/list.h
 coverage.o: $(top_srcdir)/ccan/str/str.h
+coverage.o: $(top_srcdir)/darray.h
 coverage.o: $(top_srcdir)/gc.h
 coverage.o: $(top_srcdir)/internal.h
 coverage.o: $(top_srcdir)/internal/array.h

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -525,6 +525,7 @@ objspace_dump.o: $(top_srcdir)/ccan/check_type/check_type.h
 objspace_dump.o: $(top_srcdir)/ccan/container_of/container_of.h
 objspace_dump.o: $(top_srcdir)/ccan/list/list.h
 objspace_dump.o: $(top_srcdir)/ccan/str/str.h
+objspace_dump.o: $(top_srcdir)/darray.h
 objspace_dump.o: $(top_srcdir)/gc.h
 objspace_dump.o: $(top_srcdir)/internal.h
 objspace_dump.o: $(top_srcdir)/internal/array.h

--- a/iseq.c
+++ b/iseq.c
@@ -493,7 +493,6 @@ rb_iseq_constant_body_alloc(void)
 {
     struct rb_iseq_constant_body *iseq_body;
     iseq_body = ZALLOC(struct rb_iseq_constant_body);
-    list_head_init(&iseq_body->ujit_blocks);
     return iseq_body;
 }
 

--- a/iseq.c
+++ b/iseq.c
@@ -109,6 +109,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
     if (iseq && iseq->body) {
 	struct rb_iseq_constant_body *const body = iseq->body;
 	mjit_free_iseq(iseq); /* Notify MJIT */
+        rb_ujit_iseq_free(body);
 	ruby_xfree((void *)body->iseq_encoded);
 	ruby_xfree((void *)body->insns_info.body);
 	if (body->insns_info.positions) ruby_xfree((void *)body->insns_info.positions);
@@ -321,6 +322,7 @@ rb_iseq_update_references(rb_iseq_t *iseq)
 #if USE_MJIT
         mjit_update_references(iseq);
 #endif
+        rb_ujit_iseq_update_references(body);
     }
 }
 
@@ -401,6 +403,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 #if USE_MJIT
         mjit_mark_cc_entries(body);
 #endif
+        rb_ujit_iseq_mark(body);
     }
 
     if (FL_TEST_RAW((VALUE)iseq, ISEQ_NOT_LOADED_YET)) {
@@ -490,6 +493,7 @@ rb_iseq_constant_body_alloc(void)
 {
     struct rb_iseq_constant_body *iseq_body;
     iseq_body = ZALLOC(struct rb_iseq_constant_body);
+    list_head_init(&iseq_body->ujit_blocks);
     return iseq_body;
 }
 

--- a/ujit.h
+++ b/ujit.h
@@ -54,5 +54,8 @@ void rb_ujit_compile_iseq(const rb_iseq_t *iseq);
 void rb_ujit_init(struct rb_ujit_options *options);
 void rb_ujit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop);
 void rb_ujit_constant_state_changed(void);
+void rb_ujit_iseq_mark(const struct rb_iseq_constant_body *body);
+void rb_ujit_iseq_update_references(const struct rb_iseq_constant_body *body);
+void rb_ujit_iseq_free(const struct rb_iseq_constant_body *body);
 
 #endif // #ifndef UJIT_H

--- a/ujit_core.c
+++ b/ujit_core.c
@@ -151,6 +151,7 @@ get_first_version(const rb_iseq_t *iseq, unsigned idx)
     if (rb_darray_size(body->ujit_blocks) == 0) {
         return NULL;
     }
+    RUBY_ASSERT((unsigned)rb_darray_size(body->ujit_blocks) == body->iseq_size);
     return rb_darray_get(body->ujit_blocks, idx);
 }
 

--- a/ujit_core.c
+++ b/ujit_core.c
@@ -148,10 +148,10 @@ static block_t *
 get_first_version(const rb_iseq_t *iseq, unsigned idx)
 {
     struct rb_iseq_constant_body *body = iseq->body;
-    if (rb_dary_size(body->ujit_blocks) == 0) {
+    if (rb_darray_size(body->ujit_blocks) == 0) {
         return NULL;
     }
-    return rb_dary_get(body->ujit_blocks, idx);
+    return rb_darray_get(body->ujit_blocks, idx);
 }
 
 // Add a block version to the map. Block should be fully constructed
@@ -164,11 +164,11 @@ add_block_version(blockid_t blockid, block_t* block)
     struct rb_iseq_constant_body *body = iseq->body;
 
     // Ensure ujit_blocks is initialized
-    if (rb_dary_size(body->ujit_blocks) == 0) {
+    if (rb_darray_size(body->ujit_blocks) == 0) {
         // Initialize ujit_blocks to be as wide as body->iseq_encoded
         // TODO: add resize API for dary
-        while ((unsigned)rb_dary_size(body->ujit_blocks) < body->iseq_size) {
-            (void)rb_dary_append(&body->ujit_blocks, NULL);
+        while ((unsigned)rb_darray_size(body->ujit_blocks) < body->iseq_size) {
+            (void)rb_darray_append(&body->ujit_blocks, NULL);
         }
     }
 
@@ -182,7 +182,7 @@ add_block_version(blockid_t blockid, block_t* block)
     }
 
     // Make new block the first version
-    rb_dary_set(body->ujit_blocks, blockid.idx, block);
+    rb_darray_set(body->ujit_blocks, blockid.idx, block);
     RUBY_ASSERT(find_block_version(blockid, &block->ctx) != NULL);
 
     {
@@ -603,7 +603,7 @@ invalidate_block_version(block_t* block)
     // Remove references to this block
     if (first_block == block) {
         // Make the next block the new first version
-        rb_dary_set(iseq->body->ujit_blocks, block->blockid.idx, block->next);
+        rb_darray_set(iseq->body->ujit_blocks, block->blockid.idx, block->next);
     }
     else {
         bool deleted = false;

--- a/ujit_core.c
+++ b/ujit_core.c
@@ -600,9 +600,10 @@ invalidate_block_version(block_t* block)
     block_t *first_block = get_first_version(iseq, block->blockid.idx);
     RUBY_ASSERT(first_block != NULL);
 
-    // Remove the version object from the map so we can re-generate stubs
+    // Remove references to this block
     if (first_block == block) {
-        rb_dary_set(iseq->body->ujit_blocks, block->blockid.idx, NULL);
+        // Make the next block the new first version
+        rb_dary_set(iseq->body->ujit_blocks, block->blockid.idx, block->next);
     }
     else {
         bool deleted = false;

--- a/ujit_core.c
+++ b/ujit_core.c
@@ -16,9 +16,6 @@
 // Maximum number of branch instructions we can track
 #define MAX_BRANCHES 32768
 
-// Table of block versions indexed by (iseq, index) tuples
-st_table *version_tbl;
-
 // Registered branch entries
 branch_t branch_entries[MAX_BRANCHES];
 uint32_t num_branches = 0;
@@ -147,33 +144,50 @@ int ctx_diff(const ctx_t* src, const ctx_t* dst)
     return diff;
 }
 
+static block_t *
+get_first_version(const rb_iseq_t *iseq, unsigned idx)
+{
+    struct rb_iseq_constant_body *body = iseq->body;
+    if (rb_dary_size(body->ujit_blocks) == 0) {
+        return NULL;
+    }
+    return rb_dary_get(body->ujit_blocks, idx);
+}
+
 // Add a block version to the map. Block should be fully constructed
 static void
 add_block_version(blockid_t blockid, block_t* block)
 {
     // Function entry blocks must have stack size 0
     RUBY_ASSERT(!(block->blockid.idx == 0 && block->ctx.stack_size > 0));
+    const rb_iseq_t *iseq = block->blockid.iseq;
+    struct rb_iseq_constant_body *body = iseq->body;
+
+    // Ensure ujit_blocks is initialized
+    if (rb_dary_size(body->ujit_blocks) == 0) {
+        // Initialize ujit_blocks to be as wide as body->iseq_encoded
+        // TODO: add resize API for dary
+        while ((unsigned)rb_dary_size(body->ujit_blocks) < body->iseq_size) {
+            (void)rb_dary_append(&body->ujit_blocks, NULL);
+        }
+    }
+
+    block_t *first_version = get_first_version(iseq, blockid.idx);
 
     // If there exists a version for this block id
-    block_t* first_version = NULL;
-    st_lookup(version_tbl, (st_data_t)&blockid, (st_data_t*)&first_version);
-
-    // Link to the next version in a linked list
     if (first_version != NULL) {
+        // Link to the next version in a linked list
         RUBY_ASSERT(block->next == NULL);
         block->next = first_version;
     }
 
-    // Add the block version to the map
-    st_insert(version_tbl, (st_data_t)&block->blockid, (st_data_t)block);
+    // Make new block the first version
+    rb_dary_set(body->ujit_blocks, blockid.idx, block);
     RUBY_ASSERT(find_block_version(blockid, &block->ctx) != NULL);
 
     {
-        // Store the block on the iseq
-        list_add_tail(&block->blockid.iseq->body->ujit_blocks, &block->iseq_block_node);
-
-        const rb_iseq_t *iseq = block->blockid.iseq;
-        // Run write barriers for block dependencies
+        // By writing the new block to the iseq, the iseq now
+        // contains new references to Ruby objects. Run write barriers.
         RB_OBJ_WRITTEN(iseq, Qundef, block->dependencies.iseq);
         RB_OBJ_WRITTEN(iseq, Qundef, block->dependencies.cc);
         RB_OBJ_WRITTEN(iseq, Qundef, block->dependencies.cme);
@@ -194,15 +208,11 @@ static void add_incoming(block_t* p_block, uint32_t branch_idx)
 // Count the number of block versions matching a given blockid
 static size_t count_block_versions(blockid_t blockid)
 {
-    // If there exists a version for this block id
-    block_t* first_version;
-    if (!rb_st_lookup(version_tbl, (st_data_t)&blockid, (st_data_t*)&first_version))
-        return 0;
-
     size_t count = 0;
+    block_t *first_version = get_first_version(blockid.iseq, blockid.idx);
 
     // For each version matching the blockid
-    for (block_t* version = first_version; version != NULL; version = version->next)
+    for (block_t *version = first_version; version != NULL; version = version->next)
     {
         count += 1;
     }
@@ -213,10 +223,10 @@ static size_t count_block_versions(blockid_t blockid)
 // Retrieve a basic block version for an (iseq, idx) tuple
 block_t* find_block_version(blockid_t blockid, const ctx_t* ctx)
 {
+    block_t *first_version = get_first_version(blockid.iseq, blockid.idx);
+
     // If there exists a version for this block id
-    block_t* first_version;
-    if (!rb_st_lookup(version_tbl, (st_data_t)&blockid, (st_data_t*)&first_version))
-        return NULL;
+    if (!first_version) return NULL;
 
     // Best match found
     block_t* best_version = NULL;
@@ -568,32 +578,36 @@ void gen_direct_jump(
     branch_entries[branch_idx] = branch_entry;
 }
 
+// Remove all references to a block then free it.
+void
+ujit_free_block(block_t *block)
+{
+    ujit_unlink_method_lookup_dependency(block);
+
+    free(block->incoming);
+    free(block);
+}
+
 // Invalidate one specific block version
 void
 invalidate_block_version(block_t* block)
 {
+    const rb_iseq_t *iseq = block->blockid.iseq;
+
     fprintf(stderr, "invalidating block (%p, %d)\n", block->blockid.iseq, block->blockid.idx);
     fprintf(stderr, "block=%p\n", block);
 
-    // Find the first version for this blockid
-    block_t* first_block = NULL;
-    rb_st_lookup(version_tbl, (st_data_t)&block->blockid, (st_data_t*)&first_block);
+    block_t *first_block = get_first_version(iseq, block->blockid.idx);
     RUBY_ASSERT(first_block != NULL);
 
     // Remove the version object from the map so we can re-generate stubs
-    if (first_block == block)
-    {
-        st_data_t key = (st_data_t)&block->blockid;
-        int success = st_delete(version_tbl, &key, NULL);
-        RUBY_ASSERT(success);
+    if (first_block == block) {
+        rb_dary_set(iseq->body->ujit_blocks, block->blockid.idx, NULL);
     }
-    else
-    {
+    else {
         bool deleted = false;
-        for (block_t* cur = first_block; cur != NULL; cur = cur->next)
-        {
-            if (cur->next == block)
-            {
+        for (block_t* cur = first_block; cur != NULL; cur = cur->next) {
+            if (cur->next == block) {
                 cur->next = cur->next->next;
                 deleted = true;
                 break;
@@ -645,8 +659,8 @@ invalidate_block_version(block_t* block)
         }
     }
 
-    const rb_iseq_t* iseq = block->blockid.iseq;
     uint32_t idx = block->blockid.idx;
+    // FIXME: the following says "if", but it's unconditional.
     // If the block is an entry point, it needs to be unmapped from its iseq
     VALUE* entry_pc = &iseq->body->iseq_encoded[idx];
     int entry_opcode = opcode_at_pc(iseq, entry_pc);
@@ -664,12 +678,7 @@ invalidate_block_version(block_t* block)
     // FIXME:
     // Call continuation addresses on the stack can also be atomically replaced by jumps going to the stub.
 
-    // Remove block from iseq
-    list_del_from(&iseq->body->ujit_blocks, &block->iseq_block_node);
-    ujit_unlink_method_lookup_dependency(block);
-    // Free the old block version object
-    free(block->incoming);
-    free(block);
+    ujit_free_block(block);
 
     fprintf(stderr, "invalidation done\n");
 }
@@ -691,14 +700,8 @@ st_index_t blockid_hash(st_data_t arg)
     return hash0 ^ hash1;
 }
 
-static const struct st_hash_type hashtype_blockid = {
-    blockid_cmp,
-    blockid_hash,
-};
-
 void
 ujit_init_core(void)
 {
-    // Initialize the version hash table
-    version_tbl = st_init_table(&hashtype_blockid);
+    // Nothing yet
 }

--- a/ujit_core.h
+++ b/ujit_core.h
@@ -103,7 +103,7 @@ Basic block version
 Represents a portion of an iseq compiled with a given context
 Note: care must be taken to minimize the size of block_t objects
 */
-typedef struct BlockVersion
+typedef struct ujit_block_version
 {
     // Bytecode sequence (iseq, idx) this is a version of
     blockid_t blockid;
@@ -119,11 +119,11 @@ typedef struct BlockVersion
     uint32_t end_pos;
 
     // List of incoming branches indices
-    uint32_t* incoming;
+    uint32_t *incoming;
     uint32_t num_incoming;
 
     // Next block version for this blockid (singly-linked list)
-    struct BlockVersion* next;
+    struct ujit_block_version *next;
 
     // List node for all block versions in an iseq
     struct list_node iseq_block_node;
@@ -147,6 +147,7 @@ int ctx_diff(const ctx_t* src, const ctx_t* dst);
 block_t* find_block_version(blockid_t blockid, const ctx_t* ctx);
 block_t* gen_block_version(blockid_t blockid, const ctx_t* ctx);
 uint8_t*  gen_entry_point(const rb_iseq_t *iseq, uint32_t insn_idx);
+void ujit_free_block(block_t *block);
 
 void gen_branch(
     const ctx_t* src_ctx,

--- a/ujit_core.h
+++ b/ujit_core.h
@@ -125,6 +125,15 @@ typedef struct BlockVersion
     // Next block version for this blockid (singly-linked list)
     struct BlockVersion* next;
 
+    // List node for all block versions in an iseq
+    struct list_node iseq_block_node;
+
+    // GC managed objects that this block depend on
+    struct {
+        VALUE cc;
+        VALUE cme;
+        VALUE iseq;
+    } dependencies;
 } block_t;
 
 // Context object methods

--- a/ujit_iface.c
+++ b/ujit_iface.c
@@ -592,6 +592,8 @@ rb_ujit_iseq_free(const struct rb_iseq_constant_body *body)
             block = next;
         }
     }
+
+    rb_darray_free(body->ujit_blocks);
 }
 
 void

--- a/ujit_iface.h
+++ b/ujit_iface.h
@@ -34,5 +34,6 @@ bool cfunc_needs_frame(const rb_method_cfunc_t *cfunc);
 void assume_method_lookup_stable(const struct rb_callcache *cc, const rb_callable_method_entry_t *cme, block_t* block);
 // this function *must* return passed exit_pc
 const VALUE *rb_ujit_count_side_exit_op(const VALUE *exit_pc);
+void ujit_unlink_method_lookup_dependency(block_t *block);
 
 #endif // #ifndef UJIT_IFACE_H

--- a/vm_core.h
+++ b/vm_core.h
@@ -437,6 +437,8 @@ struct rb_iseq_constant_body {
     long unsigned total_calls; /* number of total calls with `mjit_exec()` */
     struct rb_mjit_unit *jit_unit;
 #endif
+
+    struct list_head ujit_blocks;
 };
 
 /* T_IMEMO/iseq */

--- a/vm_core.h
+++ b/vm_core.h
@@ -77,6 +77,7 @@
 #include "ruby/st.h"
 #include "ruby_atomic.h"
 #include "vm_opts.h"
+#include "dary.h"
 
 #include "ruby/thread_native.h"
 #if   defined(_WIN32)
@@ -302,6 +303,8 @@ pathobj_realpath(VALUE pathobj)
 /* Forward declarations */
 struct rb_mjit_unit;
 
+typedef rb_dary(struct ujit_block_version *) rb_ujit_block_array_t;
+
 struct rb_iseq_constant_body {
     enum iseq_type {
 	ISEQ_TYPE_TOP,
@@ -438,7 +441,7 @@ struct rb_iseq_constant_body {
     struct rb_mjit_unit *jit_unit;
 #endif
 
-    struct list_head ujit_blocks;
+    rb_ujit_block_array_t ujit_blocks;
 };
 
 /* T_IMEMO/iseq */

--- a/vm_core.h
+++ b/vm_core.h
@@ -441,7 +441,7 @@ struct rb_iseq_constant_body {
     struct rb_mjit_unit *jit_unit;
 #endif
 
-    rb_ujit_block_array_t ujit_blocks;
+    rb_ujit_block_array_t ujit_blocks; // empty, or has a size equal to iseq_size
 };
 
 /* T_IMEMO/iseq */

--- a/vm_core.h
+++ b/vm_core.h
@@ -77,7 +77,7 @@
 #include "ruby/st.h"
 #include "ruby_atomic.h"
 #include "vm_opts.h"
-#include "dary.h"
+#include "darray.h"
 
 #include "ruby/thread_native.h"
 #if   defined(_WIN32)
@@ -303,7 +303,7 @@ pathobj_realpath(VALUE pathobj)
 /* Forward declarations */
 struct rb_mjit_unit;
 
-typedef rb_dary(struct ujit_block_version *) rb_ujit_block_array_t;
+typedef rb_darray(struct ujit_block_version *) rb_ujit_block_array_t;
 
 struct rb_iseq_constant_body {
     enum iseq_type {


### PR DESCRIPTION
Blocks weren't being freed when iseqs are collected.