### PR TITLE
Build: Always run Cargo on GNU make

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -82,17 +82,6 @@ ENC_MK        = enc.mk
 MAKE_ENC      = -f $(ENC_MK) V="$(V)" UNICODE_HDR_DIR="$(UNICODE_HDR_DIR)" \
 		RUBY="$(MINIRUBY)" MINIRUBY="$(MINIRUBY)" $(mflags)
 
-# It's a bit annoying to maintain this list, but seems to be necessary
-# to support different Make implementations?
-# Possible alternative: make libyjit.a rule POHNY and rely on cargo to
-# figure out what's out of date. It seems fast when nothing changes.
-RUST_SOURCE = $(srcdir)/yjit/Cargo.lock $(srcdir)/yjit/Cargo.toml \
-	$(srcdir)/yjit/src/codegen.rs \
-	$(srcdir)/yjit/src/core.rs \
-	$(srcdir)/yjit/src/cruby.rs \
-	$(srcdir)/yjit/src/lib.rs \
-	$(empty)
-
 COMMONOBJS    = array.$(OBJEXT) \
 		ast.$(OBJEXT) \
 		bignum.$(OBJEXT) \
@@ -329,9 +318,7 @@ programs: $(PROGRAM) $(WPROGRAM) $(arch)-fake.rb
 
 $(PREP): $(MKFILES)
 
-miniruby$(EXEEXT): config.status $(ALLOBJS) $(ARCHFILE) $(YJIT_LIBS)
-
-$(YJIT_LIBS): $(RUST_SOURCE)
+miniruby$(EXEEXT): config.status $(ALLOBJS) $(ARCHFILE)
 
 objs: $(ALLOBJS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3729,7 +3729,7 @@ AS_CASE(["${YJIT_SUPPORT}"],
     )
     AS_IF([test x"$YJIT_SUPPORT" = "xyes"],
             [rb_rust_target_subdir=release
-             CARGO_BUILD_ARGS=--offline --release],
+             CARGO_BUILD_ARGS='--release'],
             [rb_rust_target_subdir=debug])
     YJIT_LIBS="yjit/target/${rb_rust_target_subdir}/libyjit.a"
 ], [])

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -108,8 +108,9 @@ MJIT_MIN_HEADER = $(MJIT_HEADER_BUILD_DIR)/$(MJIT_MIN_HEADER_NAME)
 MJIT_HEADER_BUILD_DIR = $(EXTOUT)/include/$(arch)
 MJIT_TABS=@MJIT_TABS@
 YJIT_SUPPORT = @YJIT_SUPPORT@
-CARGO_BUILD_ARGS = @CARGO_BUILD_ARGS@
 YJIT_LIBS = @YJIT_LIBS@
+CARGO_TARGET_DIR=@abs_top_builddir@/yjit/target
+CARGO_BUILD_ARGS = @CARGO_BUILD_ARGS@
 LDFLAGS = @STATIC@ $(CFLAGS) @LDFLAGS@
 EXE_LDFLAGS = $(LDFLAGS)
 EXTLDFLAGS = @EXTLDFLAGS@
@@ -647,11 +648,6 @@ $(INSNS): $(srcdir)/insns.def vm_opts.h \
 	$(Q) $(BASERUBY) -Ku $(tooldir)/insns2vm.rb $(INSNS2VMOPT) $@
 
 verconf.h: $(RBCONFIG)
-
-$(YJIT_LIBS):
-	$(ECHO) building $@
-	$(Q) cd $(top_srcdir)/yjit && \
-	CARGO_TARGET_DIR=@abs_top_builddir@/yjit/target $(CARGO) build $(CARGO_BUILD_ARGS)
 
 loadpath: verconf.h
 	@$(CPP) $(XCFLAGS) $(CPPFLAGS) $(srcdir)/loadpath.c | \


### PR DESCRIPTION
Always running cargo(1) makes it so we don't need to list Rust sources.
It's fast when recompilation is unnecessary.

Also contains possible fixes for Windows nmake builds. Make stuff are
moved into defs/gmake.mk for now and we can test BSD make later. Tested
a clean build from macOS and some rebuilds.