### PR TITLE
Implement opt_nil_p instruction

### DIFF
--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -1049,7 +1049,7 @@ gen_opt_nil_p(jitstate_t* jit, ctx_t* ctx)
     jnz_ptr(cb, side_exit);
 
     // nil? confirmed
-    x86opnd_t dst = ctx_stack_push(ctx, T_TRUE);
+    x86opnd_t dst = ctx_stack_push(ctx, T_NONE);
     mov(cb, dst, imm_opnd(Qtrue));
     jmp_label(cb, DONE);
 


### PR DESCRIPTION
This PR implements the `opt_nil_p` instruction in uJIT.  I worked on this with @jhawthorn and we found a couple interesting things.

First, `opt_nil_p` has an inline cache.  However, a case like `nil.nil?` will not use the inline cache, nor will it mutate the inline cache.  So if you have code like:

```ruby
def test_nil(obj)
  obj.nil?
end

test_nil Object.new
test_nil nil
```

The inline cache will point to `Object` even after the second call.

The next thing to note is that the JIT'd code contains a reference to the class that was in the inline cache at compilation time.  It means that we'll always take a side exit if the class type is different than the first type to generate the jit'd code.  However, we'll always stay in the JIT if someone passes in `nil`.

I separated this in to two commits, one that only tests `nil` and side exits on non-nil, and a second commit that adds support for non-nil objects.

Another interesting thing we found is that it seems like `jmp` doesn't work (or we used it wrong).  We tried to do an unconditional jump [here](https://github.com/ruby/ruby/blob/9941e48f481196c342c06ef3b0bdd6563cfffb3f/ujit_codegen.c#L976-L978), but got invalid instruction errors.