### PR TITLE
YJIT: adjust branch shape properly when target already exists

### DIFF
--- a/yjit_core.c
+++ b/yjit_core.c
@@ -475,7 +475,7 @@ branch_stub_hit(const uint32_t branch_idx, const uint32_t target_idx, rb_executi
     dst_addr = cb_get_ptr(cb, p_block->start_pos);
     branch->dst_addrs[target_idx] = dst_addr;
 
-    // Adjust brach shape base on block placement relative to the branch
+    // Adjust brach shape based on block placement relative to the branch
     if (branch->end_pos == p_block->start_pos) {
         branch->shape = (branch_shape_t)target_idx;
     }

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -156,7 +156,7 @@ typedef void (*branchgen_fn)(codeblock_t* cb, uint8_t* target0, uint8_t* target1
 Store info about an outgoing branch in a code segment
 Note: care must be taken to minimize the size of branch_t objects
 */
-typedef struct BranchEntry
+typedef struct yjit_branch_entry
 {
     // Positions where the generated code starts and ends
     uint32_t start_pos;


### PR DESCRIPTION
The old code decides branch->shape based on the write position of the
native code block, which is unsound in case the block already exists
and no new code is written to the write position.

Make this decision with the start address of the target block instead.
Also handle when the branch becomes smaller after patching.