### PR TITLE
fix: ensure add_incoming allocates the proper length memory

### DIFF
--- a/ujit_core.c
+++ b/ujit_core.c
@@ -167,7 +167,7 @@ static void add_block_version(blockid_t blockid, block_t* block)
 static void add_incoming(block_t* p_block, uint32_t branch_idx)
 {
     // Add this branch to the list of incoming branches for the target
-    uint32_t* new_list = malloc(sizeof(uint32_t) * p_block->num_incoming + 1);
+    uint32_t* new_list = malloc(sizeof(uint32_t) * (p_block->num_incoming + 1));
     memcpy(new_list, p_block->incoming, p_block->num_incoming);
     new_list[p_block->num_incoming] = branch_idx;
     p_block->incoming = new_list;


### PR DESCRIPTION
Without this fix, valgrind reports for zero-length blocks:

```
==149294== Invalid write of size 4
==149294==    at 0x408121: add_incoming (ujit_core.c:173)
==149294==    by 0x408121: gen_block_version (ujit_core.c:286)
==149294==    by 0x40873C: gen_entry_point (ujit_core.c:303)
==149294==    by 0x3609DF: rb_ujit_compile_iseq (ujit_iface.c:319)
==149294==    by 0x33BD2F: mjit_exec (mjit.h:158)
==149294==    by 0x33BD2F: rb_vm_exec (vm.c:2167)
...
==149294==  Address 0x11278850 is 0 bytes inside a block of size 1 alloc'd
==149294==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==149294==    by 0x40811B: add_incoming (ujit_core.c:171)
==149294==    by 0x40811B: gen_block_version (ujit_core.c:286)
==149294==    by 0x40873C: gen_entry_point (ujit_core.c:303)
==149294==    by 0x3609DF: rb_ujit_compile_iseq (ujit_iface.c:319)
==149294==    by 0x33BD2F: mjit_exec (mjit.h:158)
==149294==    by 0x33BD2F: rb_vm_exec (vm.c:2167)
```
