### PR TITLE
Assembly comments on CodeBlocks

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -88,7 +88,6 @@ pub struct CodeBlock
     label_refs: Vec<LabelRef>,
 
     // Comments for assembly instructions, if that feature is enabled
-    #[cfg(feature="asm_comments")]
     asm_comments: Vec<(usize, String)>,
 
     // Keep track of the current aligned write position.
@@ -112,21 +111,6 @@ impl CodeBlock
         let mut dummy_block = vec![0; mem_size];
         let mem_ptr = dummy_block.as_mut_ptr();
 
-        #[cfg(not(feature="asm_comments"))]
-        return Self {
-            dummy_block: dummy_block,
-            mem_block: mem_ptr,
-            mem_size: mem_size,
-            write_pos: 0,
-            label_addrs: Vec::new(),
-            label_names: Vec::new(),
-            label_refs: Vec::new(),
-            current_aligned_write_pos: ALIGNED_WRITE_POSITION_NONE,
-            page_size: 4096,
-            dropped_bytes: false
-        };
-
-        #[cfg(feature="asm_comments")]
         Self {
             dummy_block: dummy_block,
             mem_block: mem_ptr,
@@ -143,21 +127,6 @@ impl CodeBlock
     }
 
     pub fn new(mem_block: *mut u8, mem_size: usize, page_size: usize) -> Self {
-        #[cfg(not(feature="asm_comments"))]
-        return Self {
-            dummy_block: vec![0; 0],
-            mem_block: mem_block,
-            mem_size: mem_size,
-            write_pos: 0,
-            label_addrs: Vec::new(),
-            label_names: Vec::new(),
-            label_refs: Vec::new(),
-            current_aligned_write_pos: ALIGNED_WRITE_POSITION_NONE,
-            page_size,
-            dropped_bytes: false
-        };
-
-        #[cfg(feature="asm_comments")]
         Self {
             dummy_block: vec![0; 0],
             mem_block: mem_block,
@@ -202,12 +171,8 @@ impl CodeBlock
     }
 
     /// Get a slice (readonly ref) of assembly comments - if the feature is off, this will be empty.
-    pub fn get_comments(&self) -> Option<&[(usize, String)]> {
-        #[cfg(feature="asm_comments")]
-        return Some(self.asm_comments.as_slice());
-
-        #[cfg(not(feature="asm_comments"))]
-        None
+    pub fn get_comments(&self) -> &[(usize, String)] {
+        return self.asm_comments.as_slice();
     }
 
     pub fn get_write_pos(&self) -> usize {

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -417,12 +417,12 @@ fn basic_capstone_usage() -> std::result::Result<(), capstone::Error> {
 fn block_comments() {
     let mut cb = super::CodeBlock::new_dummy(4096);
 
-    cb.add_comment("Beginning".to_string());
+    cb.add_comment("Beginning");
     xor(&mut cb, EAX, EAX); // 2 bytes long
-    cb.add_comment("Two bytes in".to_string());
-    cb.add_comment("Two bytes in".to_string()); // Duplicate, should be ignored
+    cb.add_comment("Two bytes in");
+    cb.add_comment("Two bytes in"); // Duplicate, should be ignored
     test(&mut cb, mem_opnd(64, RSI, 64), imm_opnd(!0x08)); // 8 bytes long
-    cb.add_comment("Ten bytes in".to_string());
+    cb.add_comment("Ten bytes in");
 
     let comments = cb.get_comments();
     let expected:Vec<(usize,String)> = vec!( (0, "Beginning".to_string()), (2, "Two bytes in".to_string()), (10, "Ten bytes in".to_string()) );

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -411,3 +411,20 @@ fn basic_capstone_usage() -> std::result::Result<(), capstone::Error> {
         )),
     }
 }
+
+#[test]
+#[cfg(feature = "asm_comments")]
+fn block_comments() {
+    let mut cb = super::CodeBlock::new_dummy(4096);
+
+    cb.add_comment("Beginning".to_string());
+    xor(&mut cb, EAX, EAX); // 2 bytes long
+    cb.add_comment("Two bytes in".to_string());
+    cb.add_comment("Two bytes in".to_string()); // Duplicate, should be ignored
+    test(&mut cb, mem_opnd(64, RSI, 64), imm_opnd(!0x08)); // 8 bytes long
+    cb.add_comment("Ten bytes in".to_string());
+
+    let comments = cb.get_comments();
+    let expected:Vec<(usize,String)> = vec!( (0, "Beginning".to_string()), (2, "Two bytes in".to_string()), (10, "Ten bytes in".to_string()) );
+    assert_eq!(expected, comments);
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -233,23 +233,7 @@ fn add_comment(cb: &mut CodeBlock, comment_str: &str)
 {
     #[cfg(feature = "asm_comments")]
     {
-        /*
-        // We can't add comments to the outlined code block
-        if (cb == ocb)
-            return;
-
-        // Avoid adding duplicate comment strings (can happen due to deferred codegen)
-        size_t num_comments = rb_darray_size(yjit_code_comments);
-        if (num_comments > 0) {
-            struct yjit_comment last_comment = rb_darray_get(yjit_code_comments, num_comments - 1);
-            if (last_comment.offset == cb->write_pos && strcmp(last_comment.comment, comment_str) == 0) {
-                return;
-            }
-        }
-
-        struct yjit_comment new_comment = (struct yjit_comment){ cb->write_pos, comment_str };
-        rb_darray_append(&yjit_code_comments, new_comment);
-        */
+        cb.add_comment(comment_str);
     }
 }
 


### PR DESCRIPTION
This adds basic assembly comments on the CodeBlock object -- much easier to track lifetimes there than separately. This does *not* yet add a convenient disassembly-and-comments method like we had in yjit.rb.