### PR TITLE
Use u64 for size_t and cut down on noise in bindgen output

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -12,6 +12,13 @@
 #include "vm_sync.h"
 #include "yjit.h"
 
+// We need size_t to have a known size to simplify code generation and FFI.
+// TODO(alan): check this in configure.ac to fail fast on 32 bit platforms.
+STATIC_ASSERT(64b_size_t, SIZE_MAX == UINT64_MAX);
+// I don't know any C implementation that has uint64_t and puts padding bits
+// into size_t but the standard seems to allow it.
+STATIC_ASSERT(size_t_no_padding_bits, sizeof(size_t) == sizeof(uint64_t));
+
 #ifndef YJIT_CHECK_MODE
 # define YJIT_CHECK_MODE 0
 #endif

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -32,6 +32,12 @@ fn main() {
         // Don't want layout tests as they are platform dependent
         .layout_tests(false)
 
+        // Block for stability since output is different on Darwin and Linux
+        .blocklist_type("size_t")
+
+        // Prune these types since they are system dependant and we don't use them
+        .blocklist_type("__.*")
+
         // This struct is public to Ruby C extensions
         .allowlist_type("RBasic")
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -85,6 +85,10 @@
 use std::convert::From;
 use std::os::raw::{c_int, c_uint, c_long};
 
+// We check that we can do this with the configure script and a couple of
+// static asserts. u64 and not usize to play nice with lowering to x86.
+pub type size_t = u64;
+
 // Textually include output from rust-bindgen as suggested by its user guide.
 include!("cruby_bindings.inc.rs");
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -12,8 +12,6 @@ pub const NIL_REDEFINED_OP_FLAG: u32 = 512;
 pub const TRUE_REDEFINED_OP_FLAG: u32 = 1024;
 pub const FALSE_REDEFINED_OP_FLAG: u32 = 2048;
 pub const PROC_REDEFINED_OP_FLAG: u32 = 4096;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type __uint32_t = ::std::os::raw::c_uint;
 pub type ID = ::std::os::raw::c_ulong;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 extern "C" {


### PR DESCRIPTION
Using a fixed width type has better ergonomic than usize. The static
asserts give build errors when we want to port to 32 bit machines.
The "__.*" type pruning is attempt to keep output consistent between my
Mac and GNU/Linux systems. Let's see how much they diverge as we go.
We can always use CI to bless one particular setup to avoid dealing with
divergence.
