### PR TITLE
Don't compile assembler test module on release builds

### DIFF
--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#![cfg(test)]
 
 use crate::asm::x86_64::*;
 use std::fmt;


### PR DESCRIPTION
Previously, the attribute was attaching to the use statement that
followed. See https://doc.rust-lang.org/reference/attributes.html

This syntax is analogous to the `//!` and `///` doc string syntax.
See https://doc.rust-lang.org/reference/comments.html#doc-comments
