### PR TITLE
Track interpreter return as an exit reason for leave instr

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1873,6 +1873,7 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
     // Fall back to the interpreter
     cb_write_label(cb, FALLBACK_LABEL);
     cb_link_labels(cb);
+    GEN_COUNTER_INC(cb, leave_interp_return);
     cb_write_post_call_bytes(cb);
 
     return YJIT_END_BLOCK;

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -46,6 +46,7 @@ YJIT_DECLARE_COUNTERS(
 
     leave_se_finish_frame,
     leave_se_interrupt,
+    leave_interp_return,
 
     getivar_se_self_not_heap,
     getivar_idx_out_of_range,


### PR DESCRIPTION
Added this to investigate #81 