### PR TITLE
Fix build on MSVC

### DIFF
--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -26,7 +26,8 @@ static codeblock_t outline_block;
 codeblock_t* ocb = NULL;
 
 // Print the current source location for debugging purposes
-static void __attribute__((unused))
+RBIMPL_ATTR_MAYBE_UNUSED()
+static void
 jit_print_loc(jitstate_t* jit, const char* msg)
 {
     char *ptr;

--- a/ujit_iface.c
+++ b/ujit_iface.c
@@ -127,7 +127,9 @@ cfunc_needs_frame(const rb_method_cfunc_t *cfunc)
 }
 
 // GC root for interacting with the GC
-struct ujit_root_struct {};
+struct ujit_root_struct {
+    int unused; // empty structs are not legal in C99
+};
 
 // Map cme_or_cc => [[iseq, offset]]. An entry in the map means compiled code at iseq[offset]
 // is only valid when cme_or_cc is valid


### PR DESCRIPTION
Use compiler protable way of delcaring function as maybe unused.