### PR TITLE
Port aref and aset functions

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -351,6 +351,12 @@ rb_get_cme_def_body_optimized_type(rb_callable_method_entry_t* cme)
     return cme->def->body.optimized.type;
 }
 
+unsigned int
+rb_get_cme_def_body_optimized_index(rb_callable_method_entry_t* cme)
+{
+    return cme->def->body.optimized.index;
+}
+
 rb_method_cfunc_t*
 rb_get_cme_def_body_cfunc(rb_callable_method_entry_t* cme)
 {
@@ -534,6 +540,13 @@ rb_yarv_str_eql_internal(VALUE str1, VALUE str2)
     return rb_str_eql_internal(str1, str2);
 }
 
+// YJIT needs this function to never allocate and never raise
+VALUE
+rb_yarv_ary_entry_internal(VALUE ary, long offset)
+{
+    return rb_ary_entry_internal(ary, offset);
+}
+
 // The FL_TEST() macro
 VALUE
 rb_FL_TEST(VALUE obj, VALUE flags)
@@ -559,6 +572,21 @@ rb_serial_t
 rb_GET_IC_SERIAL(const struct iseq_inline_constant_cache_entry *ice)
 {
     return GET_IC_SERIAL(ice);
+}
+
+long
+rb_RSTRUCT_LEN(VALUE st)
+{
+    return RSTRUCT_LEN(st);
+}
+
+// There are RSTRUCT_SETs in ruby/internal/core/rstruct.h and internal/struct.h
+// with different types (int vs long) for k. Here we use the one from ruby/internal/core/rstruct.h,
+// which takes an int.
+void
+rb_RSTRUCT_SET(VALUE st, int k, VALUE v)
+{
+    RSTRUCT_SET(st, k, v);
 }
 
 const struct rb_callinfo*

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -56,11 +56,13 @@ fn main() {
 
         // From include/ruby/internal/intern/hash.h
         .allowlist_function("rb_hash_aset")
+        .allowlist_function("rb_hash_aref")
         .allowlist_function("rb_hash_bulk_insert")
 
         // From include/ruby/internal/intern/array.h
         .allowlist_function("rb_ary_resurrect")
         .allowlist_function("rb_ary_clear")
+        .allowlist_function("rb_ary_store")
 
         // From internal/array.h
         .allowlist_function("rb_ec_ary_new_from_values")
@@ -84,16 +86,19 @@ fn main() {
         .allowlist_var("rb_cFloat")
         .allowlist_var("rb_cString")
         .allowlist_var("rb_cThread")
+        .allowlist_var("rb_cArray")
+        .allowlist_var("rb_cHash")
 
         // From ruby/internal/globals.h
         .allowlist_var("rb_mKernel")
 
         // From vm_callinfo.h
-        .allowlist_type("VM_CALL.*") // This doesn't work, possibly due to the odd structure of the #defines
-        .allowlist_type("vm_call_flag_bits") // So instead we include the other enum and do the bit-shift ourselves
-        .blocklist_type("rb_call_data")
-        .opaque_type("rb_call_data")
-        .blocklist_type("rb_callinfo_kwarg") // Contains a VALUE[] array of undefined size
+        .allowlist_type("VM_CALL.*")         // This doesn't work, possibly due to the odd structure of the #defines
+        .allowlist_type("vm_call_flag_bits") // So instead we include the other enum and do the bit-shift ourselves.
+        .allowlist_type("rb_call_data")
+        .blocklist_type("rb_callcache.*")      // Not used yet - opaque to make it easy to import rb_call_data
+        .opaque_type("rb_callcache.*")
+        .blocklist_type("rb_callinfo_kwarg") // Contains a VALUE[] array of undefined size, so we don't import
         .opaque_type("rb_callinfo_kwarg")
         .allowlist_type("rb_callinfo")
 
@@ -151,6 +156,8 @@ fn main() {
         .allowlist_function("rb_method_entry_at")
         .allowlist_type("rb_method_entry_t")
         .blocklist_type("rb_method_cfunc_t")
+        .blocklist_type("rb_method_definition_.*") // Large struct with a bitfield and union of many types - don't import (yet?)
+        .opaque_type("rb_method_definition_.*")
 
         // From vm_core.h
         .allowlist_type("ruby_basic_operators")
@@ -168,9 +175,7 @@ fn main() {
         .allowlist_type("iseq_inline_iv_cache_entry")
         .allowlist_type("ICVARC") // pointer to iseq_inline_cvar_cache_entry
         .allowlist_type("iseq_inline_cvar_cache_entry")
-        .blocklist_type("rb_method_definition_.*")
-        .opaque_type("rb_method_definition_.*")
-        .blocklist_type("rb_execution_context_.*")
+        .blocklist_type("rb_execution_context_.*") // Large struct with various-type fields and an ifdef, so we don't import
         .opaque_type("rb_execution_context_.*")
         .blocklist_type("rb_control_frame_struct")
         .opaque_type("rb_control_frame_struct")

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -143,6 +143,9 @@ extern "C" {
     #[link_name = "rb_get_cme_def_body_optimized_type"]
     pub fn get_cme_def_body_optimized_type(cme: * const rb_callable_method_entry_t) -> method_optimized_type;
 
+    #[link_name = "rb_get_cme_def_body_optimized_index"]
+    pub fn get_cme_def_body_optimized_index(cme: * const rb_callable_method_entry_t) -> c_uint;
+
     #[link_name = "rb_get_cme_def_body_cfunc"]
     pub fn get_cme_def_body_cfunc(cme: * const rb_callable_method_entry_t) -> *mut rb_method_cfunc_t;
 
@@ -210,6 +213,9 @@ extern "C" {
     #[link_name = "rb_yarv_str_eql_internal"]
     pub fn rb_str_eql_internal(str1: VALUE, str2: VALUE) -> VALUE;
 
+    #[link_name = "rb_yarv_ary_entry_internal"]
+    pub fn rb_ary_entry_internal(ary: VALUE, offset: c_long) -> VALUE;
+
     #[link_name = "rb_FL_TEST"]
     pub fn FL_TEST(obj: VALUE, flags: VALUE) -> VALUE;
 
@@ -224,6 +230,12 @@ extern "C" {
 
     #[link_name = "rb_GET_IC_SERIAL"]
     pub fn GET_IC_SERIAL(ice: *const iseq_inline_constant_cache_entry) -> rb_serial_t;
+
+    #[link_name = "rb_RSTRUCT_LEN"]
+    pub fn RSTRUCT_LEN(st: VALUE) -> c_long;
+
+    #[link_name = "rb_RSTRUCT_SET"]
+    pub fn RSTRUCT_SET(st: VALUE, k: c_int, v: VALUE);
 
     // Ruby only defines these in vm_insnhelper.c, not in any header.
     // Parsing it would result in a lot of duplicate definitions.
@@ -339,9 +351,9 @@ pub struct FILE {
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
-/// Opaque call-data type from vm_callinfo.h
+/// Opaque call-cache type from vm_callinfo.h
 #[repr(C)]
-pub struct rb_call_data {
+pub struct rb_callcache {
     _data: [u8; 0],
     _marker:
     core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
@@ -598,6 +610,9 @@ pub const RARRAY_EMBED_FLAG:usize = RUBY_FL_USER_1;
 pub const RARRAY_EMBED_LEN_SHIFT:usize = RUBY_FL_USHIFT + 3;
 pub const RARRAY_EMBED_LEN_MASK:usize = RUBY_FL_USER_3 | RUBY_FL_USER_4;
 
+// From internal/struct.h
+pub const RSTRUCT_EMBED_LEN_MASK:usize = RUBY_FL_USER_2 | RUBY_FL_USER_1;
+
 // We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
 // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.
 pub const RUBY_OFFSET_RBASIC_FLAGS:i32 = 0;  // struct RBasic, field "flags"
@@ -605,6 +620,9 @@ pub const RUBY_OFFSET_RBASIC_KLASS:i32 = 8;  // struct RBasic, field "klass"
 pub const RUBY_OFFSET_RARRAY_AS_HEAP_LEN:i32 = 16;  // struct RArray, subfield "as.heap.len"
 pub const RUBY_OFFSET_RARRAY_AS_ARY:i32 = 16;  // struct RArray, subfield "as.ary"
 pub const RUBY_OFFSET_RARRAY_AS_HEAP_PTR:i32 = 16;  // struct RArray, subfield "as.heap.ptr"
+
+pub const RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR:i32 = 24;  // struct RStruct, subfield "as.heap.ptr"
+pub const RUBY_OFFSET_RSTRUCT_AS_ARY:i32 = 16;  // struct RStruct, subfield "as.ary"
 
 pub const RUBY_OFFSET_ROBJECT_AS_ARY:i32 = 16; // struct RObject, subfield "as.ary"
 pub const RUBY_OFFSET_ROBJECT_AS_HEAP_NUMIV:i32 = 16; // struct RObject, subfield "as.heap.numiv"

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -68,10 +68,16 @@ extern "C" {
     pub static mut rb_cBasicObject: VALUE;
 }
 extern "C" {
+    pub static mut rb_cArray: VALUE;
+}
+extern "C" {
     pub static mut rb_cFalseClass: VALUE;
 }
 extern "C" {
     pub static mut rb_cFloat: VALUE;
+}
+extern "C" {
+    pub static mut rb_cHash: VALUE;
 }
 extern "C" {
     pub static mut rb_cInteger: VALUE;
@@ -95,6 +101,9 @@ extern "C" {
     pub static mut rb_cTrueClass: VALUE;
 }
 extern "C" {
+    pub fn rb_ary_store(ary: VALUE, key: ::std::os::raw::c_long, val: VALUE);
+}
+extern "C" {
     pub fn rb_ary_resurrect(ary: VALUE) -> VALUE;
 }
 extern "C" {
@@ -102,6 +111,9 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_hash_new() -> VALUE;
+}
+extern "C" {
+    pub fn rb_hash_aref(hash: VALUE, key: VALUE) -> VALUE;
 }
 extern "C" {
     pub fn rb_hash_aset(hash: VALUE, key: VALUE, val: VALUE) -> VALUE;
@@ -546,6 +558,12 @@ pub struct rb_callinfo {
     pub mid: VALUE,
     pub flag: VALUE,
     pub argc: VALUE,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_call_data {
+    pub ci: *const rb_callinfo,
+    pub cc: *const rb_callcache,
 }
 extern "C" {
     pub fn rb_obj_as_string_result(str_: VALUE, obj: VALUE) -> VALUE;


### PR DESCRIPTION
Port gen_opt_aref, gen_opt_aset, gen_struct_aref and gen_struct_aset.

For now, gen_opt_aref is commented out because it depends on rb_callinfo being a non-opaque struct (fixed by PR #203). That's why this is draft -- can't commit yet.