### PR TITLE
Export stats primitives from Rust to CRuby

### DIFF
--- a/inits.c
+++ b/inits.c
@@ -11,7 +11,6 @@
 
 #include "internal/inits.h"
 #include "ruby.h"
-#include "yjit.h"
 #include "builtin.h"
 static void Init_builtin_prelude(void);
 #include "prelude.rbinc"

--- a/inits.c
+++ b/inits.c
@@ -98,9 +98,9 @@ rb_call_builtin_inits(void)
     BUILTIN(array);
     BUILTIN(kernel);
     BUILTIN(timev);
+    BUILTIN(yjit);
     BUILTIN(nilclass);
     BUILTIN(marshal);
-    BUILTIN(yjit);
     Init_builtin_prelude();
 }
 #undef CALL

--- a/inits.c
+++ b/inits.c
@@ -11,6 +11,7 @@
 
 #include "internal/inits.h"
 #include "ruby.h"
+#include "yjit.h"
 #include "builtin.h"
 static void Init_builtin_prelude(void);
 #include "prelude.rbinc"

--- a/inits.c
+++ b/inits.c
@@ -100,6 +100,7 @@ rb_call_builtin_inits(void)
     BUILTIN(timev);
     BUILTIN(nilclass);
     BUILTIN(marshal);
+    BUILTIN(yjit);
     Init_builtin_prelude();
 }
 #undef CALL

--- a/vm.c
+++ b/vm.c
@@ -3961,6 +3961,11 @@ Init_vm_objects(void)
     vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 10000);
 }
 
+/* Stub for builtin function when not building YJIT units*/
+#if !YJIT_BUILD
+void Init_builtin_yjit(void) {}
+#endif
+
 /* top self */
 
 static VALUE

--- a/yjit.c
+++ b/yjit.c
@@ -379,7 +379,7 @@ rb_get_iseq_body_param_opt_num(rb_iseq_t* iseq) {
     return iseq->body->param.opt_num;
 }
 
-VALUE*
+const VALUE*
 rb_get_iseq_body_param_opt_table(rb_iseq_t* iseq) {
     return iseq->body->param.opt_table;
 }

--- a/yjit.h
+++ b/yjit.h
@@ -44,9 +44,6 @@
 // Expose these as declarations since we are building YJIT.
 bool rb_yjit_enabled_p(void);
 unsigned rb_yjit_call_threshold(void);
-VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
 void rb_yjit_invalidate_all_method_lookup_assumptions(void);
 void rb_yjit_method_lookup_change(VALUE klass, ID mid);
 void rb_yjit_cme_invalidate(VALUE cme);
@@ -54,7 +51,7 @@ void rb_yjit_collect_vm_usage_insn(int insn);
 void rb_yjit_collect_binding_alloc(void);
 void rb_yjit_collect_binding_set(void);
 bool rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec);
-void rb_yjit_init();
+void rb_yjit_init(void);
 void rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop);
 void rb_yjit_constant_state_changed(void);
 void rb_yjit_iseq_mark(const struct rb_iseq_constant_body *body);

--- a/yjit.h
+++ b/yjit.h
@@ -65,7 +65,6 @@ void rb_yjit_tracing_invalidate_all(void);
 // !YJIT_BUILD
 // In these builds, YJIT could never be turned on. Provide dummy implementations.
 
-static inline void Init_builtin_yjit(void) {}
 static inline bool rb_yjit_enabled_p(void) { return false; }
 static inline unsigned rb_yjit_call_threshold(void) { return UINT_MAX; }
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}

--- a/yjit.h
+++ b/yjit.h
@@ -67,9 +67,6 @@ void rb_yjit_tracing_invalidate_all(void);
 
 static inline bool rb_yjit_enabled_p(void) { return false; }
 static inline unsigned rb_yjit_call_threshold(void) { return UINT_MAX; }
-static inline VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self) {}
-static inline VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self) {}
-static inline VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self) {}
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}
 static inline void rb_yjit_method_lookup_change(VALUE klass, ID mid) {}
 static inline void rb_yjit_cme_invalidate(VALUE cme) {}

--- a/yjit.h
+++ b/yjit.h
@@ -44,7 +44,9 @@
 // Expose these as declarations since we are building YJIT.
 bool rb_yjit_enabled_p(void);
 unsigned rb_yjit_call_threshold(void);
-
+VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
 void rb_yjit_invalidate_all_method_lookup_assumptions(void);
 void rb_yjit_method_lookup_change(VALUE klass, ID mid);
 void rb_yjit_cme_invalidate(VALUE cme);
@@ -68,6 +70,9 @@ void rb_yjit_tracing_invalidate_all(void);
 
 static inline bool rb_yjit_enabled_p(void) { return false; }
 static inline unsigned rb_yjit_call_threshold(void) { return UINT_MAX; }
+static inline VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self) {}
+static inline VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self) {}
+static inline VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self) {}
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}
 static inline void rb_yjit_method_lookup_change(VALUE klass, ID mid) {}
 static inline void rb_yjit_cme_invalidate(VALUE cme) {}

--- a/yjit.h
+++ b/yjit.h
@@ -65,6 +65,7 @@ void rb_yjit_tracing_invalidate_all(void);
 // !YJIT_BUILD
 // In these builds, YJIT could never be turned on. Provide dummy implementations.
 
+static inline void Init_builtin_yjit(void) {}
 static inline bool rb_yjit_enabled_p(void) { return false; }
 static inline unsigned rb_yjit_call_threshold(void) { return UINT_MAX; }
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}

--- a/yjit.rb
+++ b/yjit.rb
@@ -134,18 +134,16 @@ module RubyVM::YJIT
   # Return a hash for statistics generated for the --yjit-stats command line option.
   # Return nil when option is not passed or unavailable.
   def self.runtime_stats
-    # defined in yjit_iface.c
-    Primitive.get_yjit_stats
+    Primitive.rb_yjit_get_stats
   end
 
   # Discard statistics collected for --yjit-stats.
   def self.reset_stats!
-    # defined in yjit_iface.c
-    Primitive.reset_stats_bang
+    Primitive.rb_yjit_reset_stats_bang
   end
 
   def self.stats_enabled?
-    Primitive.yjit_stats_enabled_p
+    Primitive.rb_yjit_stats_enabled_p
   end
 
   def self.enabled?
@@ -157,7 +155,7 @@ module RubyVM::YJIT
   end
 
   # Avoid calling a method here to not interfere with compilation tests
-  if Primitive.yjit_stats_enabled_p
+  if Primitive.rb_yjit_stats_enabled_p
     at_exit { _print_stats }
   end
 

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -546,108 +546,18 @@ comments_for(rb_execution_context_t *ec, VALUE self, VALUE start_address, VALUE 
     return comment_array;
 }
 
-static VALUE
-yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self)
+// Primitive called in yjit.rb.
+// Export all YJIT statistics as a Ruby hash.
+VALUE
+rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self)
 {
-    // FIXME: moved to Rust
-    return Qfalse;
-}
-
-// Primitive called in yjit.rb. Export all YJIT statistics as a Ruby hash.
-static VALUE
-get_yjit_stats(rb_execution_context_t *ec, VALUE self)
-{
-    // TODO: take VM lock and call into Rust code
-    return Qnil;
-
-    /*
-    // Return Qnil if YJIT isn't enabled
-    if (cb == NULL) {
-        return Qnil;
-    }
-
-    VALUE hash = rb_hash_new();
-
+    VALUE stats_hash;
     RB_VM_LOCK_ENTER();
-
-    {
-        VALUE key = ID2SYM(rb_intern("inline_code_size"));
-        VALUE value = LL2NUM((long long)cb->write_pos);
-        rb_hash_aset(hash, key, value);
-
-        key = ID2SYM(rb_intern("outlined_code_size"));
-        value = LL2NUM((long long)ocb->write_pos);
-        rb_hash_aset(hash, key, value);
-    }
-
-#if YJIT_STATS
-    if (rb_yjit_opts.gen_stats) {
-        // Indicate that the complete set of stats is available
-        rb_hash_aset(hash, ID2SYM(rb_intern("all_stats")), Qtrue);
-
-        int64_t *counter_reader = (int64_t *)&yjit_runtime_counters;
-        int64_t *counter_reader_end = &yjit_runtime_counters.last_member;
-
-        // For each counter in yjit_counter_names, add that counter as
-        // a key/value pair.
-
-        // Iterate through comma separated counter name list
-        char *name_reader = yjit_counter_names;
-        char *counter_name_end = yjit_counter_names + sizeof(yjit_counter_names);
-        while (name_reader < counter_name_end && counter_reader < counter_reader_end) {
-            if (*name_reader == ',' || *name_reader == ' ') {
-                name_reader++;
-                continue;
-            }
-
-            // Compute length of counter name
-            int name_len;
-            char *name_end;
-            {
-                name_end = strchr(name_reader, ',');
-                if (name_end == NULL) break;
-                name_len = (int)(name_end - name_reader);
-            }
-
-            // Put counter into hash
-            VALUE key = ID2SYM(rb_intern2(name_reader, name_len));
-            VALUE value = LL2NUM((long long)*counter_reader);
-            rb_hash_aset(hash, key, value);
-
-            counter_reader++;
-            name_reader = name_end;
-        }
-
-        // For each entry in exit_op_count, add a stats entry with key "exit_INSTRUCTION_NAME"
-        // and the value is the count of side exits for that instruction.
-
-        char key_string[rb_vm_max_insn_name_size + 6]; // Leave room for "exit_" and a final NUL
-        for (int i = 0; i < VM_INSTRUCTION_SIZE; i++) {
-            const char *i_name = insn_name(i); // Look up Ruby's NUL-terminated insn name string
-            snprintf(key_string, rb_vm_max_insn_name_size + 6, "%s%s", "exit_", i_name);
-
-            VALUE key = ID2SYM(rb_intern(key_string));
-            VALUE value = LL2NUM((long long)exit_op_count[i]);
-            rb_hash_aset(hash, key, value);
-        }
-    }
-#endif
-
+    VALUE rb_yjit_gen_stats_dict(rb_execution_context_t *ec, VALUE self);
+    stats_hash = rb_yjit_gen_stats_dict(ec, self);
     RB_VM_LOCK_LEAVE();
 
-    return hash;
-    */
-}
-
-// Primitive called in yjit.rb. Zero out all the counters.
-static VALUE
-reset_stats_bang(rb_execution_context_t *ec, VALUE self)
-{
-#if YJIT_STATS
-    memset(&exit_op_count, 0, sizeof(exit_op_count));
-    memset(&yjit_runtime_counters, 0, sizeof(yjit_runtime_counters));
-#endif // if YJIT_STATS
-    return Qnil;
+    return stats_hash;
 }
 
 // Primitive for yjit.rb. For testing running out of executable memory

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -572,6 +572,12 @@ simulate_oom_bang(rb_execution_context_t *ec, VALUE self)
     return Qnil;
 }
 
+// Primitives used by yjit.rb
+VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
+
+// Preprocessed yjit.rb generated during build
 #include "yjit.rbinc"
 
 #if YJIT_STATS
@@ -759,7 +765,7 @@ outgoing_ids(VALUE self)
 
 // Can raise RuntimeError
 void
-rb_yjit_init()
+rb_yjit_init(void)
 {
     if (!PLATFORM_SUPPORTED_P || !JIT_ENABLED) {
         return;


### PR DESCRIPTION
@XrXr would appreciate your input on whether I'm doing this right/wrong

I wanted the stats `Primitive` functions that are called from `yjit.rb` to be exported from Rust. I had to manually declare function prototypes in `yjit.h`, which we somehow didn't need to do before. I renamed the functions so they have `rb_yjit_` in the name for consistency.

On a sidenote, `RubyVM::YJIT` is not available.  Is calling `mYjit = rb_define_module_under(rb_cRubyVM, "YJIT");` sufficient to make `RubyVM::YJIT` available?