### PR TITLE
Instrument GVL acquire and release with dtrace

### DIFF
--- a/probes.d
+++ b/probes.d
@@ -225,6 +225,34 @@ provider ruby {
      * `lineno` the line number where the cache is _being cleared_ (an int)
   */
   probe method__cache__clear(const char *class, const char *filename, int lineno);
+
+  /*
+     ruby:::vm-gvl-acquire-begin(waiting);
+
+     This probe is fired when a thread attempts to acquire the GVL.
+
+      * `waiting` the number of threads waiting for the GVL (long)
+  */
+  probe vm__gvl__acquire__begin(long waiting);
+
+  /*
+     ruby:::vm-gvl-acquire-end(waiting);
+
+     This probe is fired when a thread successfully acquires the GVL.
+
+      * `waiting` the number of threads waiting for the GVL (long)
+  */
+  probe vm__gvl__acquire__end(long waiting);
+
+  /*
+     ruby:::vm-gvl-release(waiting);
+
+     This probe is fired when a thread releases the GVL.
+
+      * `waiting` the number of threads waiting for the GVL (long)
+  */
+  probe vm__gvl__release(long waiting);
+
 };
 
 #pragma D attributes Stable/Evolving/Common provider ruby provider

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -62,6 +62,7 @@ typedef struct rb_global_vm_lock_struct {
      *   timer.
      */
     struct list_head waitq; /* <=> native_thread_data_t.node.ubf */
+    volatile unsigned long waiting;
     const struct rb_thread_struct *timer;
     int timer_err;
 


### PR DESCRIPTION
This is a slightly modified version of the dtrace patch for instrumenting
gvl acquire and release, originally authored by Balázs Kutil:

https://balazs.kutilovi.cz/posts/dtracing-the-ruby-gvl/

The only modifications are:

- The macro for enabling the dtrace probe additionally adds the use of the
UNLIKELY macro around the enabled check, for compiler optimization, as per
existing dtrace probe idiom within the ruby codebase
- Two hooks are added for when the GVL is acquired:
  - gvl-acquire-begin, when a thread begins waiting for the GVL
  - gvl-acquire-end, when a thread successfully acquires the GVL

The existing probe for when the GVL was released is left untouched