### PR TITLE
Add UJIT.reset_stats!

### DIFF
--- a/ujit.rb
+++ b/ujit.rb
@@ -43,6 +43,12 @@ module UJIT
     Primitive.get_stat_counters
   end
 
+  # Discard statistics collected for --ujit-stats.
+  def self.reset_stats!
+    # defined in ujit_iface.c
+    Primitive.reset_stats_bang
+  end
+
   class << self
     private
 

--- a/ujit_iface.c
+++ b/ujit_iface.c
@@ -561,6 +561,19 @@ get_stat_counters(rb_execution_context_t *ec, VALUE self)
 #endif // if RUBY_DEBUG
 }
 
+// Primitive called in ujit.rb. Zero out all the counters.
+static VALUE
+reset_stats_bang(rb_execution_context_t *ec, VALUE self)
+{
+#if RUBY_DEBUG
+    vm_insns_count = 0;
+    rb_compiled_iseq_count = 0;
+    memset(&exit_op_count, 0, sizeof(exit_op_count));
+    memset(&ujit_runtime_counters, 0, sizeof(ujit_runtime_counters));
+#endif // if RUBY_DEBUG
+    return Qnil;
+}
+
 #include "ujit.rbinc"
 
 #if RUBY_DEBUG


### PR DESCRIPTION
To allow analyzing sections of the application.
Usage in railsbench: https://github.com/Shopify/microjit-bench/pull/2
Doesn't change the side exit stats much, but gives a better idea for how many iseqs compile.