### PR TITLE
YJIT: Some debug code to verify possible race with MJIT's worker 

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -3142,14 +3142,6 @@ typedef struct insn_data_struct {
 } insn_data_t;
 static insn_data_t insn_data[VM_INSTRUCTION_SIZE/2];
 
-
-
-
-#include "yjit_asm.h"
-
-
-
-
 void
 rb_vm_encoded_insn_data_table_init(void)
 {

--- a/iseq.c
+++ b/iseq.c
@@ -3181,7 +3181,9 @@ rb_vm_insn_addr2insn(const void *addr)
     st_data_t key = (st_data_t)addr;
     st_data_t val;
 
+    if (rb_native_mutex_trylock(&GET_VM()->addr2insn_lock) != 0) rb_bug("there is contention!");
     if (st_lookup(rb_encoded_insn_data, key, &val)) {
+        rb_native_mutex_unlock(&GET_VM()->addr2insn_lock);
         insn_data_t *e = (insn_data_t *)val;
         return (int)e->insn;
     }
@@ -3196,7 +3198,9 @@ rb_vm_insn_addr2opcode(const void *addr)
     st_data_t key = (st_data_t)addr;
     st_data_t val;
 
+    if (rb_native_mutex_trylock(&GET_VM()->addr2insn_lock) != 0) rb_bug("there is contention!");
     if (st_lookup(rb_encoded_insn_data, key, &val)) {
+        rb_native_mutex_unlock(&GET_VM()->addr2insn_lock);
         insn_data_t *e = (insn_data_t *)val;
         int opcode = e->insn;
         if (addr == e->trace_encoded_insn) {
@@ -3214,7 +3218,9 @@ encoded_iseq_trace_instrument(VALUE *iseq_encoded_insn, rb_event_flag_t turnon, 
     st_data_t key = (st_data_t)*iseq_encoded_insn;
     st_data_t val;
 
+    if (rb_native_mutex_trylock(&GET_VM()->addr2insn_lock) != 0) rb_bug("there is contention!");
     if (st_lookup(rb_encoded_insn_data, key, &val)) {
+        rb_native_mutex_unlock(&GET_VM()->addr2insn_lock);
         insn_data_t *e = (insn_data_t *)val;
         if (remain_current_trace && key == (st_data_t)e->trace_encoded_insn) {
             turnon = 1;

--- a/thread.c
+++ b/thread.c
@@ -5408,6 +5408,10 @@ Init_Thread_Mutex(void)
     rb_native_mutex_initialize(&th->vm->waitpid_lock);
     rb_native_mutex_initialize(&th->vm->workqueue_lock);
     rb_native_mutex_initialize(&th->interrupt_lock);
+
+
+
+    rb_native_mutex_initialize(&th->vm->addr2insn_lock);
 }
 
 /*

--- a/vm_core.h
+++ b/vm_core.h
@@ -647,6 +647,8 @@ typedef struct rb_vm_struct {
     struct list_head workqueue; /* <=> rb_workqueue_job.jnode */
     rb_nativethread_lock_t workqueue_lock;
 
+    rb_nativethread_lock_t addr2insn_lock;
+
     VALUE orig_progname, progname;
     VALUE coverages;
     int coverage_mode;

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -147,6 +147,9 @@ yjit_gen_exit(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
         mov(cb, REG0, const_ptr_opnd(exit_pc));
         mov(cb, REG1, const_ptr_opnd(handler_addr));
         mov(cb, mem_opnd(64, REG0, 0), REG1);
+
+        // FIXME: this leaks the entry in the table mapping direct threading
+        // addresses to information about bytecode instructions. See map_addr2insn().
     }
 
     // Generate the code to exit to the interpreters


### PR DESCRIPTION
    YJIT: Some debug code to verify possible race with MJIT's worker

    MJIT sometimes crashes on CI. While it also crashes on upstream's master
    brach, YJIT might be making it worse.

    YJIT inserts into the table for mapping direct threading addresses to
    opcodes, and that might be racing with mjit_worker trying to compile
    things. Without YJIT, that table is constant, so multiple threads trying
    to read from it was not a problem.

    Use trylock to detect the race. If the race outlined above happens,
    trylock should fail to acquire the lock and trigger rb_bug.