### PR TITLE
Collect statistics about binding allocations / local variable set

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -10055,6 +10055,7 @@ proc.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 proc.$(OBJEXT): {$(VPATH)}thread_native.h
 proc.$(OBJEXT): {$(VPATH)}vm_core.h
 proc.$(OBJEXT): {$(VPATH)}vm_opts.h
+proc.$(OBJEXT): {$(VPATH)}yjit.h
 process.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 process.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 process.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/proc.c
+++ b/proc.c
@@ -21,6 +21,7 @@
 #include "method.h"
 #include "iseq.h"
 #include "vm_core.h"
+#include "yjit.h"
 
 #if !defined(__GNUC__) || __GNUC__ < 5 || defined(__MINGW32__)
 # define NO_CLOBBERED(v) (*(volatile VALUE *)&(v))
@@ -351,6 +352,9 @@ rb_binding_alloc(VALUE klass)
     VALUE obj;
     rb_binding_t *bind;
     obj = TypedData_Make_Struct(klass, rb_binding_t, &ruby_binding_data_type, bind);
+#if RUBY_DEBUG
+    rb_yjit_collect_binding_alloc();
+#endif
     return obj;
 }
 
@@ -614,6 +618,10 @@ bind_local_variable_set(VALUE bindval, VALUE sym, VALUE val)
 	ptr = rb_binding_add_dynavars(bindval, bind, 1, &lid);
 	env = VM_ENV_ENVVAL_PTR(vm_block_ep(&bind->block));
     }
+
+#if RUBY_DEBUG
+    rb_yjit_collect_binding_set();
+#endif
 
     RB_OBJ_WRITE(env, ptr, val);
 

--- a/yjit.h
+++ b/yjit.h
@@ -51,6 +51,8 @@ void rb_yjit_invalidate_all_method_lookup_assumptions(void);
 void rb_yjit_method_lookup_change(VALUE klass, ID mid);
 void rb_yjit_cme_invalidate(VALUE cme);
 void rb_yjit_collect_vm_usage_insn(int insn);
+void rb_yjit_collect_binding_alloc(void);
+void rb_yjit_collect_binding_set(void);
 void rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec);
 void rb_yjit_init(struct rb_yjit_options *options);
 void rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop);

--- a/yjit.rb
+++ b/yjit.rb
@@ -60,7 +60,7 @@ module YJIT
 
       $stderr.puts("***YJIT: Printing runtime counters from yjit.rb***")
 
-      $stderr.puts "Number of Bindings Allocated: %d\n" % counters[:binding_allocation_count]
+      $stderr.puts "Number of bindings allocated: %d\n" % counters[:binding_allocation_count]
       $stderr.puts "Number of locals modified through binding: %d\n" % counters[:local_variable_set_count]
 
       print_counters(counters, prefix: 'oswb_', prompt: 'opt_send_without_block exit reasons: ')

--- a/yjit.rb
+++ b/yjit.rb
@@ -60,6 +60,9 @@ module YJIT
 
       $stderr.puts("***YJIT: Printing runtime counters from yjit.rb***")
 
+      $stderr.puts "Number of Bindings Allocated: %d\n" % counters[:binding_allocation_count]
+      $stderr.puts "Number of locals modified through binding: %d\n" % counters[:local_variable_set_count]
+
       print_counters(counters, prefix: 'oswb_', prompt: 'opt_send_without_block exit reasons: ')
       print_counters(counters, prefix: 'leave_', prompt: 'leave exit reasons: ')
       print_counters(counters, prefix: 'getivar_', prompt: 'getinstancevariable exit reasons:')

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -726,6 +726,18 @@ rb_yjit_collect_vm_usage_insn(int insn)
     vm_insns_count++;
 }
 
+void
+rb_yjit_collect_binding_alloc(void)
+{
+    yjit_runtime_counters.binding_allocations++;
+}
+
+void
+rb_yjit_collect_binding_set(void)
+{
+    yjit_runtime_counters.binding_set++;
+}
+
 const VALUE *
 rb_yjit_count_side_exit_op(const VALUE *exit_pc)
 {

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -58,6 +58,9 @@ YJIT_DECLARE_COUNTERS(
     oaref_argc_not_one,
     oaref_arg_not_fixnum,
 
+    binding_allocations,
+    binding_set,
+
     // Member with known name for iterating over counters
     last_member
 )


### PR DESCRIPTION
This commit collects statistics about how many binding objects are
allocated as well as the number of local variables set on bindings.
Statistics are output along with other YJIT stats.  Here is an example
of the output:

```
***YJIT: Printing runtime counters from yjit.rb***
Number of Bindings Allocated: 195
Number of Local Variable Set: 0
opt_send_without_block exit reasons:
          ivar_get_method    7515891 (40.4%)
       se_cc_klass_differ    3081330 (16.6%)
       iseq_argc_mismatch    1564578 ( 8.4%)
     se_receiver_not_heap    1557663 ( 8.4%)
                 ic_empty    1407064 ( 7.6%)
         optimized_method     995823 ( 5.4%)
          iseq_not_simple     819413 ( 4.4%)
             alias_method     706972 ( 3.8%)
                  bmethod     685253 ( 3.7%)
      callsite_not_simple     225983 ( 1.2%)
                 kw_splat      25999 ( 0.1%)
          ivar_set_method        902 ( 0.0%)
       cfunc_toomany_args        394 ( 0.0%)
           refined_method         42 ( 0.0%)
    cfunc_ruby_array_varg         29 ( 0.0%)
              invalid_cme          4 ( 0.0%)
leave exit reasons:
    se_finish_frame    4067107 (100.0%)
       se_interrupt         24 ( 0.0%)
getinstancevariable exit reasons:
               undef     121177 (100.0%)
    idx_out_of_range          5 ( 0.0%)
opt_aref exit reasons:
    (all relevant counters are zero)
compiled_iseq_count:         3944
main_block_code_size:     1.1 MiB
side_block_code_size:     0.6 MiB
vm_insns_count:        1137268516
yjit_exec_insns_count:  414015644
ratio_in_yjit:              26.7%
avg_len_in_yjit:              7.5
total_exit_count:        55491789
most frequent exit op:
    opt_send_without_block:   18587628 (33.5%)
        opt_getinlinecache:   11075822 (20.0%)
                      send:    4949300 (8.9%)
                     leave:    4067131 (7.3%)
                   defined:    3975196 (7.2%)
       setinstancevariable:    3567315 (6.4%)
               invokesuper:    2982163 (5.4%)
        getblockparamproxy:    2168852 (3.9%)
                 opt_nil_p:    2104524 (3.8%)
                  opt_aref:    2013858 (3.6%)
```

Running RailsBench allocates 195 binding objects but doesn't set any
local variables.
