### PR TITLE
Port logic for gen_send_iseq calls with keyword args

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -275,6 +275,11 @@ rb_str_bytesize(VALUE str)
     return LONG2NUM(RSTRING_LEN(str));
 }
 
+// This is defined only as a named struct inside rb_iseq_constant_body.
+// By giving it a separate typedef, we make it nameable by rust-bindgen.
+// Bindgen's temp/anon name isn't guaranteed stable.
+typedef struct rb_iseq_param_keyword rb_seq_param_keyword_struct;
+
 const char*
 rb_insn_name(VALUE insn)
 {
@@ -301,6 +306,24 @@ rb_vm_ci_mid(const struct rb_callinfo *ci) {
 unsigned int
 rb_vm_ci_flag(const struct rb_callinfo *ci) {
     return vm_ci_flag(ci);
+}
+
+const struct rb_callinfo_kwarg *
+rb_vm_ci_kwarg(const struct rb_callinfo *ci)
+{
+    return vm_ci_kwarg(ci);
+}
+
+int
+rb_get_cikw_keyword_len(const struct rb_callinfo_kwarg* cikw)
+{
+    return cikw->keyword_len;
+}
+
+VALUE
+rb_get_cikw_keywords_idx(const struct rb_callinfo_kwarg* cikw, int idx)
+{
+    return cikw->keywords[idx];
 }
 
 rb_method_visibility_t
@@ -381,9 +404,9 @@ rb_get_iseq_flags_has_opt(rb_iseq_t* iseq) {
     return iseq->body->param.flags.has_opt;
 }
 
-int
-rb_get_iseq_body_param_keyword_num(rb_iseq_t* iseq) {
-    return iseq->body->param.keyword->num;
+const rb_seq_param_keyword_struct*
+rb_get_iseq_body_param_keyword(rb_iseq_t* iseq) {
+    return iseq->body->param.keyword;
 }
 
 unsigned

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -90,10 +90,14 @@ fn main() {
         .allowlist_type("vm_call_flag_bits") // So instead we include the other enum and do the bit-shift ourselves
         .blocklist_type("rb_call_data")
         .opaque_type("rb_call_data")
+        .blocklist_type("rb_callinfo_kwarg") // Contains a VALUE[] array of undefined size
+        .opaque_type("rb_callinfo_kwarg")
+        .allowlist_type("rb_callinfo")
 
         // From vm_core.h
         .allowlist_var("VM_BLOCK_HANDLER_NONE")
         .allowlist_var("VM_ENV_FLAG_.*")
+        .allowlist_type("rb_seq_param_keyword_struct")
 
         // From include/ruby/internal/intern/range.h
         .allowlist_function("rb_range_new")
@@ -101,6 +105,7 @@ fn main() {
         // From include/ruby/internal/symbol.h
         .allowlist_function("rb_intern")
         .allowlist_function("rb_id2sym")
+        .allowlist_function("rb_sym2id")
 
         // From internal/string.h
         .allowlist_function("rb_ec_str_resurrect")
@@ -138,8 +143,6 @@ fn main() {
         .allowlist_type("rb_callable_method_entry_struct")
         .allowlist_function("rb_method_entry_at")
         .allowlist_type("rb_method_entry_t")
-
-        // Opaque types from method.h
         .blocklist_type("rb_method_cfunc_t")
 
         // From vm_core.h
@@ -153,8 +156,6 @@ fn main() {
         .allowlist_type("iseq_inline_cvar_cache_entry")
         .blocklist_type("rb_method_definition_.*")
         .opaque_type("rb_method_definition_.*")
-
-        // Opaque types from vm_core.h
         .blocklist_type("rb_execution_context_.*")
         .opaque_type("rb_execution_context_.*")
         .blocklist_type("rb_control_frame_struct")

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -995,7 +995,9 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
                 write_rm(cb, mem.num_bits == 16, mem.num_bits == 64, X86Opnd::None, dst, 0, &[0xc7]);
             }
 
-            cb.write_int(imm.value as u64, if mem.num_bits > 32 { 32 } else { mem.num_bits.into() });
+            let output_num_bits:u32 = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
+            assert!(sig_imm_size(imm.value) <= (output_num_bits as u8));
+            cb.write_int(imm.value as u64, output_num_bits);
         },
         // M + UImm
         (X86Opnd::Mem(mem), X86Opnd::UImm(uimm)) => {
@@ -1007,7 +1009,9 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
                 write_rm(cb, mem.num_bits == 16, mem.num_bits == 64, X86Opnd::None, dst, 0, &[0xc7]);
             }
 
-            cb.write_int(uimm.value, if mem.num_bits > 32 { 32 } else { mem.num_bits.into() });
+            let output_num_bits = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
+            assert!(unsig_imm_size(uimm.value) <= (output_num_bits as u8));
+            cb.write_int(uimm.value, output_num_bits);
         },
         // * + Imm/UImm
         (_, X86Opnd::Imm(_) | X86Opnd::UImm(_)) => unreachable!(),

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1857,7 +1857,7 @@ fn gen_checkkeyword(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, o
 {
     // When a keyword is unspecified past index 32, a hash will be used
     // instead. This can only happen in iseqs taking more than 32 keywords.
-    if unsafe { get_iseq_body_param_keyword_num(jit.iseq) >= 32 } {
+    if unsafe { (*get_iseq_body_param_keyword(jit.iseq)).num >= 32 } {
         return CantCompile;
     }
 
@@ -3682,6 +3682,7 @@ fn gen_return_branch(cb: &mut CodeBlock, target0: CodePtr, target1: Option<CodeP
 fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: &mut OutlinedCb, ci: * const rb_callinfo, cme: * const rb_callable_method_entry_t, block: Option<IseqPtr>, argc: i32) -> CodegenStatus
 {
     let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
+    let mut argc = argc;
 
     // When you have keyword arguments, there is an extra object that gets
     // placed on the stack the represents a bitmap of the keywords that were not
@@ -3756,19 +3757,14 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
         // Here we're calling a method with keyword arguments and specifying
         // keyword arguments at this call site.
 
-        todo!();
-
-        /*
         // This struct represents the metadata about the caller-specified
         // keyword arguments.
-        //const struct rb_callinfo_kwarg *kw_arg = vm_ci_kwarg(ci);
         let kw_arg = unsafe { vm_ci_kwarg(ci) };
 
-        // This struct represents the metadata about the callee-specified
-        // keyword parameters.
-        const struct rb_iseq_param_keyword *keyword = iseq->body->param.keyword;
+        let keyword = unsafe { get_iseq_body_param_keyword(iseq) };
+        let keyword_num = unsafe { (*keyword).num };
 
-        if (keyword->num > 30) {
+        if keyword_num > 30 {
             // We have so many keywords that (1 << num) encoded as a FIXNUM
             // (which shifts it left one more) no longer fits inside a 32-bit
             // immediate.
@@ -3778,32 +3774,36 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
 
         if unsafe { vm_ci_flag(ci) } & VM_CALL_KWARG != 0 {
             // Check that the size of non-keyword arguments matches
-            if lead_num != argc - kw_arg->keyword_len {
+            if lead_num != argc - unsafe { get_cikw_keyword_len(kw_arg) } {
                 gen_counter_incr!(cb, send_iseq_complex_callee);
                 return CantCompile;
             }
 
             // This is the list of keyword arguments that the callee specified
             // in its initial declaration.
-            const ID *callee_kwargs = keyword->table;
+            let callee_kwargs = unsafe { (*keyword).table };
 
             // Here we're going to build up a list of the IDs that correspond to
             // the caller-specified keyword arguments. If they're not in the
             // same order as the order specified in the callee declaration, then
             // we're going to need to generate some code to swap values around
             // on the stack.
-            ID *caller_kwargs = ALLOCA_N(VALUE, kw_arg->keyword_len);
-            for (int kwarg_idx = 0; kwarg_idx < kw_arg->keyword_len; kwarg_idx++)
-                caller_kwargs[kwarg_idx] = SYM2ID(kw_arg->keywords[kwarg_idx]);
+            let kw_arg_keyword_len:usize = unsafe { get_cikw_keyword_len(kw_arg) }.try_into().unwrap();
+            let mut caller_kwargs: Vec<ID> = vec![0; kw_arg_keyword_len];
+            for kwarg_idx in 0..kw_arg_keyword_len {
+                let sym = unsafe { get_cikw_keywords_idx(kw_arg, kwarg_idx.try_into().unwrap()) };
+                caller_kwargs[kwarg_idx as usize] = unsafe { rb_sym2id(sym) };
+            }
 
             // First, we're going to be sure that the names of every
             // caller-specified keyword argument correspond to a name in the
             // list of callee-specified keyword parameters.
-            for (int caller_idx = 0; caller_idx < kw_arg->keyword_len; caller_idx++) {
-                int callee_idx;
-
-                for (callee_idx = 0; callee_idx < keyword->num; callee_idx++) {
-                    if (caller_kwargs[caller_idx] == callee_kwargs[callee_idx]) {
+            let mut callee_idx = keyword_num + 1; // will never be equal to keyword_num
+            for caller_idx in 0..kw_arg_keyword_len {
+                for tmp_callee_idx in 0..keyword_num {
+                    let callee_arg_id = unsafe { *(callee_kwargs.offset(tmp_callee_idx as isize)) };
+                    if caller_kwargs[caller_idx] == callee_arg_id {
+                        callee_idx = tmp_callee_idx;
                         break;
                     }
                 }
@@ -3811,18 +3811,18 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
                 // If the keyword was never found, then we know we have a
                 // mismatch in the names of the keyword arguments, so we need to
                 // bail.
-                if (callee_idx == keyword->num) {
+                if callee_idx == keyword_num {
                     gen_counter_incr!(cb, send_iseq_kwargs_mismatch);
                     return CantCompile;
                 }
             }
         }
-        else if (argc == lead_num) {
+        else if argc == lead_num {
             // Here we are calling a method that accepts keyword arguments
             // (optional or required) but we're not passing any keyword
             // arguments at this call site
 
-            if (keyword->required_num != 0) {
+            if unsafe { (*keyword).required_num } != 0 {
                 // If any of the keywords are required this is a mismatch
                 gen_counter_incr!(cb, send_iseq_kwargs_mismatch);
                 return CantCompile;
@@ -3834,7 +3834,6 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
             gen_counter_incr!(cb, send_iseq_complex_callee);
             return CantCompile;
         }
-        */
     }
     else {
         // Only handle iseqs that have simple parameter setup.
@@ -3898,105 +3897,123 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
     jle_ptr(cb, counted_exit!(ocb, side_exit, send_se_cf_overflow));
 
     if doing_kw_call {
-        todo!()
-
-        /*
         // Here we're calling a method with keyword arguments and specifying
         // keyword arguments at this call site.
-        const int lead_num = iseq->body->param.lead_num;
+        let lead_num = unsafe { get_iseq_body_param_lead_num(iseq) };
 
         // This struct represents the metadata about the caller-specified
         // keyword arguments.
-        int caller_keyword_len = 0;
-        const VALUE *caller_keywords = NULL;
-        if (vm_ci_kwarg(ci)) {
-            caller_keyword_len = vm_ci_kwarg(ci)->keyword_len;
-            caller_keywords = &vm_ci_kwarg(ci)->keywords[0];
-        }
+        let ci_kwarg = unsafe { vm_ci_kwarg(ci) };
+        let caller_keyword_len:usize = if ci_kwarg.is_null() { 0 }
+        else {
+            unsafe { get_cikw_keyword_len(ci_kwarg) }.try_into().unwrap()
+        };
 
         // This struct represents the metadata about the callee-specified
         // keyword parameters.
-        const struct rb_iseq_param_keyword *keyword = iseq->body->param.keyword;
+        let keyword = unsafe { get_iseq_body_param_keyword(iseq) };
 
         add_comment(cb, "keyword args");
 
         // This is the list of keyword arguments that the callee specified
         // in its initial declaration.
-        const ID *callee_kwargs = keyword->table;
-
-        int total_kwargs = keyword->num;
+        let callee_kwargs = unsafe { (*keyword).table };
+        let total_kwargs:usize = unsafe { (*keyword).num }.try_into().unwrap();
 
         // Here we're going to build up a list of the IDs that correspond to
         // the caller-specified keyword arguments. If they're not in the
         // same order as the order specified in the callee declaration, then
         // we're going to need to generate some code to swap values around
         // on the stack.
-        ID *caller_kwargs = ALLOCA_N(VALUE, total_kwargs);
-        int kwarg_idx;
-        for (kwarg_idx = 0; kwarg_idx < caller_keyword_len; kwarg_idx++) {
-                caller_kwargs[kwarg_idx] = SYM2ID(caller_keywords[kwarg_idx]);
+        let mut caller_kwargs: Vec<ID> = vec![0; total_kwargs];
+
+        for kwarg_idx in 0..caller_keyword_len {
+            let sym = unsafe { get_cikw_keywords_idx(ci_kwarg, kwarg_idx.try_into().unwrap()) };
+            let kwarg_idx_usize:usize = kwarg_idx.try_into().unwrap();
+            caller_kwargs[kwarg_idx_usize] = unsafe { rb_sym2id(sym) };
         }
+        let mut kwarg_idx = caller_keyword_len;
 
-        int unspecified_bits = 0;
+        let mut unspecified_bits = 0;
 
-        for (int callee_idx = keyword->required_num; callee_idx < total_kwargs; callee_idx++) {
-            bool already_passed = false;
-            ID callee_kwarg = callee_kwargs[callee_idx];
+        let keyword_required_num:usize = unsafe { (*keyword).required_num }.try_into().unwrap();
+        for callee_idx in keyword_required_num..total_kwargs {
+            let mut already_passed = false;
+            let callee_kwarg = unsafe { *(callee_kwargs.offset(callee_idx.try_into().unwrap())) };
 
-            for (int caller_idx = 0; caller_idx < caller_keyword_len; caller_idx++) {
-                if (caller_kwargs[caller_idx] == callee_kwarg) {
+            for caller_idx in 0..caller_keyword_len {
+                if caller_kwargs[caller_idx] == callee_kwarg {
                     already_passed = true;
                     break;
                 }
             }
 
-            if (!already_passed) {
+            if !already_passed {
                 // Reserve space on the stack for each default value we'll be
                 // filling in (which is done in the next loop). Also increments
                 // argc so that the callee's SP is recorded correctly.
-                argc++;
+                argc += 1;
                 let default_arg = ctx.stack_push(Type::Unknown);
-                VALUE default_value = keyword->default_values[callee_idx - keyword->required_num];
 
-                if (default_value == Qundef) {
+                // callee_idx - keyword->required_num is used in a couple of places below.
+                let req_num:isize = unsafe { (*keyword).required_num }.try_into().unwrap();
+                let callee_idx_isize:isize = callee_idx.try_into().unwrap();
+                let extra_args = callee_idx_isize - req_num;
+
+                //VALUE default_value = keyword->default_values[callee_idx - keyword->required_num];
+                let mut default_value = unsafe {
+                    *((*keyword).default_values.offset(extra_args))
+                };
+
+                if default_value == Qundef {
                     // Qundef means that this value is not constant and must be
                     // recalculated at runtime, so we record it in unspecified_bits
                     // (Qnil is then used as a placeholder instead of Qundef).
-                    unspecified_bits |= 0x01 << (callee_idx - keyword->required_num);
+                    unspecified_bits |= 0x01 << extra_args;
                     default_value = Qnil;
                 }
 
-                mov(cb, default_arg, imm_opnd(default_value));
+                jit_mov_gc_ptr(jit, cb, REG0, default_value);
+                mov(cb, default_arg, REG0);
 
-                caller_kwargs[kwarg_idx++] = callee_kwarg;
+                caller_kwargs[kwarg_idx] = callee_kwarg;
+                kwarg_idx += 1;
             }
         }
-        RUBY_ASSERT(kwarg_idx == total_kwargs);
+
+        assert!(kwarg_idx == total_kwargs);
 
         // Next, we're going to loop through every keyword that was
         // specified by the caller and make sure that it's in the correct
         // place. If it's not we're going to swap it around with another one.
-        for (kwarg_idx = 0; kwarg_idx < total_kwargs; kwarg_idx++) {
-            ID callee_kwarg = callee_kwargs[kwarg_idx];
+        for kwarg_idx in 0..total_kwargs {
+            let kwarg_idx_isize:isize = kwarg_idx.try_into().unwrap();
+            let callee_kwarg = unsafe { *(callee_kwargs.offset(kwarg_idx_isize)) };
 
             // If the argument is already in the right order, then we don't
             // need to generate any code since the expected value is already
             // in the right place on the stack.
-            if (callee_kwarg == caller_kwargs[kwarg_idx]) continue;
+            if callee_kwarg == caller_kwargs[kwarg_idx] {
+                continue;
+            }
 
             // In this case the argument is not in the right place, so we
             // need to find its position where it _should_ be and swap with
             // that location.
-            for (int swap_idx = kwarg_idx + 1; swap_idx < total_kwargs; swap_idx++) {
-                if (callee_kwarg == caller_kwargs[swap_idx]) {
+            for swap_idx in (kwarg_idx + 1)..total_kwargs {
+                if callee_kwarg == caller_kwargs[swap_idx] {
                     // First we're going to generate the code that is going
                     // to perform the actual swapping at runtime.
-                    stack_swap(ctx, cb, argc - 1 - swap_idx - lead_num, argc - 1 - kwarg_idx - lead_num, REG1, REG0);
+                    let swap_idx_i32:i32 = swap_idx.try_into().unwrap();
+                    let kwarg_idx_i32:i32 = kwarg_idx.try_into().unwrap();
+                    let offset0:u16 = (argc - 1 - swap_idx_i32 - lead_num).try_into().unwrap();
+                    let offset1:u16 = (argc - 1 - kwarg_idx_i32 - lead_num).try_into().unwrap();
+                    stack_swap(ctx, cb, offset0, offset1, REG1, REG0);
 
                     // Next we're going to do some bookkeeping on our end so
                     // that we know the order that the arguments are
                     // actually in now.
-                    ID tmp = caller_kwargs[kwarg_idx];
+                    let tmp = caller_kwargs[kwarg_idx];
                     caller_kwargs[kwarg_idx] = caller_kwargs[swap_idx];
                     caller_kwargs[swap_idx] = tmp;
 
@@ -4008,8 +4025,8 @@ fn gen_send_iseq(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
         // Keyword arguments cause a special extra local variable to be
         // pushed onto the stack that represents the parameters that weren't
         // explicitly given a value and have a non-constant default.
-        mov(cb, ctx.stack_opnd(-1), imm_opnd(INT2FIX(unspecified_bits)));
-        */
+        let unspec_opnd = uimm_opnd(VALUE::fixnum_from_usize(unspecified_bits).as_u64());
+        mov(cb, ctx.stack_opnd(-1), unspec_opnd);
     }
 
     // Points to the receiver operand on the stack

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -177,8 +177,8 @@ extern "C" {
     #[link_name = "rb_get_iseq_body_local_table_size"]
     pub fn get_iseq_body_local_table_size(iseq: IseqPtr) -> c_uint;
 
-    #[link_name = "rb_get_iseq_body_param_keyword_num"]
-    pub fn get_iseq_body_param_keyword_num(iseq: IseqPtr) -> c_int;
+    #[link_name = "rb_get_iseq_body_param_keyword"]
+    pub fn get_iseq_body_param_keyword(iseq: IseqPtr) -> *const rb_seq_param_keyword_struct;
 
     #[link_name = "rb_get_iseq_body_param_size"]
     pub fn get_iseq_body_param_size(iseq: IseqPtr) -> c_uint;
@@ -191,6 +191,12 @@ extern "C" {
 
     #[link_name = "rb_get_iseq_body_param_opt_table"]
     pub fn get_iseq_body_param_opt_table(iseq: IseqPtr) -> *const VALUE;
+
+    #[link_name = "rb_get_cikw_keyword_len"]
+    pub fn get_cikw_keyword_len(cikw: *const rb_callinfo_kwarg) -> c_int;
+
+    #[link_name = "rb_get_cikw_keywords_idx"]
+    pub fn get_cikw_keywords_idx(cikw: *const rb_callinfo_kwarg, idx: c_int) -> VALUE;
 
     #[link_name = "rb_iseq_needs_lead_args_only"]
     pub fn iseq_needs_lead_args_only(iseq: *const rb_iseq_t) -> bool;
@@ -234,6 +240,9 @@ extern "C" {
 
     #[link_name = "rb_vm_ci_flag"]
     pub fn vm_ci_flag(ci: * const rb_callinfo) -> c_uint;
+
+    #[link_name = "rb_vm_ci_kwarg"]
+    pub fn vm_ci_kwarg(ci: * const rb_callinfo) -> *const rb_callinfo_kwarg;
 
     #[link_name = "rb_METHOD_ENTRY_VISI"]
     pub fn METHOD_ENTRY_VISI(me: * const rb_callable_method_entry_t) -> rb_method_visibility_t;
@@ -330,7 +339,7 @@ pub struct rb_call_data {
 
 /// Opaque call-info type from vm_callinfo.h
 #[repr(C)]
-pub struct rb_callinfo {
+pub struct rb_callinfo_kwarg {
     _data: [u8; 0],
     _marker:
     core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -106,6 +106,9 @@ extern "C" {
     pub fn rb_hash_bulk_insert(argc: ::std::os::raw::c_long, argv: *const VALUE, hash: VALUE);
 }
 extern "C" {
+    pub fn rb_sym2id(obj: VALUE) -> ID;
+}
+extern "C" {
     pub fn rb_id2sym(id: ID) -> VALUE;
 }
 extern "C" {
@@ -432,6 +435,16 @@ pub struct iseq_inline_iv_cache_entry {
 pub struct iseq_inline_cvar_cache_entry {
     pub entry: *mut rb_cvar_class_tbl_entry,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword {
+    pub num: ::std::os::raw::c_int,
+    pub required_num: ::std::os::raw::c_int,
+    pub bits_start: ::std::os::raw::c_int,
+    pub rest_start: ::std::os::raw::c_int,
+    pub table: *const ID,
+    pub default_values: *mut VALUE,
+}
 pub const BOP_PLUS: ruby_basic_operators = 0;
 pub const BOP_MINUS: ruby_basic_operators = 1;
 pub const BOP_MULT: ruby_basic_operators = 2;
@@ -502,6 +515,14 @@ pub const VM_CALL_OPT_SEND_bit: vm_call_flag_bits = 11;
 pub const VM_CALL_KW_SPLAT_MUT_bit: vm_call_flag_bits = 12;
 pub const VM_CALL__END: vm_call_flag_bits = 13;
 pub type vm_call_flag_bits = u32;
+#[repr(C)]
+pub struct rb_callinfo {
+    pub flags: VALUE,
+    pub kwarg: *const rb_callinfo_kwarg,
+    pub mid: VALUE,
+    pub flag: VALUE,
+    pub argc: VALUE,
+}
 extern "C" {
     pub fn rb_obj_as_string_result(str_: VALUE, obj: VALUE) -> VALUE;
 }
@@ -566,6 +587,7 @@ extern "C" {
 extern "C" {
     pub fn rb_iseq_opcode_at_pc(iseq: *const rb_iseq_t, pc: *const VALUE) -> ::std::os::raw::c_int;
 }
+pub type rb_seq_param_keyword_struct = rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword;
 extern "C" {
     pub fn rb_leaf_invokebuiltin_iseq_p(iseq: *const rb_iseq_t) -> bool;
 }


### PR DESCRIPTION
I've pulled rb_callinfo into bindgen. But rb_callinfo_kwargs has an unspecified-length VALUE array field, so it can't really be bindgen'd.

There's some ugly integer-typecast logic in a few places. While I worked to clean it up, some seemed difficult -- places where offsets into a vector have to be usize and offsets into pointers have to be isize, for instance, and we're grabbing values from C structures so we can't *really* guarantee value ranges. I figured .try_into().unwrap() was probably the right answer in those cases.

I'm not 100% sure we don't want more interesting C-side code, but that seemed like it'd be messy here too.