### PR TITLE
uJIT: Add exit counters for leave and refactor stats printout code

### DIFF
--- a/ujit.rb
+++ b/ujit.rb
@@ -53,10 +53,16 @@ module UJIT
       return unless counters
 
       $stderr.puts("***uJIT: Printing runtime counters from ujit.rb***")
-      $stderr.puts("opt_send_without_block exit reasons: ")
 
-      counters.filter! { |key, _| key.start_with?('oswb_') }
-      counters.transform_keys! { |key| key.to_s.delete_prefix('oswb_') }
+      print_counters(counters, prefix: 'oswb_', prompt: 'opt_send_without_block exit reasons: ')
+      print_counters(counters, prefix: 'leave_', prompt: 'leave exit reasons: ')
+    end
+
+    def print_counters(counters, prefix:, prompt:)
+      $stderr.puts(prompt)
+      counters = counters.filter { |key, _| key.start_with?(prefix) }
+      counters.filter! { |_, value| value > 0 }
+      counters.transform_keys! { |key| key.to_s.delete_prefix(prefix) }
 
       counters = counters.to_a
       counters.sort_by! { |(_, counter_value)| counter_value }

--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -1605,10 +1605,10 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
     // if (flags & VM_FRAME_FLAG_FINISH) != 0
     x86opnd_t flags_opnd = mem_opnd(64, REG0, sizeof(VALUE) * VM_ENV_DATA_INDEX_FLAGS);
     test(cb, flags_opnd, imm_opnd(VM_FRAME_FLAG_FINISH));
-    jnz_ptr(cb, side_exit);
+    jnz_ptr(cb, COUNTED_EXIT(side_exit, leave_se_finish_frame));
 
     // Check for interrupts
-    ujit_check_ints(cb, side_exit);
+    ujit_check_ints(cb, COUNTED_EXIT(side_exit, leave_se_interrupt));
 
     // Load the return value
     mov(cb, REG0, ctx_stack_pop(ctx, 1));
@@ -1625,7 +1625,7 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
     // The SP points one above the topmost value
     add(cb, member_opnd(REG_CFP, rb_control_frame_t, sp), imm_opnd(SIZEOF_VALUE));
     mov(cb, REG_SP, member_opnd(REG_CFP, rb_control_frame_t, sp));
-    mov(cb, mem_opnd(64, REG_SP, -SIZEOF_VALUE), REG0);  
+    mov(cb, mem_opnd(64, REG_SP, -SIZEOF_VALUE), REG0);
 
     // If the return address is NULL, fall back to the interpreter
     int FALLBACK_LABEL = cb_new_label(cb, "FALLBACK");

--- a/ujit_iface.h
+++ b/ujit_iface.h
@@ -55,6 +55,9 @@ UJIT_DECLARE_COUNTERS(
     oswb_se_cc_klass_differ,
     oswb_se_protected_check_failed,
 
+    leave_se_finish_frame,
+    leave_se_interrupt,
+
     // Member with known name for iterating over counters
     last_member
 )


### PR DESCRIPTION
Filter out counters that are zero and make it easier to have multiple
printout groups.

On `railsbench`:

```
opt_send_without_block exit reasons:
    se_finish_frame     184809 (100.0%)
```

ref: #63 