### PR TITLE
fix: allow make to complete when RUBY_DEBUG is not set

### DIFF
--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -69,10 +69,12 @@ ujit_gen_exit(jitstate_t* jit, ctx_t* ctx, codeblock_t* cb, VALUE* exit_pc)
     mov(cb, member_opnd(REG_CFP, rb_control_frame_t, pc), RAX);
 
     // Accumulate stats about interpreter exits
+#if RUBY_DEBUG
     if (rb_ujit_opts.gen_stats) {
         mov(cb, RDI, const_ptr_opnd(exit_pc));
         call_ptr(cb, RSI, (void *)&rb_ujit_count_side_exit_op);
     }
+#endif
 
     // Write the post call bytes
     cb_write_post_call_bytes(cb);


### PR DESCRIPTION
When building the microjit branch without RUBY_DEBUG being set, we see this linker error:

```
linking miniruby
/usr/bin/ld: ujit_codegen.o: in function `ujit_gen_exit':
/home/runner/work/ruby/ruby/ujit_codegen.c:74: undefined reference to `rb_ujit_count_side_exit_op'
collect2: error: ld returned 1 exit status
```