### PR TITLE
Convert rb_builtin_func to use bindgen

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -328,18 +328,6 @@ rb_get_mct_func(rb_method_cfunc_t *mct)
     return (void*)mct->func; // this field is defined as type VALUE (*func)(ANYARGS)
 }
 
-int
-rb_get_builtin_argc(struct rb_builtin_function* bi)
-{
-    return bi->argc;
-}
-
-void*
-rb_get_builtin_func_ptr(struct rb_builtin_function* bi)
-{
-    return bi->func_ptr;
-}
-
 const rb_iseq_t*
 rb_def_iseq_ptr(rb_method_definition_t *def)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -131,7 +131,6 @@ fn main() {
         .allowlist_function("rb_yjit_get_page_size")
         .allowlist_function("rb_leaf_invokebuiltin_iseq_p")
         .allowlist_function("rb_leaf_builtin_function")
-        .blocklist_type("rb_builtin_function")
 
         // Not sure why it's picking these up, but don't.
         .blocklist_type("FILE")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3898,7 +3898,7 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
     let leaf_builtin: Option<*const rb_builtin_function> = if leaf_builtin_raw == (0 as *const rb_builtin_function) { None } else { Some(leaf_builtin_raw) };
     match (block, leaf_builtin) {
         (None, Some(builtin_info)) => {
-            let builtin_argc = unsafe { get_builtin_argc(builtin_info) };
+            let builtin_argc = unsafe { (*builtin_info).argc };
             if builtin_argc + 1 /* for self */ + 1 /* for ec */ <= (C_ARG_REGS.len() as i32) {
                 add_comment(cb, "inlined leaf builtin");
 
@@ -3913,7 +3913,7 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
                     mov(cb, c_arg_reg, stack_opnd);
                 }
                 ctx.stack_pop((builtin_argc + 1).try_into().unwrap());
-                let builtin_func_ptr = unsafe { get_builtin_func_ptr(builtin_info) };
+                let builtin_func_ptr = unsafe { (*builtin_info).func_ptr as *const u8 };
                 call_ptr(cb, REG0, builtin_func_ptr);
 
                 // Push the return value

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -158,12 +158,6 @@ extern "C" {
     #[link_name = "rb_get_mct_func"]
     pub fn get_mct_func(mct: * const rb_method_cfunc_t) -> *const u8;
 
-    #[link_name="rb_get_builtin_argc"]
-    pub fn get_builtin_argc(bi: * const rb_builtin_function) -> c_int;
-
-    #[link_name="rb_get_builtin_func_ptr"]
-    pub fn get_builtin_func_ptr(bi: * const rb_builtin_function) -> *mut u8;
-
     #[link_name = "rb_def_iseq_ptr"]
     pub fn def_iseq_ptr(def: *const rb_method_definition_t) -> IseqPtr;
 
@@ -317,9 +311,9 @@ pub struct rb_method_cfunc_t {
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
-/// Ruby built-in C function info
+/// Opaque FILE type
 #[repr(C)]
-pub struct rb_builtin_function {
+pub struct FILE {
     _data: [u8; 0],
     _marker:
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -421,6 +421,22 @@ extern "C" {
 extern "C" {
     pub fn rb_ec_str_resurrect(ec: *mut rb_execution_context_struct, str_: VALUE) -> VALUE;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_builtin_function {
+    pub func_ptr: *const ::std::os::raw::c_void,
+    pub argc: ::std::os::raw::c_int,
+    pub index: ::std::os::raw::c_int,
+    pub name: *const ::std::os::raw::c_char,
+    pub compiler: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut FILE,
+            arg2: ::std::os::raw::c_long,
+            arg3: ::std::os::raw::c_uint,
+            arg4: bool,
+        ),
+    >,
+}
 extern "C" {
     pub fn rb_vm_insn_addr2opcode(addr: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
 }


### PR DESCRIPTION
Since rb_builtin_func includes a function pointer type with FILE* as a param, that means adding a FILE opaque type.