### PR TITLE
Get make yjit-bindgen to work on clean checkout. Fix miniruby build

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -374,12 +374,14 @@ $(YJIT_LIBS): yjit-static-lib
 # TODO: might need to move for BSD Make support
 miniruby$(EXEEXT): $(YJIT_LIBS)
 
-# generate rust bindings. see source for details
+# Generate rust bindings. See source for details. Needs `./configure --enable-yjit`
+ifneq ($(strip $(CARGO)),) # if configure found Cargo
 .PHONY: yjit-bindgen
-yjit-bindgen:
+yjit-bindgen: miniruby$(EXEEXT)
 	cd '$(top_srcdir)'
 	# See make recipe for `.c.i`
 	$(CARGO) run --manifest-path '$(top_srcdir)/yjit/bindgen/Cargo.toml' -- $(CFLAGS) $(XCFLAGS) $(CPPFLAGS)
+endif
 
 # Query on the generated rdoc
 #

--- a/yjit.h
+++ b/yjit.h
@@ -14,6 +14,9 @@
 #ifndef YJIT_STATS
 # define YJIT_STATS RUBY_DEBUG
 #endif
+// For porting, disable YJIT_STATS. C code mostly for textual reference now.
+#undef YJIT_STATS
+#define YJIT_STATS 0
 
 // We generate x86 assembly
 #if (defined(__x86_64__) && !defined(_WIN32)) || (defined(_WIN32) && defined(_M_AMD64)) // x64 platforms without mingw/msys

--- a/yjit/README.md
+++ b/yjit/README.md
@@ -29,8 +29,7 @@ To generate C bindings for the YJIT Rust code, run:
 
 ```sh
 CC=clang ./configure --enable-yjit=dev
-make -j miniruby
-make yjit-bindgen
+make -j yjit-bindgen
 ```
 
 This will generate/update `yjit/src/cruby_bindings.inc.rs`. Avoid manually editing this file

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -672,7 +672,8 @@ static VALUE
 comments_for(rb_execution_context_t *ec, VALUE self, VALUE start_address, VALUE end_address)
 {
     VALUE comment_array = rb_ary_new();
-#if RUBY_DEBUG
+// disabled to help porting.
+#if 0
     uint8_t *start = (void *)NUM2ULL(start_address);
     uint8_t *end = (void *)NUM2ULL(end_address);
 


### PR DESCRIPTION
By adding miniruby as a prerequisite, `make yjit-bindgen` works right
after a fresh `configure` run. This allows simplifying the instruction
for running the command a bit in yjit/README.md.

Tested with `make distclean` and a fresh `configure` run.

Lots of warnings when building miniruby we will fix as we prune more C
YJIT.
