### PR TITLE
YJIT: use a context-free landing pad to optimize `leave`

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2019,9 +2019,6 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
     // Load the return value
     mov(cb, REG0, ctx_stack_pop(ctx, 1));
 
-    // Load the JIT return address
-    mov(cb, REG1, member_opnd(REG_CFP, rb_control_frame_t, jit_return));
-
     // Pop the current frame (ec->cfp++)
     // Note: the return PC is already in the previous CFP
     add(cb, REG_CFP, imm_opnd(sizeof(rb_control_frame_t)));
@@ -2033,8 +2030,9 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
     mov(cb, REG_SP, member_opnd(REG_CFP, rb_control_frame_t, sp));
     mov(cb, mem_opnd(64, REG_SP, -SIZEOF_VALUE), REG0);
 
-    // Jump to the JIT return address
-    jmp_rm(cb, REG1);
+    // Jump to the JIT return address in the frame that was popped
+    const int32_t offset_to_jit_return = -((int32_t)sizeof(rb_control_frame_t)) + (int32_t)offsetof(rb_control_frame_t, jit_return);
+    jmp_rm(cb, mem_opnd(64, REG_CFP, offset_to_jit_return));
 
     return YJIT_END_BLOCK;
 }

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -26,6 +26,9 @@ codeblock_t* cb = NULL;
 static codeblock_t outline_block;
 codeblock_t* ocb = NULL;
 
+// Code for exiting back to the interpreter
+static void *interp_exit;
+
 // Print the current source location for debugging purposes
 RBIMPL_ATTR_MAYBE_UNUSED()
 static void
@@ -136,7 +139,7 @@ yjit_load_regs(codeblock_t* cb)
 static uint8_t *
 yjit_gen_exit(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 {
-    uint8_t *code_ptr = cb_get_ptr(ocb, ocb->write_pos);
+    uint8_t *code_ptr = cb_get_ptr(cb, cb->write_pos);
 
     VALUE *exit_pc = jit->pc;
 
@@ -179,6 +182,26 @@ yjit_gen_exit(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 #endif
 
     cb_write_post_call_bytes(cb);
+
+    return code_ptr;
+}
+
+// Generate an interpreter to REG_CFP->pc.
+static uint8_t *
+yjit_gen_context_free_exit(codeblock_t *cb)
+{
+    uint8_t *code_ptr = cb_get_ptr(cb, cb->write_pos);
+
+    // Update the CFP on the EC
+    mov(cb, member_opnd(REG_EC, rb_execution_context_t, cfp), REG_CFP);
+
+    // Put PC into the return register, which the post call bytes dispatches to
+    mov(cb, RAX, member_opnd(REG_CFP, rb_control_frame_t, pc));
+
+    cb_write_post_call_bytes(cb);
+
+    // Note, not incrementing stats here since this exit is the natural end to
+    // executing output code.
 
     return code_ptr;
 }
@@ -250,7 +273,7 @@ yjit_comment_array_t yjit_code_comments;
 Compile an interpreter entry block to be inserted into an iseq
 Returns `NULL` if compilation fails.
 */
-uint8_t*
+uint8_t *
 yjit_entry_prologue(void)
 {
     RUBY_ASSERT(cb != NULL);
@@ -269,6 +292,11 @@ yjit_entry_prologue(void)
 
     // Load the current SP from the CFP into REG_SP
     mov(cb, REG_SP, member_opnd(REG_CFP, rb_control_frame_t, sp));
+
+    // Setup cfp->jit_return
+    // TODO: this could use a IP relative LEA instead of an 8 byte immediate
+    mov(cb, REG0, const_ptr_opnd(interp_exit));
+    mov(cb, member_opnd(REG_CFP, rb_control_frame_t, jit_return), REG0);
 
     return code_ptr;
 }
@@ -2005,20 +2033,8 @@ gen_leave(jitstate_t* jit, ctx_t* ctx)
     mov(cb, REG_SP, member_opnd(REG_CFP, rb_control_frame_t, sp));
     mov(cb, mem_opnd(64, REG_SP, -SIZEOF_VALUE), REG0);
 
-    // If the return address is NULL, fall back to the interpreter
-    ADD_COMMENT(cb, "check for jit return");
-    int FALLBACK_LABEL = cb_new_label(cb, "FALLBACK");
-    test(cb, REG1, REG1);
-    jz_label(cb, FALLBACK_LABEL);
-
     // Jump to the JIT return address
     jmp_rm(cb, REG1);
-
-    // Fall back to the interpreter
-    cb_write_label(cb, FALLBACK_LABEL);
-    cb_link_labels(cb);
-    GEN_COUNTER_INC(cb, leave_interp_return);
-    cb_write_post_call_bytes(cb);
 
     return YJIT_END_BLOCK;
 }
@@ -2080,11 +2096,16 @@ yjit_init_codegen(void)
 {
     // Initialize the code blocks
     uint32_t mem_size = 128 * 1024 * 1024;
-    uint8_t* mem_block = alloc_exec_mem(mem_size);
+    uint8_t *mem_block = alloc_exec_mem(mem_size);
+
     cb = &block;
     cb_init(cb, mem_block, mem_size/2);
+
     ocb = &outline_block;
     cb_init(ocb, mem_block + mem_size/2, mem_size/2);
+
+    // Generate interp_exit
+    interp_exit = yjit_gen_context_free_exit(cb);
 
     // Map YARV opcodes to the corresponding codegen functions
     yjit_reg_op(BIN(dup), gen_dup);

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -294,7 +294,7 @@ yjit_entry_prologue(void)
     mov(cb, REG_SP, member_opnd(REG_CFP, rb_control_frame_t, sp));
 
     // Setup cfp->jit_return
-    // TODO: this could use a IP relative LEA instead of an 8 byte immediate
+    // TODO: this could use an IP relative LEA instead of an 8 byte immediate
     mov(cb, REG0, const_ptr_opnd(interp_exit));
     mov(cb, member_opnd(REG_CFP, rb_control_frame_t, jit_return), REG0);
 


### PR DESCRIPTION
This allows gen_leave to always do an indirect jump to `cfp->jit_return`.