### PR TITLE
YJIT: make ratio_in_yjit more accurate

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -318,9 +318,9 @@ yjit_gen_block(ctx_t* ctx, block_t* block, rb_execution_context_t* ec)
         //fprintf(stderr, "compiling %d: %s\n", insn_idx, insn_name(opcode));
         //print_str(cb, insn_name(opcode));
 
-        // Count bytecode instructions that execute in generated code
-        // FIXME: when generation function returns false, we shouldn't increment
-        //        this counter.
+        // :count-placement:
+        // Count bytecode instructions that execute in generated code.
+        // Note that the increment happens even when the output takes side exit.
         GEN_COUNTER_INC(cb, exec_instruction);
 
         // Call the code generation function

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -783,7 +783,7 @@ print_insn_count_buffer(const struct insn_count *buffer, int how_many, int left_
     int64_t retired_in_yjit = yjit_runtime_counters.exec_instruction - total_exit_count;
 
     // Average length of instruction sequences executed by YJIT
-    double avg_len_in_yjit = (double)yjit_runtime_counters.exec_instruction / total_exit_count;
+    double avg_len_in_yjit = (double)retired_in_yjit / total_exit_count;
 
     // Proportion of instructions that retire in YJIT
     double total_insns_count = retired_in_yjit + vm_insns_count;

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -779,9 +779,17 @@ print_insn_count_buffer(const struct insn_count *buffer, int how_many, int left_
         total_exit_count += buffer[i].count;
     }
 
+    // Number of instructions that finish executing in YJIT. See :count-placement:.
+    int64_t retired_in_yjit = yjit_runtime_counters.exec_instruction - total_exit_count;
+
     // Average length of instruction sequences executed by YJIT
     double avg_len_in_yjit = (double)yjit_runtime_counters.exec_instruction / total_exit_count;
 
+    // Proportion of instructions that retire in YJIT
+    double total_insns_count = retired_in_yjit + vm_insns_count;
+    double ratio = retired_in_yjit / total_insns_count;
+
+    fprintf(stderr, "ratio_in_yjit:         %9.1f%%\n", ratio * 100);
     fprintf(stderr, "avg_len_in_yjit:       %10.1f\n", avg_len_in_yjit);
     fprintf(stderr, "total_exit_count:      %10ld\n", total_exit_count);
     fprintf(stderr, "most frequent exit op:\n");
@@ -805,15 +813,11 @@ print_yjit_stats(void)
 
     const struct insn_count *sorted_exit_ops = sort_insn_count_array(exit_op_count);
 
-    double total_insns_count = vm_insns_count + yjit_runtime_counters.exec_instruction;
-    double ratio = yjit_runtime_counters.exec_instruction / total_insns_count;
-
     fprintf(stderr, "compiled_iseq_count:   %10" PRId64 "\n", rb_compiled_iseq_count);
     fprintf(stderr, "inline_code_size:      %10d\n", cb->write_pos);
     fprintf(stderr, "outlined_code_size:    %10d\n", ocb->write_pos);
     fprintf(stderr, "vm_insns_count:        %10" PRId64 "\n", vm_insns_count);
     fprintf(stderr, "yjit_exec_insns_count: %10" PRId64 "\n", yjit_runtime_counters.exec_instruction);
-    fprintf(stderr, "ratio_in_yjit:         %9.1f%%\n", ratio * 100);
     print_insn_count_buffer(sorted_exit_ops, 10, 4);
 }
 #endif // if RUBY_DEBUG


### PR DESCRIPTION
Don't count instructions that take exit to the interpreter.