### PR TITLE
Runtime counters for bailing from opt_send_without_block

### DIFF
--- a/ujit.rb
+++ b/ujit.rb
@@ -43,25 +43,30 @@ module UJIT
     Primitive.get_stat_counters
   end
 
-  at_exit do
-    counters = runtime_stats
+  class << self
+    private
 
-    next unless counters
+    # Format and print out counters
+    def _print_stats
+      counters = runtime_stats
 
-    $stderr.puts("***uJIT: Printing runtime counters from ujit.rb***")
-    $stderr.puts("opt_send_without_block exit reasons: ")
+      return unless counters
 
-    counters.filter { |key, _| key.start_with?('oswb_') }
-    counters.transform_keys! { |key| key.to_s.delete_prefix('oswb_') }
+      $stderr.puts("***uJIT: Printing runtime counters from ujit.rb***")
+      $stderr.puts("opt_send_without_block exit reasons: ")
 
-    counters = counters.to_a
-    counters.sort_by! { |(_, counter_value)| counter_value }
-    longest_name_length = counters.max_by { |(name, _)| name.length }.first.length
-    total = counters.sum { |(_, counter_value)| counter_value }
+      counters.filter! { |key, _| key.start_with?('oswb_') }
+      counters.transform_keys! { |key| key.to_s.delete_prefix('oswb_') }
 
-    counters.reverse_each do |(name, value)|
-      percentage = value.fdiv(total) * 100
-      $stderr.printf("    %*s %10d (%4.1f%%)\n", longest_name_length, name, value, percentage);
+      counters = counters.to_a
+      counters.sort_by! { |(_, counter_value)| counter_value }
+      longest_name_length = counters.max_by { |(name, _)| name.length }.first.length
+      total = counters.sum { |(_, counter_value)| counter_value }
+
+      counters.reverse_each do |(name, value)|
+        percentage = value.fdiv(total) * 100
+        $stderr.printf("    %*s %10d (%4.1f%%)\n", longest_name_length, name, value, percentage);
+      end
     end
   end
 end

--- a/ujit.rb
+++ b/ujit.rb
@@ -35,4 +35,31 @@ module UJIT
 
     str
   end if defined?(Disasm)
+
+  # Return a hash for statistics generated for the --ujit-gen-stats command line option
+  def self.runtime_stats
+    # defined in ujit_iface.c
+    Primitive.runtime_counters_to_hash
+  end
+
+  # defined in ujit_iface.c
+  if defined?(GEN_STATS)
+    at_exit do
+      $stderr.puts("***uJIT: Printing runtime counters from ujit.rb***")
+      $stderr.puts("opt_send_without_block exit reasons: ")
+
+      counters = runtime_stats.filter { |key, _| key.start_with?('oswb_') }
+      counters.transform_keys! { |key| key.to_s.delete_prefix('oswb_') }
+
+      counters = counters.to_a
+      counters.sort_by! { |(_, counter_value)| counter_value }
+      longest_name_length = counters.max_by { |(name, _)| name.length }.first.length
+      total = counters.sum { |(_, counter_value)| counter_value }
+
+      counters.reverse_each do |(name, value)|
+        percentage = value.fdiv(total) * 100
+        $stderr.printf("    %*s %10d (%4.1f%%)\n", longest_name_length, name, value, percentage);
+      end
+    end
+  end
 end

--- a/ujit_asm.c
+++ b/ujit_asm.c
@@ -1629,3 +1629,9 @@ void xor(codeblock_t* cb, x86opnd_t opnd0, x86opnd_t opnd1)
         opnd1
     );
 }
+
+// LOCK - lock prefix for atomic shared memory operations
+void gen_lock_prefix(codeblock_t* cb)
+{
+    cb_write_byte(cb, 0xF0);
+}

--- a/ujit_asm.c
+++ b/ujit_asm.c
@@ -1631,7 +1631,7 @@ void xor(codeblock_t* cb, x86opnd_t opnd0, x86opnd_t opnd1)
 }
 
 // LOCK - lock prefix for atomic shared memory operations
-void gen_lock_prefix(codeblock_t* cb)
+void cb_write_lock_prefix(codeblock_t* cb)
 {
     cb_write_byte(cb, 0xF0);
 }

--- a/ujit_asm.h
+++ b/ujit_asm.h
@@ -379,6 +379,6 @@ void test(codeblock_t* cb, x86opnd_t rm_opnd, x86opnd_t test_opnd);
 void ud2(codeblock_t* cb);
 void xor(codeblock_t* cb, x86opnd_t opnd0, x86opnd_t opnd1);
 
-void gen_lock_prefix(codeblock_t* cb);
+void cb_write_lock_prefix(codeblock_t* cb);
 
 #endif

--- a/ujit_asm.h
+++ b/ujit_asm.h
@@ -379,4 +379,6 @@ void test(codeblock_t* cb, x86opnd_t rm_opnd, x86opnd_t test_opnd);
 void ud2(codeblock_t* cb);
 void xor(codeblock_t* cb, x86opnd_t opnd0, x86opnd_t opnd1);
 
+void gen_lock_prefix(codeblock_t* cb);
+
 #endif

--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -167,7 +167,7 @@ _gen_counter_inc(codeblock_t *cb, int64_t *counter)
 {
     if (!rb_ujit_opts.gen_stats) return;
      mov(cb, REG0, const_ptr_opnd(counter));
-     // XXX: Will want lock prefix for ractors.
+     gen_lock_prefix(cb); // for ractors.
      add(cb, mem_opnd(64, REG0, 0), imm_opnd(1));
 }
 

--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -159,6 +159,36 @@ ujit_side_exit(jitstate_t* jit, ctx_t* ctx)
     return code_ptr;
 }
 
+#if RUBY_DEBUG
+
+#define GEN_COUNTER_INC(cb, counter_name) _gen_counter_inc(cb, &(ujit_runtime_counters . counter_name))
+static void
+_gen_counter_inc(codeblock_t *cb, int64_t *counter)
+{
+    if (!rb_ujit_opts.gen_stats) return;
+     mov(cb, REG0, const_ptr_opnd(counter));
+     // XXX: Will want lock prefix for ractors.
+     add(cb, mem_opnd(64, REG0, 0), imm_opnd(1));
+}
+
+#define COUNTED_EXIT(existing, counter_name) _counted_side_exit(existing, &(ujit_runtime_counters . counter_name))
+// Increment a counter then take an existing side exit.
+static uint8_t *
+_counted_side_exit(uint8_t *existing_side_exit, int64_t *counter)
+{
+    if (!rb_ujit_opts.gen_stats) return existing_side_exit;
+
+    uint8_t *start = cb_get_ptr(ocb, ocb->write_pos);
+    _gen_counter_inc(ocb, counter);
+    jmp_ptr(ocb, existing_side_exit);
+    return start;
+}
+
+#else
+#define GEN_COUNTER_INC(cb, counter_name) ((void)0)
+#define COUNTED_EXIT(existing, counter_name) existing
+#endif // if RUBY_DEBUG
+
 /*
 Compile an interpreter entry block to be inserted into an iseq
 Returns `NULL` if compilation fails.
@@ -253,28 +283,23 @@ ujit_gen_block(ctx_t* ctx, block_t* block)
             break;
         }
 
-#if RUBY_DEBUG
-        // Accumulate stats about instructions executed
-        if (rb_ujit_opts.gen_stats) {
-            // Count instructions executed by the JIT
-            mov(cb, REG0, const_ptr_opnd((void *)&rb_ujit_exec_insns_count));
-            add(cb, mem_opnd(64, REG0, 0), imm_opnd(1));
-        }
-#endif
-
         //fprintf(stderr, "compiling %d: %s\n", insn_idx, insn_name(opcode));
         //print_str(cb, insn_name(opcode));
 
+        // Count bytecode instructions that execute in generated code
+        // FIXME: when generation function returns false, we shouldn't increment
+        //        this counter.
+        GEN_COUNTER_INC(cb, exec_instruction);
+
         // Call the code generation function
         opdesc_t* p_desc = (opdesc_t*)st_op_desc;
-        bool success = p_desc->gen_fn(&jit, ctx);
+        bool continue_generating = p_desc->gen_fn(&jit, ctx);
 
-        // If we can't compile this instruction, stop
-        if (!success) {
+        if (!continue_generating) {
             break;
         }
 
-    	// Move to the next instruction
+        // Move to the next instruction
         p_last_op = p_desc;
         insn_idx += insn_len(opcode);
 
@@ -1073,23 +1098,25 @@ gen_oswb_cfunc(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_c
     // If the function expects a Ruby array of arguments
     if (cfunc->argc < 0 && cfunc->argc != -1)
     {
+        GEN_COUNTER_INC(cb, oswb_cfunc_ruby_array_varg);
         return false;
     }
 
     // If the argument count doesn't match
     if (cfunc->argc >= 0 && cfunc->argc != argc)
     {
+        GEN_COUNTER_INC(cb, oswb_cfunc_argc_mismatch);
         return false;
     }
 
     // Don't JIT functions that need C stack arguments for now
-    if (argc + 1 > NUM_C_ARG_REGS)
-    {
+    if (argc + 1 > NUM_C_ARG_REGS) {
+        GEN_COUNTER_INC(cb, oswb_cfunc_toomany_args);
         return false;
     }
 
     // Create a size-exit to fall back to the interpreter
-    uint8_t* side_exit = ujit_side_exit(jit, ctx);
+    uint8_t *side_exit = ujit_side_exit(jit, ctx);
 
     // Check for interrupts
     ujit_check_ints(cb, side_exit);
@@ -1108,12 +1135,15 @@ gen_oswb_cfunc(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_c
     //print_ptr(cb, recv);
 
     // Check that the receiver is a heap object
-    test(cb, REG0, imm_opnd(RUBY_IMMEDIATE_MASK));
-    jnz_ptr(cb, side_exit);
-    cmp(cb, REG0, imm_opnd(Qfalse));
-    je_ptr(cb, side_exit);
-    cmp(cb, REG0, imm_opnd(Qnil));
-    je_ptr(cb, side_exit);
+    {
+        uint8_t *receiver_not_heap = COUNTED_EXIT(side_exit, oswb_se_receiver_not_heap);
+        test(cb, REG0, imm_opnd(RUBY_IMMEDIATE_MASK));
+        jnz_ptr(cb, receiver_not_heap);
+        cmp(cb, REG0, imm_opnd(Qfalse));
+        je_ptr(cb, receiver_not_heap);
+        cmp(cb, REG0, imm_opnd(Qnil));
+        je_ptr(cb, receiver_not_heap);
+    }
 
     // Pointer to the klass field of the receiver &(recv->klass)
     x86opnd_t klass_opnd = mem_opnd(64, REG0, offsetof(struct RBasic, klass));
@@ -1124,7 +1154,7 @@ gen_oswb_cfunc(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_c
     // Bail if receiver class is different from compile-time call cache class
     jit_mov_gc_ptr(jit, cb, REG1, (VALUE)cd->cc->klass);
     cmp(cb, klass_opnd, REG1);
-    jne_ptr(cb, side_exit);
+    jne_ptr(cb, COUNTED_EXIT(side_exit, oswb_se_cc_klass_differ));
 
     // Store incremented PC into current control frame in case callee raises.
     mov(cb, REG0, const_ptr_opnd(jit->pc + insn_len(BIN(opt_send_without_block))));
@@ -1138,7 +1168,7 @@ gen_oswb_cfunc(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_c
         // REG_CFP <= REG_SP + 4 * sizeof(VALUE) + sizeof(rb_control_frame_t)
         lea(cb, REG0, ctx_sp_opnd(ctx, sizeof(VALUE) * 4 + sizeof(rb_control_frame_t)));
         cmp(cb, REG_CFP, REG0);
-        jle_ptr(cb, side_exit);
+        jle_ptr(cb, COUNTED_EXIT(side_exit, oswb_se_cf_overflow));
 
         // Increment the stack pointer by 3 (in the callee)
         // sp += 3
@@ -1299,18 +1329,20 @@ gen_oswb_iseq(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_ca
     int num_locals = iseq->body->local_table_size - num_params;
 
     if (num_params != argc) {
-        //fprintf(stderr, "param argc mismatch\n");
+        GEN_COUNTER_INC(cb, oswb_iseq_argc_mismatch);
         return false;
     }
 
     if (!rb_simple_iseq_p(iseq)) {
         // Only handle iseqs that have simple parameters.
         // See vm_callee_setup_arg().
+        GEN_COUNTER_INC(cb, oswb_iseq_not_simple);
         return false;
     }
 
     if (vm_ci_flag(cd->ci) & VM_CALL_TAILCALL) {
         // We can't handle tailcalls
+        GEN_COUNTER_INC(cb, oswb_iseq_tailcall);
         return false;
     }
 
@@ -1333,12 +1365,15 @@ gen_oswb_iseq(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_ca
     //print_ptr(cb, recv);
 
     // Check that the receiver is a heap object
-    test(cb, REG0, imm_opnd(RUBY_IMMEDIATE_MASK));
-    jnz_ptr(cb, side_exit);
-    cmp(cb, REG0, imm_opnd(Qfalse));
-    je_ptr(cb, side_exit);
-    cmp(cb, REG0, imm_opnd(Qnil));
-    je_ptr(cb, side_exit);
+    {
+        uint8_t *receiver_not_heap = COUNTED_EXIT(side_exit, oswb_se_receiver_not_heap);
+        test(cb, REG0, imm_opnd(RUBY_IMMEDIATE_MASK));
+        jnz_ptr(cb, receiver_not_heap);
+        cmp(cb, REG0, imm_opnd(Qfalse));
+        je_ptr(cb, receiver_not_heap);
+        cmp(cb, REG0, imm_opnd(Qnil));
+        je_ptr(cb, receiver_not_heap);
+    }
 
     // Pointer to the klass field of the receiver &(recv->klass)
     x86opnd_t klass_opnd = mem_opnd(64, REG0, offsetof(struct RBasic, klass));
@@ -1348,7 +1383,7 @@ gen_oswb_iseq(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_ca
     // Bail if receiver class is different from compile-time call cache class
     jit_mov_gc_ptr(jit, cb, REG1, (VALUE)cd->cc->klass);
     cmp(cb, klass_opnd, REG1);
-    jne_ptr(cb, side_exit);
+    jne_ptr(cb, COUNTED_EXIT(side_exit, oswb_se_cc_klass_differ));
 
     // Store the updated SP on the current frame (pop arguments and receiver)
     lea(cb, REG0, ctx_sp_opnd(ctx, sizeof(VALUE) * -(argc + 1)));
@@ -1362,7 +1397,7 @@ gen_oswb_iseq(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_ca
     // #define CHECK_VM_STACK_OVERFLOW0(cfp, sp, margin)
     lea(cb, REG0, ctx_sp_opnd(ctx, sizeof(VALUE) * (num_locals + iseq->body->stack_max) + sizeof(rb_control_frame_t)));
     cmp(cb, REG_CFP, REG0);
-    jle_ptr(cb, side_exit);
+    jle_ptr(cb, COUNTED_EXIT(side_exit, oswb_se_cf_overflow));
 
     // Adjust the callee's stack pointer
     lea(cb, REG0, ctx_sp_opnd(ctx, sizeof(VALUE) * (3 + num_locals)));
@@ -1439,7 +1474,7 @@ gen_oswb_iseq(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_ca
 
     // Load the updated SP
     mov(cb, REG_SP, member_opnd(REG_CFP, rb_control_frame_t, sp));
-   
+
     // Directly jump to the entry point of the callee
     gen_direct_jump(
         &DEFAULT_CTX,
@@ -1463,19 +1498,20 @@ gen_opt_send_without_block(jitstate_t* jit, ctx_t* ctx)
     int32_t argc = (int32_t)vm_ci_argc(cd->ci);
 
     // Don't JIT calls with keyword splat
-    if (vm_ci_flag(cd->ci) & VM_CALL_KW_SPLAT)
-    {
+    if (vm_ci_flag(cd->ci) & VM_CALL_KW_SPLAT) {
+        GEN_COUNTER_INC(cb, oswb_kw_splat);
         return false;
     }
 
     // Don't JIT calls that aren't simple
-    if (!(vm_ci_flag(cd->ci) & VM_CALL_ARGS_SIMPLE))
-    {
+    if (!(vm_ci_flag(cd->ci) & VM_CALL_ARGS_SIMPLE)) {
+        GEN_COUNTER_INC(cb, oswb_callsite_not_simple);
         return false;
     }
 
     // Don't JIT if the inline cache is not set
     if (!cd->cc || !cd->cc->klass) {
+        GEN_COUNTER_INC(cb, oswb_ic_empty);
         return false;
     }
 
@@ -1483,32 +1519,58 @@ gen_opt_send_without_block(jitstate_t* jit, ctx_t* ctx)
 
     // Don't JIT if the method entry is out of date
     if (METHOD_ENTRY_INVALIDATED(cme)) {
+        GEN_COUNTER_INC(cb, oswb_invalid_cme);
         return false;
     }
 
     // We don't generate code to check protected method calls
     if (METHOD_ENTRY_VISI(cme) == METHOD_VISI_PROTECTED) {
+        GEN_COUNTER_INC(cb, oswb_protected);
         return false;
     }
 
-    // If this is a C call
-    if (cme->def->type == VM_METHOD_TYPE_CFUNC)
-    {
-        return gen_oswb_cfunc(jit, ctx, cd, cme, argc);
-    }
-
-    // If this is a Ruby call
-    if (cme->def->type == VM_METHOD_TYPE_ISEQ)
-    {
+    switch (cme->def->type) {
+    case VM_METHOD_TYPE_ISEQ:
         return gen_oswb_iseq(jit, ctx, cd, cme, argc);
+    case VM_METHOD_TYPE_CFUNC:
+        return gen_oswb_cfunc(jit, ctx, cd, cme, argc);
+    case VM_METHOD_TYPE_ATTRSET:
+        GEN_COUNTER_INC(cb, oswb_ivar_set_method);
+        return false;
+    case VM_METHOD_TYPE_BMETHOD:
+        GEN_COUNTER_INC(cb, oswb_bmethod);
+        return false;
+    case VM_METHOD_TYPE_IVAR:
+        GEN_COUNTER_INC(cb, oswb_ivar_get_method);
+        return false;
+    case VM_METHOD_TYPE_ZSUPER:
+        GEN_COUNTER_INC(cb, oswb_zsuper_method);
+        return false;
+    case VM_METHOD_TYPE_ALIAS:
+        GEN_COUNTER_INC(cb, oswb_alias_method);
+        return false;
+    case VM_METHOD_TYPE_UNDEF:
+        GEN_COUNTER_INC(cb, oswb_undef_method);
+        return false;
+    case VM_METHOD_TYPE_NOTIMPLEMENTED:
+        GEN_COUNTER_INC(cb, oswb_not_implemented_method);
+        return false;
+    case VM_METHOD_TYPE_OPTIMIZED:
+        GEN_COUNTER_INC(cb, oswb_optimized_method);
+        return false;
+    case VM_METHOD_TYPE_MISSING:
+        GEN_COUNTER_INC(cb, oswb_missing_method);
+        return false;
+    case VM_METHOD_TYPE_REFINED:
+        GEN_COUNTER_INC(cb, oswb_refined_method);
+        return false;
+    // no default case so compiler issues a warning if this is not exhaustive
     }
-
-    return false;
 }
 
 static bool
 gen_leave(jitstate_t* jit, ctx_t* ctx)
-{ 
+{
     // Only the return value should be on the stack
     RUBY_ASSERT(ctx->stack_size == 1);
 

--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -168,7 +168,7 @@ _gen_counter_inc(codeblock_t *cb, int64_t *counter)
 {
     if (!rb_ujit_opts.gen_stats) return;
      mov(cb, REG0, const_ptr_opnd(counter));
-     gen_lock_prefix(cb); // for ractors.
+     cb_write_lock_prefix(cb); // for ractors.
      add(cb, mem_opnd(64, REG0, 0), imm_opnd(1));
 }
 

--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -161,6 +161,7 @@ ujit_side_exit(jitstate_t* jit, ctx_t* ctx)
 
 #if RUBY_DEBUG
 
+// Increment a profiling counter with counter_name
 #define GEN_COUNTER_INC(cb, counter_name) _gen_counter_inc(cb, &(ujit_runtime_counters . counter_name))
 static void
 _gen_counter_inc(codeblock_t *cb, int64_t *counter)
@@ -171,8 +172,8 @@ _gen_counter_inc(codeblock_t *cb, int64_t *counter)
      add(cb, mem_opnd(64, REG0, 0), imm_opnd(1));
 }
 
-#define COUNTED_EXIT(existing, counter_name) _counted_side_exit(existing, &(ujit_runtime_counters . counter_name))
 // Increment a counter then take an existing side exit.
+#define COUNTED_EXIT(side_exit, counter_name) _counted_side_exit(side_exit, &(ujit_runtime_counters . counter_name))
 static uint8_t *
 _counted_side_exit(uint8_t *existing_side_exit, int64_t *counter)
 {
@@ -186,7 +187,7 @@ _counted_side_exit(uint8_t *existing_side_exit, int64_t *counter)
 
 #else
 #define GEN_COUNTER_INC(cb, counter_name) ((void)0)
-#define COUNTED_EXIT(existing, counter_name) existing
+#define COUNTED_EXIT(side_exit, counter_name) side_exit
 #endif // if RUBY_DEBUG
 
 /*

--- a/ujit_iface.c
+++ b/ujit_iface.c
@@ -507,10 +507,12 @@ ujit_disasm(VALUE self, VALUE code, VALUE from)
 
 // Primitive called in ujit.rb. Export all runtime counters as a Ruby hash.
 static VALUE
-runtime_counters_to_hash(rb_execution_context_t *ec, VALUE self)
+get_stat_counters(rb_execution_context_t *ec, VALUE self)
 {
-    VALUE hash = rb_hash_new();
 #if RUBY_DEBUG
+    if (!rb_ujit_opts.gen_stats) return Qnil;
+
+    VALUE hash = rb_hash_new();
     RB_VM_LOCK_ENTER();
     {
         int64_t *counter_reader = (int64_t *)&ujit_runtime_counters;
@@ -544,9 +546,10 @@ runtime_counters_to_hash(rb_execution_context_t *ec, VALUE self)
         }
     }
     RB_VM_LOCK_LEAVE();
-
-#endif
     return hash;
+#else
+    return Qnil;
+#endif // if RUBY_DEBUG
 }
 
 #include "ujit.rbinc"

--- a/ujit_iface.h
+++ b/ujit_iface.h
@@ -21,9 +21,49 @@ struct rb_callcache;
 #define rb_callcache rb_callcache
 #endif
 
+#define UJIT_DECLARE_COUNTERS(...) struct rb_ujit_runtime_counters { \
+    int64_t __VA_ARGS__; \
+}; \
+static char ujit_counter_names[] = #__VA_ARGS__;
+
+UJIT_DECLARE_COUNTERS(
+    exec_instruction,
+
+    oswb_callsite_not_simple,
+    oswb_kw_splat,
+    oswb_ic_empty,
+    oswb_invalid_cme,
+    oswb_protected,
+    oswb_ivar_set_method,
+    oswb_ivar_get_method,
+    oswb_zsuper_method,
+    oswb_alias_method,
+    oswb_undef_method,
+    oswb_optimized_method,
+    oswb_missing_method,
+    oswb_bmethod,
+    oswb_refined_method,
+    oswb_unknown_method_type,
+    oswb_cfunc_ruby_array_varg,
+    oswb_cfunc_argc_mismatch,
+    oswb_cfunc_toomany_args,
+    oswb_iseq_tailcall,
+    oswb_iseq_argc_mismatch,
+    oswb_iseq_not_simple,
+    oswb_not_implemented_method,
+    oswb_se_receiver_not_heap,
+    oswb_se_cf_overflow,
+    oswb_se_cc_klass_differ,
+
+    // Member with known name for iterating over counters
+    last_member
+)
+
+#undef UJIT_DECLARE_COUNTERS
+
 RUBY_EXTERN struct rb_ujit_options rb_ujit_opts;
-RUBY_EXTERN int64_t rb_ujit_exec_insns_count;
 RUBY_EXTERN int64_t rb_compiled_iseq_count;
+RUBY_EXTERN struct rb_ujit_runtime_counters ujit_runtime_counters;
 
 void cb_write_pre_call_bytes(codeblock_t* cb);
 void cb_write_post_call_bytes(codeblock_t* cb);


### PR DESCRIPTION


This PR adds the ability to count the taking of different types of side exits and the various reason we stop compiling for `opt_send_without_block`