### PR TITLE
Check for ::Array, not T_ARRAY in opt_aref

### DIFF
--- a/bootstraptest/test_ujit.rb
+++ b/bootstraptest/test_ujit.rb
@@ -197,3 +197,20 @@ assert_equal "nil\n", %q{
 
   p other.read
 }
+
+# Test that opt_aref checks the class of the receiver
+assert_equal ":special\n", %q{
+  def foo(array)
+    array[30]
+  end
+
+  UJIT.install_entry(RubyVM::InstructionSequence.of(method(:foo)))
+
+  special = []
+  def special.[](idx)
+    :special
+  end
+
+  p foo(special)
+  nil
+}


### PR DESCRIPTION
T_ARRAY check was overzealous. BOP flags are only for ::Array. Objects that are array subclasses and ones that have singleton aref can have the `T_ARRAY` shape.