### PR TITLE
YJIT: fix leak, remove unused field on block_t

### DIFF
--- a/ujit_codegen.c
+++ b/ujit_codegen.c
@@ -1399,8 +1399,6 @@ gen_oswb_iseq(jitstate_t* jit, ctx_t* ctx, struct rb_call_data * cd, const rb_ca
         return UJIT_CANT_COMPILE;
     }
 
-    rb_gc_register_mark_object((VALUE)iseq); // FIXME: intentional LEAK!
-
     // Create a size-exit to fall back to the interpreter
     uint8_t* side_exit = ujit_side_exit(jit, ctx);
 

--- a/ujit_core.c
+++ b/ujit_core.c
@@ -197,7 +197,6 @@ add_block_version(blockid_t blockid, block_t* block)
     {
         // By writing the new block to the iseq, the iseq now
         // contains new references to Ruby objects. Run write barriers.
-        RB_OBJ_WRITTEN(iseq, Qundef, block->dependencies.iseq);
         RB_OBJ_WRITTEN(iseq, Qundef, block->dependencies.cc);
         RB_OBJ_WRITTEN(iseq, Qundef, block->dependencies.cme);
 

--- a/ujit_core.h
+++ b/ujit_core.h
@@ -131,7 +131,6 @@ typedef struct ujit_block_version
     struct {
         VALUE cc;
         VALUE cme;
-        VALUE iseq;
     } dependencies;
 
     // Index one past the last instruction in the iseq

--- a/ujit_iface.c
+++ b/ujit_iface.c
@@ -684,7 +684,6 @@ rb_ujit_iseq_mark(const struct rb_iseq_constant_body *body)
 
             rb_gc_mark_movable(block->dependencies.cc);
             rb_gc_mark_movable(block->dependencies.cme);
-            rb_gc_mark_movable(block->dependencies.iseq);
 
             // Walk over references to objects in generated code.
             uint32_t *offset_element;
@@ -710,7 +709,6 @@ rb_ujit_iseq_update_references(const struct rb_iseq_constant_body *body)
 
             block->dependencies.cc = rb_gc_location(block->dependencies.cc);
             block->dependencies.cme = rb_gc_location(block->dependencies.cme);
-            block->dependencies.iseq = rb_gc_location(block->dependencies.iseq);
 
             // Walk over references to objects in generated code.
             uint32_t *offset_element;


### PR DESCRIPTION
This field was never used and is now covered by jit_mov_gc_ptr.