### PR TITLE
Fix condition in cb_align_pos which should return early when aligned

### DIFF
--- a/yjit_asm.c
+++ b/yjit_asm.c
@@ -178,7 +178,7 @@ void cb_align_pos(codeblock_t* cb, uint32_t multiple)
     uint32_t rem = ((uint32_t)ptr) % multiple;
 
     // If the pointer is already aligned, stop
-    if (rem != 0)
+    if (rem == 0)
         return;
 
     // Pad the pointer by the necessary amount to align it


### PR DESCRIPTION
The early return condition in cb_align_pos was inverted, which was causing the function to effectively do nothing.

I just noticed this bug while reading the code, so I'm just sharing an untested fix to point out the problem.