### PR TITLE
Implement opt_nil_p instruction

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,99 @@
+# opt_nil_p checks for heap objects
+assert_equal 'false', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; end
+    check_nil Foo.new
+    check_nil Foo.new
+    check_nil Foo.new
+    check_nil 10
+}
+
+# opt_nil_p on filled IC but with nil
+assert_equal 'true', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; end
+    check_nil Foo.new
+    check_nil nil
+    check_nil nil
+    check_nil nil
+}
+
+# opt_nil_p on object
+assert_equal 'true', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; def nil?; true; end end
+    m = Foo.new
+    check_nil Object.new
+    check_nil Object.new
+    check_nil Object.new
+    check_nil m
+}
+
+# opt_nil_p on symbol
+assert_equal 'true', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; def nil?; true; end end
+    m = Foo.new
+    check_nil :foo
+    check_nil :foo
+    check_nil :foo
+    check_nil m
+}
+
+# opt_nil_p on immediate float
+assert_equal 'true', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; def nil?; true; end end
+    m = Foo.new
+    check_nil 1.3
+    check_nil 1.3
+    check_nil 1.3
+    check_nil m
+}
+
+# opt_nil_p on true
+assert_equal 'true', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; def nil?; true; end end
+    m = Foo.new
+    check_nil true
+    check_nil true
+    check_nil true
+    check_nil m
+}
+
+# opt_nil_p on false
+assert_equal 'true', %q{
+    def check_nil(x)
+      x.nil?
+    end
+
+    class Foo; def nil?; true; end end
+    m = Foo.new
+    check_nil false
+    check_nil false
+    check_nil false
+    check_nil m
+}
+
 # Putobject, less-than operator, fixnums
 assert_equal '2', %q{
     def check_index(index)


### PR DESCRIPTION
This commit implements the opt_nil_p instruction.  It's kind of an
awkward instruction to implement because the interpreter inconsistently
uses the inline cache.  When the receiver is `nil`, the inline cache
won't be used.

For example:

```ruby
def foo x
  x.nil?
end

class Foo; end

foo Foo.new # IC is filled with `Foo` as the class
foo nil     # IC isn't used, and `Foo` isn't evacuated from the cache
foo Foo.new # IC is still filled with `Foo` so this is an IC hit
```

Anyway, the compiled instructions are specialized based off whatever
class is stored in the inline cache.  Since `nil` doesn't use the inline
cache, `rb_cNilClass` will never be stored in the inline cache.  Meaning
the only time we ever specialize the instruction for `nil` is in the
case when the stored class is NULL.

For example, this will get specialized with the `nil` case:

```ruby
def foo x
  x.nil?
end

foo nil
foo nil
foo nil
```

However, if the instruction has ever seen any object besides `nil`, the
instruction is basically "poisoned" and can never be specialized for
`nil` again.

The below example gets poisoned with the class `Foo`, and even though
subsequent calls only use `nil` and invoke the JIT, the compiled JIT
instructions will be specialized for `Foo` (since it is stored in the
cache):

```ruby
def foo x
  x.nil?
end

class Foo; end

foo Foo.new # inline cache is poisoned with Foo
foo nil
foo nil
foo nil
```