### PR TITLE
Use bindgen for RUBY_T_OBJECT and friends

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -1,3 +1,4 @@
+//! See https://docs.rs/bindgen/0.59.2/bindgen/struct.Builder.html
 //! This is the binding generation tool that the YJIT cruby module talks about.
 //! More docs later once we have more experience with this, for now, check
 //! the output to make sure it looks reasonable and allowlist things you want
@@ -33,6 +34,12 @@ fn main() {
 
         .allowlist_function("rb_hash_new")
         .allowlist_function("rb_hash_aset")
+
+        // `ruby_value_type` is a C enum and this stops it from
+        // prefixing all the members with the name of the type
+        .prepend_enum_name(false)
+        .translate_enum_integer_types(true) // so we get fixed width Rust types for members
+        .allowlist_type("ruby_value_type") // really old C extension API
 
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2222,7 +2222,7 @@ fn gen_defined(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: &
 
 fn gen_checktype(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: &mut OutlinedCb) -> CodegenStatus
 {
-    let type_val = jit_get_arg(jit, 0).as_usize();
+    let type_val = jit_get_arg(jit, 0).as_u32();
 
     // Only three types are emitted by compile.c
     if type_val == RUBY_T_STRING || type_val == RUBY_T_ARRAY || type_val == RUBY_T_HASH {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -232,13 +232,13 @@ impl VALUE {
     }
 
     // Read the flags bits from the RBasic object, then return a Ruby type enum (e.g. RUBY_T_ARRAY)
-    pub fn builtin_type(self:VALUE) -> usize {
+    pub fn builtin_type(self:VALUE) -> ruby_value_type {
         assert!(self.special_const_p());
 
         let VALUE(cval) = self;
-        let rbasic_ptr:*const usize = cval as *const usize;
-        let flags_bits:usize = unsafe { *rbasic_ptr };
-        flags_bits & RUBY_T_MASK
+        let rbasic_ptr = cval as *const RBasic;
+        let flags_bits:usize = unsafe { (*rbasic_ptr).flags }.as_usize();
+        (flags_bits & (RUBY_T_MASK as usize)) as ruby_value_type
     }
 
     pub fn as_isize(self:VALUE) -> isize {
@@ -315,40 +315,6 @@ pub const Qtrue: VALUE = VALUE(20);
 pub const Qundef: VALUE = VALUE(52);
 
 pub const RB_SYMBOL_FLAG: usize = 0x0c;
-
-// These are the types used by BUILTIN_TYPE from include/ruby/internal/value_type.h.
-pub const RUBY_T_NONE    :usize = 0x00;
-
-pub const RUBY_T_OBJECT  :usize = 0x01;
-pub const RUBY_T_CLASS   :usize = 0x02;
-pub const RUBY_T_MODULE  :usize = 0x03;
-pub const RUBY_T_FLOAT   :usize = 0x04;
-pub const RUBY_T_STRING  :usize = 0x05;
-pub const RUBY_T_REGEXP  :usize = 0x06;
-pub const RUBY_T_ARRAY   :usize = 0x07;
-pub const RUBY_T_HASH    :usize = 0x08;
-pub const RUBY_T_STRUCT  :usize = 0x09;
-pub const RUBY_T_BIGNUM  :usize = 0x0a;
-pub const RUBY_T_FILE    :usize = 0x0b;
-pub const RUBY_T_DATA    :usize = 0x0c;
-pub const RUBY_T_MATCH   :usize = 0x0d;
-pub const RUBY_T_COMPLEX :usize = 0x0e;
-pub const RUBY_T_RATIONAL:usize = 0x0f;
-
-pub const RUBY_T_NIL     :usize = 0x11;
-pub const RUBY_T_TRUE    :usize = 0x12;
-pub const RUBY_T_FALSE   :usize = 0x13;
-pub const RUBY_T_SYMBOL  :usize = 0x14;
-pub const RUBY_T_FIXNUM  :usize = 0x15;
-pub const RUBY_T_UNDEF   :usize = 0x16;
-
-pub const RUBY_T_IMEMO   :usize = 0x1a;
-pub const RUBY_T_NODE    :usize = 0x1b;
-pub const RUBY_T_ICLASS  :usize = 0x1c;
-pub const RUBY_T_ZOMBIE  :usize = 0x1d;
-pub const RUBY_T_MOVED   :usize = 0x1e;
-
-pub const RUBY_T_MASK    :usize = 0x1f;
 
 pub const RUBY_LONG_MIN:isize = std::os::raw::c_long::MIN as isize;
 pub const RUBY_LONG_MAX:isize = std::os::raw::c_long::MAX as isize;

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -77,6 +77,9 @@
 //! [FFI example]: https://doc.rust-lang.org/nomicon/ffi.html
 //! [GhostCell]: http://plv.mpi-sws.org/rustbelt/ghostcell/
 
+// CRuby types use snake_case. Allow them so we use one name across languages.
+#![allow(non_camel_case_types)]
+
 use std::convert::From;
 use std::os::raw::{c_int, c_uint, c_long};
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -5,6 +5,35 @@ pub struct RBasic {
     pub flags: VALUE,
     pub klass: VALUE,
 }
+pub const RUBY_T_NONE: ruby_value_type = 0;
+pub const RUBY_T_OBJECT: ruby_value_type = 1;
+pub const RUBY_T_CLASS: ruby_value_type = 2;
+pub const RUBY_T_MODULE: ruby_value_type = 3;
+pub const RUBY_T_FLOAT: ruby_value_type = 4;
+pub const RUBY_T_STRING: ruby_value_type = 5;
+pub const RUBY_T_REGEXP: ruby_value_type = 6;
+pub const RUBY_T_ARRAY: ruby_value_type = 7;
+pub const RUBY_T_HASH: ruby_value_type = 8;
+pub const RUBY_T_STRUCT: ruby_value_type = 9;
+pub const RUBY_T_BIGNUM: ruby_value_type = 10;
+pub const RUBY_T_FILE: ruby_value_type = 11;
+pub const RUBY_T_DATA: ruby_value_type = 12;
+pub const RUBY_T_MATCH: ruby_value_type = 13;
+pub const RUBY_T_COMPLEX: ruby_value_type = 14;
+pub const RUBY_T_RATIONAL: ruby_value_type = 15;
+pub const RUBY_T_NIL: ruby_value_type = 17;
+pub const RUBY_T_TRUE: ruby_value_type = 18;
+pub const RUBY_T_FALSE: ruby_value_type = 19;
+pub const RUBY_T_SYMBOL: ruby_value_type = 20;
+pub const RUBY_T_FIXNUM: ruby_value_type = 21;
+pub const RUBY_T_UNDEF: ruby_value_type = 22;
+pub const RUBY_T_IMEMO: ruby_value_type = 26;
+pub const RUBY_T_NODE: ruby_value_type = 27;
+pub const RUBY_T_ICLASS: ruby_value_type = 28;
+pub const RUBY_T_ZOMBIE: ruby_value_type = 29;
+pub const RUBY_T_MOVED: ruby_value_type = 30;
+pub const RUBY_T_MASK: ruby_value_type = 31;
+pub type ruby_value_type = u32;
 extern "C" {
     pub fn rb_hash_new() -> VALUE;
 }


### PR DESCRIPTION
I couldn't figure out how to get rust-bindgen to allow me to pick the
type for the constants, so now these `RUBY_T_*` constants are now u32
as opposed to usize. Refactoring wasn't too painful so I think this
is okay.

I might want to add some utilities so casting between fixed size ints to
usize/isize is easier than `try_into().unwrap()`. Check that usize is
big enough statically and implement `Into`, maybe. This way if we port
to 32 bit platforms far in the future we get build errors as opposed to
dynamic checks or silent truncations.
