### PR TITLE
Port most of gen_send_general

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -251,53 +251,96 @@ rb_iseq_opcode_at_pc(const rb_iseq_t *iseq, const VALUE *pc)
 
 // Query the instruction length in bytes for YARV opcode insn
 int
-rb_yarv_insn_len(VALUE insn)
+rb_insn_len(VALUE insn)
 {
     return insn_len(insn);
 }
 
 unsigned int
-get_iseq_body_local_table_size(rb_iseq_t* iseq) {
+rb_vm_ci_argc(const struct rb_callinfo *ci) {
+    return vm_ci_argc(ci);
+}
+
+ID
+rb_vm_ci_mid(const struct rb_callinfo *ci) {
+    return vm_ci_mid(ci);
+}
+
+unsigned int
+rb_vm_ci_flag(const struct rb_callinfo *ci) {
+    return vm_ci_flag(ci);
+}
+
+rb_method_visibility_t
+rb_METHOD_ENTRY_VISI(rb_callable_method_entry_t *me) {
+    return METHOD_ENTRY_VISI(me);
+}
+
+VALUE
+rb_get_cme_defined_class(rb_callable_method_entry_t* cme) {
+    return cme->defined_class;
+}
+
+rb_method_type_t
+rb_get_cme_def_type(rb_callable_method_entry_t* cme)
+{
+    return cme->def->type;
+}
+
+ID
+rb_get_cme_def_body_attr_id(rb_callable_method_entry_t* cme)
+{
+    return cme->def->body.attr.id;
+}
+
+enum method_optimized_type
+rb_get_cme_def_body_optimized_type(rb_callable_method_entry_t* cme)
+{
+    return cme->def->body.optimized.type;
+}
+
+unsigned int
+rb_get_iseq_body_local_table_size(rb_iseq_t* iseq) {
     return iseq->body->local_table_size;
 }
 
 VALUE*
-get_iseq_body_iseq_encoded(rb_iseq_t* iseq) {
+rb_get_iseq_body_iseq_encoded(rb_iseq_t* iseq) {
     return iseq->body->iseq_encoded;
 }
 
 int
-get_iseq_flags_has_opt(rb_iseq_t* iseq) {
+rb_get_iseq_flags_has_opt(rb_iseq_t* iseq) {
     return iseq->body->param.flags.has_opt;
 }
 
 int
-get_iseq_body_param_num(rb_iseq_t* iseq) {
+rb_get_iseq_body_param_num(rb_iseq_t* iseq) {
     return iseq->body->param.keyword->num;
 }
 
 struct rb_control_frame_struct *
-ec_get_cfp(rb_execution_context_t *ec) {
+rb_get_ec_cfp(rb_execution_context_t *ec) {
     return ec->cfp;
 }
 
 VALUE*
-cfp_get_pc(struct rb_control_frame_struct *cfp) {
+rb_get_cfp_pc(struct rb_control_frame_struct *cfp) {
     return cfp->pc;
 }
 
 VALUE*
-cfp_get_sp(struct rb_control_frame_struct *cfp) {
+rb_get_cfp_sp(struct rb_control_frame_struct *cfp) {
     return cfp->sp;
 }
 
 VALUE
-cfp_get_self(struct rb_control_frame_struct *cfp) {
+rb_get_cfp_self(struct rb_control_frame_struct *cfp) {
     return cfp->self;
 }
 
 VALUE*
-cfp_get_ep(struct rb_control_frame_struct *cfp) {
+rb_get_cfp_ep(struct rb_control_frame_struct *cfp) {
     return cfp->ep;
 }
 
@@ -317,7 +360,7 @@ rb_yarv_str_eql_internal(VALUE str1, VALUE str2)
 
 // The FL_TEST() macro
 VALUE
-rb_yarv_FL_TEST(VALUE obj, VALUE flags)
+rb_FL_TEST(VALUE obj, VALUE flags)
 {
     return RB_FL_TEST(obj, flags);
 }
@@ -334,6 +377,11 @@ bool
 rb_RB_TYPE_P(VALUE obj, enum ruby_value_type t)
 {
     return RB_TYPE_P(obj, t);
+}
+
+const struct rb_callinfo*
+rb_get_call_data_ci(struct rb_call_data* cd) {
+    return cd->ci;
 }
 
 // The number of bytes counting from the beginning of the inline code block

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -19,6 +19,8 @@ fn main() {
         .clang_args(filtered_clang_args)
         .header("internal.h")
         .header("include/ruby/ruby.h")
+        .header("vm_core.h")  // includes method.h
+        .header("vm_callinfo.h")
 
         // Some C functions that were expressly for Rust YJIT in this
         // file. TODO: Might want to move them later.
@@ -32,6 +34,8 @@ fn main() {
 
         // This struct is public to Ruby C extensions
         .allowlist_type("RBasic")
+
+        .allowlist_function("rb_obj_is_kind_of")
 
         .allowlist_function("rb_hash_new")
         .allowlist_function("rb_hash_new_with_size")
@@ -51,6 +55,9 @@ fn main() {
         .allowlist_var("rb_cFloat")
         .allowlist_var("rb_cString")
 
+        .allowlist_type("VM_CALL.*") // This doesn't work, possibly due to the odd structure of the #defines
+        .allowlist_type("vm_call_flag_bits") // So instead we include the other enum and do the bit-shift ourselves
+
         .allowlist_function("rb_range_new")
 
         .allowlist_function("rb_ec_str_resurrect")
@@ -63,6 +70,11 @@ fn main() {
         .allowlist_type("ruby_value_type") // really old C extension API
 
         .allowlist_type("ruby_method_ids")
+
+        .allowlist_function("rb_callable_method_entry")
+        .allowlist_type("rb_method_visibility_t")
+        .allowlist_type("rb_method_type_t")
+        .allowlist_type("method_optimized_type")
 
         // Constants defined in vm_core.h
         .allowlist_type("ruby_basic_operators")
@@ -100,6 +112,12 @@ fn main() {
         .allowlist_type("IVC") // pointer to cache entry
         .opaque_type("iseq_inline_iv_cache_entry")
         .blocklist_type("iseq_inline_iv_cache_entry")
+
+        .blocklist_type("rb_call_data")
+        .opaque_type("rb_call_data")
+
+        .blocklist_type("rb_callable_method_entry_t")
+        .opaque_type("rb_callable_method_entry_t")
 
         // Finish the builder and generate the bindings.
         .generate()

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -109,31 +109,61 @@ extern "C" {
     //pub fn ID2SYM(id: VALUE) -> VALUE;
     //pub fn LL2NUM((long long)ocb->write_pos) -> VALUE;
 
-    #[link_name = "rb_yarv_insn_len"]
+    #[link_name = "rb_insn_len"]
     pub fn raw_insn_len(v: VALUE) -> c_int;
 
     #[link_name = "rb_yarv_class_of"]
     pub fn CLASS_OF(v:VALUE) -> VALUE;
 
-    pub fn ec_get_cfp(ec: EcPtr) -> CfpPtr;
+    #[link_name = "rb_get_ec_cfp"]
+    pub fn get_ec_cfp(ec: EcPtr) -> CfpPtr;
 
-    pub fn cfp_get_pc(cfp: CfpPtr) -> *mut VALUE;
-    pub fn cfp_get_sp(cfp: CfpPtr) -> *mut VALUE;
-    pub fn cfp_get_self(cfp: CfpPtr) -> VALUE;
-    pub fn cfp_get_ep(cfp: CfpPtr) -> *mut VALUE;
+    #[link_name = "rb_get_cfp_pc"]
+    pub fn get_cfp_pc(cfp: CfpPtr) -> *mut VALUE;
+
+    #[link_name = "rb_get_cfp_sp"]
+    pub fn get_cfp_sp(cfp: CfpPtr) -> *mut VALUE;
+
+    #[link_name = "rb_get_cfp_self"]
+    pub fn get_cfp_self(cfp: CfpPtr) -> VALUE;
+
+    #[link_name = "rb_get_cfp_ep"]
+    pub fn get_cfp_ep(cfp: CfpPtr) -> *mut VALUE;
+
+    #[link_name = "rb_get_cme_defined_class"]
+    pub fn get_cme_defined_class(cme: * const rb_callable_method_entry_t) -> VALUE;
+
+    #[link_name = "rb_get_cme_def_type"]
+    pub fn get_cme_def_type(cme: * const rb_callable_method_entry_t) -> rb_method_type_t;
+
+    #[link_name = "rb_get_cme_def_body_attr_id"]
+    pub fn get_cme_def_body_attr_id(cme: * const rb_callable_method_entry_t) -> ID;
+
+    #[link_name = "rb_get_cme_def_body_optimized_type"]
+    pub fn get_cme_def_body_optimized_type(cme: * const rb_callable_method_entry_t) -> method_optimized_type;
 
     #[link_name = "rb_iseq_encoded_size"]
     pub fn get_iseq_encoded_size(iseq: IseqPtr) -> c_uint;
 
+    #[link_name = "rb_get_iseq_body_iseq_encoded"]
     pub fn get_iseq_body_iseq_encoded(iseq: IseqPtr) -> *mut VALUE;
+
+    #[link_name = "rb_get_iseq_flags_has_opt"]
     pub fn get_iseq_flags_has_opt(iseq: IseqPtr) -> c_int;
+
+    #[link_name = "rb_get_iseq_body_local_table_size"]
     pub fn get_iseq_body_local_table_size(iseq: IseqPtr) -> c_uint;
+
+    #[link_name = "rb_get_iseq_body_param_num"]
     pub fn get_iseq_body_param_num(iseq: IseqPtr) -> c_int;
+
+    #[link_name = "rb_get_call_data_ci"]
+    pub fn get_call_data_ci(cd: * const rb_call_data) -> *const rb_callinfo;
 
     #[link_name = "rb_yarv_str_eql_internal"]
     pub fn rb_str_eql_internal(str1: VALUE, str2: VALUE) -> VALUE;
 
-    #[link_name = "rb_yarv_FL_TEST"]
+    #[link_name = "rb_FL_TEST"]
     pub fn FL_TEST(obj: VALUE, flags: VALUE) -> VALUE;
 
     #[link_name = "rb_FL_TEST_RAW"]
@@ -149,6 +179,19 @@ extern "C" {
     pub fn rb_vm_defined(ec: EcPtr, reg_cfp: CfpPtr, op_type: rb_num_t, obj: VALUE, v: VALUE) -> bool;
     pub fn rb_vm_set_ivar_idx(obj: VALUE, idx: u32, val: VALUE) -> VALUE;
     pub fn rb_vm_setinstancevariable(iseq: IseqPtr, obj: VALUE, id: ID, val: VALUE, ic: IVC);
+    pub fn rb_aliased_callable_method_entry(me: *const rb_callable_method_entry_t) -> *const rb_callable_method_entry_t;
+
+    #[link_name = "rb_vm_ci_argc"]
+    pub fn vm_ci_argc(ci: * const rb_callinfo) -> c_int;
+
+    #[link_name = "rb_vm_ci_mid"]
+    pub fn vm_ci_mid(ci: * const rb_callinfo) -> ID;
+
+    #[link_name = "rb_vm_ci_flag"]
+    pub fn vm_ci_flag(ci: * const rb_callinfo) -> c_uint;
+
+    #[link_name = "rb_METHOD_ENTRY_VISI"]
+    pub fn METHOD_ENTRY_VISI(me: * const rb_callable_method_entry_t) -> rb_method_visibility_t;
 }
 
 pub fn insn_len(opcode:usize) -> u32
@@ -175,7 +218,6 @@ pub fn get_ruby_vm_frozen_core() -> VALUE
     // Until we can link with CRuby, return a fake constant.
     VALUE(0xACE_DECADE)
 }
-
 
 /// Opaque iseq type for opaque iseq pointers.
 /// See: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
@@ -210,6 +252,30 @@ pub struct iseq_inline_iv_cache_entry {
     _data: [u8; 0],
     _marker:
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+/// Opaque call-data type
+#[repr(C)]
+pub struct rb_call_data {
+    _data: [u8; 0],
+    _marker:
+    core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+/// Opaque call-info type
+#[repr(C)]
+pub struct rb_callinfo {
+    _data: [u8; 0],
+    _marker:
+    core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+/// Opaque call-info type
+#[repr(C)]
+pub struct rb_callable_method_entry_t {
+    _data: [u8; 0],
+    _marker:
+    core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
 /// Pointer to a control frame pointer (CFP)
@@ -371,6 +437,13 @@ pub const VM_ENV_DATA_INDEX_SPECVAL:isize = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS:isize = 0;
 pub const VM_ENV_DATA_SIZE:usize = 3;
 pub const VM_ENV_FLAG_WB_REQUIRED:usize = 0x008;
+
+// From vm_callinfo.h
+pub const VM_CALL_ARGS_SPLAT:u32    = 1 << VM_CALL_ARGS_SPLAT_bit;
+pub const VM_CALL_ARGS_BLOCKARG:u32 = 1 << VM_CALL_ARGS_BLOCKARG_bit;
+pub const VM_CALL_FCALL:u32         = 1 << VM_CALL_FCALL_bit;
+pub const VM_CALL_KWARG:u32         = 1 << VM_CALL_KWARG_bit;
+pub const VM_CALL_KW_SPLAT:u32      = 1 << VM_CALL_KW_SPLAT_bit;
 
 pub const SIZEOF_VALUE: usize = 8;
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -89,6 +89,9 @@ extern "C" {
     pub fn rb_hash_bulk_insert(argc: ::std::os::raw::c_long, argv: *const VALUE, hash: VALUE);
 }
 extern "C" {
+    pub fn rb_obj_is_kind_of(obj: VALUE, klass: VALUE) -> VALUE;
+}
+extern "C" {
     pub fn rb_range_new(beg: VALUE, end: VALUE, excl: ::std::os::raw::c_int) -> VALUE;
 }
 extern "C" {
@@ -96,12 +99,6 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_attr_get(obj: VALUE, name: ID) -> VALUE;
-}
-extern "C" {
-    pub fn rb_str_concat_literals(num: size_t, strary: *const VALUE) -> VALUE;
-}
-extern "C" {
-    pub fn rb_ec_str_resurrect(ec: *mut rb_execution_context_struct, str_: VALUE) -> VALUE;
 }
 pub const idDot2: ruby_method_ids = 128;
 pub const idDot3: ruby_method_ids = 129;
@@ -320,6 +317,35 @@ extern "C" {
 extern "C" {
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
 }
+pub const METHOD_VISI_UNDEF: rb_method_visibility_t = 0;
+pub const METHOD_VISI_PUBLIC: rb_method_visibility_t = 1;
+pub const METHOD_VISI_PRIVATE: rb_method_visibility_t = 2;
+pub const METHOD_VISI_PROTECTED: rb_method_visibility_t = 3;
+pub const METHOD_VISI_MASK: rb_method_visibility_t = 3;
+pub type rb_method_visibility_t = u32;
+pub const VM_METHOD_TYPE_ISEQ: rb_method_type_t = 0;
+pub const VM_METHOD_TYPE_CFUNC: rb_method_type_t = 1;
+pub const VM_METHOD_TYPE_ATTRSET: rb_method_type_t = 2;
+pub const VM_METHOD_TYPE_IVAR: rb_method_type_t = 3;
+pub const VM_METHOD_TYPE_BMETHOD: rb_method_type_t = 4;
+pub const VM_METHOD_TYPE_ZSUPER: rb_method_type_t = 5;
+pub const VM_METHOD_TYPE_ALIAS: rb_method_type_t = 6;
+pub const VM_METHOD_TYPE_UNDEF: rb_method_type_t = 7;
+pub const VM_METHOD_TYPE_NOTIMPLEMENTED: rb_method_type_t = 8;
+pub const VM_METHOD_TYPE_OPTIMIZED: rb_method_type_t = 9;
+pub const VM_METHOD_TYPE_MISSING: rb_method_type_t = 10;
+pub const VM_METHOD_TYPE_REFINED: rb_method_type_t = 11;
+pub type rb_method_type_t = u32;
+pub const OPTIMIZED_METHOD_TYPE_SEND: method_optimized_type = 0;
+pub const OPTIMIZED_METHOD_TYPE_CALL: method_optimized_type = 1;
+pub const OPTIMIZED_METHOD_TYPE_BLOCK_CALL: method_optimized_type = 2;
+pub const OPTIMIZED_METHOD_TYPE_STRUCT_AREF: method_optimized_type = 3;
+pub const OPTIMIZED_METHOD_TYPE_STRUCT_ASET: method_optimized_type = 4;
+pub const OPTIMIZED_METHOD_TYPE__MAX: method_optimized_type = 5;
+pub type method_optimized_type = u32;
+extern "C" {
+    pub fn rb_callable_method_entry(klass: VALUE, id: ID) -> *const rb_callable_method_entry_t;
+}
 pub type rb_num_t = ::std::os::raw::c_ulong;
 pub const BOP_PLUS: ruby_basic_operators = 0;
 pub const BOP_MINUS: ruby_basic_operators = 1;
@@ -353,6 +379,27 @@ pub const BOP_OR: ruby_basic_operators = 28;
 pub const BOP_LAST_: ruby_basic_operators = 29;
 pub type ruby_basic_operators = u32;
 pub type IVC = *mut iseq_inline_iv_cache_entry;
+pub const VM_CALL_ARGS_SPLAT_bit: vm_call_flag_bits = 0;
+pub const VM_CALL_ARGS_BLOCKARG_bit: vm_call_flag_bits = 1;
+pub const VM_CALL_FCALL_bit: vm_call_flag_bits = 2;
+pub const VM_CALL_VCALL_bit: vm_call_flag_bits = 3;
+pub const VM_CALL_ARGS_SIMPLE_bit: vm_call_flag_bits = 4;
+pub const VM_CALL_BLOCKISEQ_bit: vm_call_flag_bits = 5;
+pub const VM_CALL_KWARG_bit: vm_call_flag_bits = 6;
+pub const VM_CALL_KW_SPLAT_bit: vm_call_flag_bits = 7;
+pub const VM_CALL_TAILCALL_bit: vm_call_flag_bits = 8;
+pub const VM_CALL_SUPER_bit: vm_call_flag_bits = 9;
+pub const VM_CALL_ZSUPER_bit: vm_call_flag_bits = 10;
+pub const VM_CALL_OPT_SEND_bit: vm_call_flag_bits = 11;
+pub const VM_CALL_KW_SPLAT_MUT_bit: vm_call_flag_bits = 12;
+pub const VM_CALL__END: vm_call_flag_bits = 13;
+pub type vm_call_flag_bits = u32;
+extern "C" {
+    pub fn rb_str_concat_literals(num: size_t, strary: *const VALUE) -> VALUE;
+}
+extern "C" {
+    pub fn rb_ec_str_resurrect(ec: *mut rb_execution_context_struct, str_: VALUE) -> VALUE;
+}
 extern "C" {
     pub fn rb_yjit_mark_writable(mem_block: *mut ::std::os::raw::c_void, mem_size: u32);
 }

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -2,6 +2,8 @@
 //! generated code if and when these assumptions are invalidated.
 
 use crate::core::*;
+use crate::cruby::*;
+use crate::codegen::*;
 
 // Invariants to track:
 // assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
@@ -131,6 +133,7 @@ add_lookup_dependency_i(st_data_t *key, st_data_t *value, st_data_t data, int ex
 
     return ST_CONTINUE;
 }
+*/
 
 // Remember that a block assumes that
 // `rb_callable_method_entry(receiver_klass, cme->called_id) == cme` and that
@@ -139,9 +142,10 @@ add_lookup_dependency_i(st_data_t *key, st_data_t *value, st_data_t data, int ex
 // rb_yjit_cme_invalidate() invalidates the block.
 //
 // @raise NoMemoryError
-static void
-assume_method_lookup_stable(VALUE receiver_klass, const rb_callable_method_entry_t *cme, jitstate_t *jit)
+pub fn assume_method_lookup_stable(receiver_klass:VALUE, cme: *const rb_callable_method_entry_t, jit: &JITState)
 {
+    todo!();
+    /*
     RUBY_ASSERT(cme_validity_dependency);
     RUBY_ASSERT(method_lookup_dependency);
     RUBY_ASSERT(rb_callable_method_entry(receiver_klass, cme->called_id) == cme);
@@ -159,8 +163,8 @@ assume_method_lookup_stable(VALUE receiver_klass, const rb_callable_method_entry
 
     struct lookup_dependency_insertion info = { block, cme->called_id };
     st_update(method_lookup_dependency, (st_data_t)receiver_klass, add_lookup_dependency_i, (st_data_t)&info);
+    */
 }
-*/
 
 
 


### PR DESCRIPTION
~~Right now several enum types are just manually ported to (effectively) an int plus constants. I'd love to get more of it in bindgen, but not having much luck with the bindgen built-in enum facilities. As you can see, I tried those but they don't seem to be creating bindings.~~