### PR TITLE
uJIT: support 64 bit operands for TEST. Use it to check for zero

### DIFF
--- a/ujit_asm.c
+++ b/ujit_asm.c
@@ -1609,10 +1609,8 @@ void test(codeblock_t* cb, x86opnd_t rm_opnd, x86opnd_t test_opnd)
     }
     else
     {
-        // For now, 32-bit operands only
         assert (test_opnd.num_bits == rm_opnd.num_bits);
-        assert (test_opnd.num_bits == 32);
-        cb_write_rm(cb, false, false, test_opnd, rm_opnd, 0xFF, 1, 0x85);
+        cb_write_rm(cb, false, rm_opnd.num_bits == 64, test_opnd, rm_opnd, 0xFF, 1, 0x85);
     }
 }
 

--- a/ujit_asm_tests.c
+++ b/ujit_asm_tests.c
@@ -334,6 +334,9 @@ void run_tests()
     cb_set_pos(cb, 0); test(cb, mem_opnd(8, RSI, 16), imm_opnd(1)); check_bytes(cb, "F6461001");
     cb_set_pos(cb, 0); test(cb, mem_opnd(8, RSI, -16), imm_opnd(1)); check_bytes(cb, "F646F001");
     cb_set_pos(cb, 0); test(cb, mem_opnd(32, RSI, 64), EAX); check_bytes(cb, "854640");
+    cb_set_pos(cb, 0); test(cb, mem_opnd(64, RDI, 42), RAX); check_bytes(cb, "4885472A");
+    cb_set_pos(cb, 0); test(cb, RAX, RAX); check_bytes(cb, "4885C0");
+    cb_set_pos(cb, 0); test(cb, RAX, RSI); check_bytes(cb, "4885F0");
     cb_set_pos(cb, 0); test(cb, mem_opnd(64, RSI, 64), imm_opnd(~0x08)); check_bytes(cb, "48F74640F7FFFFFF");
 
     // xor

--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -1103,7 +1103,7 @@ jit_protected_guard(jitstate_t *jit, codeblock_t *cb, const rb_callable_method_e
     // VALUE rb_obj_is_kind_of(VALUE obj, VALUE klass);
     call_ptr(cb, REG0, (void *)&rb_obj_is_kind_of);
     ujit_load_regs(cb);
-    cmp(cb, RAX, imm_opnd(0));
+    test(cb, RAX, RAX);
     jz_ptr(cb, COUNTED_EXIT(side_exit, oswb_se_protected_check_failed));
 }
 
@@ -1629,7 +1629,7 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
 
     // If the return address is NULL, fall back to the interpreter
     int FALLBACK_LABEL = cb_new_label(cb, "FALLBACK");
-    cmp(cb, REG1, imm_opnd(0));
+    test(cb, REG1, REG1);
     jz_label(cb, FALLBACK_LABEL);
 
     // Jump to the JIT return address


### PR DESCRIPTION
It's one byte shorter than `cmp reg64, 0`. To illustrate:

```
48 83 f9 00        cmp    rcx, 0x0
48 85 c9           test   rcx, rcx
```

PS: we might want to add `ujit_asm_tests.c` to CI.