### PR TITLE
Port most of branch_stub_hit() + two other minor fixes

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -4,6 +4,8 @@
 
 #include "internal.h"
 #include "internal/string.h"
+#include "internal/hash.h"
+#include "internal/variable.h"
 #include "vm_core.h"
 #include "vm_callinfo.h"
 #include "builtin.h"

--- a/yjit.c
+++ b/yjit.c
@@ -448,6 +448,25 @@ rb_get_cfp_sp(struct rb_control_frame_struct *cfp) {
     return cfp->sp;
 }
 
+void
+rb_set_cfp_pc(struct rb_control_frame_struct *cfp, const VALUE *pc)
+{
+    cfp->pc = pc;
+}
+
+void
+rb_set_cfp_sp(struct rb_control_frame_struct *cfp, VALUE *sp)
+{
+    cfp->sp = sp;
+}
+
+rb_iseq_t *
+rb_cfp_get_iseq(struct rb_control_frame_struct *cfp)
+{
+    // TODO(alan) could assert frame type here to make sure that it's a ruby frame with an iseq.
+    return cfp->iseq;
+}
+
 VALUE
 rb_get_cfp_self(struct rb_control_frame_struct *cfp) {
     return cfp->self;
@@ -498,6 +517,26 @@ rb_get_call_data_ci(struct rb_call_data* cd) {
     return cd->ci;
 }
 
+const uint8_t *
+rb_yjit_branch_stub_hit(void *branch_ptr, uint32_t target_idx, rb_execution_context_t *ec)
+{
+    const uint8_t *ret;
+    // Acquire the VM lock and then signal all other Ruby threads (ractors) to
+    // contend for the VM lock, putting them to sleep. YJIT uses this to evict
+    // threads running inside generated code so among other things, it can
+    // safely change memory protection of regions housing generated code.
+    RB_VM_LOCK_ENTER();
+    rb_vm_barrier();
+
+    const uint8_t *rb_yjit_rust_branch_stub_hit(void *branch_ptr, uint32_t target_idx, rb_execution_context_t *ec);
+    ret = rb_yjit_rust_branch_stub_hit(branch_ptr, target_idx, ec);
+
+    // Release the VM lock. Note, watch out for Ruby exceptions and Rust panics
+    // to ensure that the lock is properly released in exceptional situations.
+    RB_VM_LOCK_LEAVE();
+
+    return ret;
+}
 #include "yjit_iface.c"
 
 #endif // if JIT_ENABLED && PLATFORM_SUPPORTED_P

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -150,6 +150,8 @@ fn main() {
         // Opaque types from vm_core.h
         .blocklist_type("rb_execution_context_.*")
         .opaque_type("rb_execution_context_.*")
+        .blocklist_type("rb_control_frame_struct")
+        .opaque_type("rb_control_frame_struct")
 
         // From yjit.c
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")
@@ -160,6 +162,8 @@ fn main() {
         .allowlist_function("rb_yjit_get_page_size")
         .allowlist_function("rb_leaf_invokebuiltin_iseq_p")
         .allowlist_function("rb_leaf_builtin_function")
+        .allowlist_function("rb_set_cfp_(pc|sp)")
+        .allowlist_function("rb_cfp_get_iseq")
 
         // Not sure why it's picking these up, but don't.
         .blocklist_type("FILE")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -742,7 +742,7 @@ pub fn gen_single_block(blockref: &BlockRef, ec: EcPtr, cb: &mut CodeBlock, ocb:
     let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
     let mut insn_idx: c_uint = blockid.idx;
     let starting_insn_idx = insn_idx;
-    let mut ctx = Context::new();
+    let mut ctx = blockref.borrow().get_ctx();
 
     // Initialize a JIT state object
     let mut jit = JITState::new(blockref);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -84,7 +84,7 @@
 
 use std::ffi::CString;
 use std::convert::From;
-use std::os::raw::{c_int, c_uint, c_long, c_char};
+use std::os::raw::{c_int, c_uint, c_long, c_char, c_void};
 
 // We check that we can do this with the configure script and a couple of
 // static asserts. u64 and not usize to play nice with lowering to x86.
@@ -230,6 +230,8 @@ extern "C" {
 
     #[link_name = "rb_METHOD_ENTRY_VISI"]
     pub fn METHOD_ENTRY_VISI(me: * const rb_callable_method_entry_t) -> rb_method_visibility_t;
+
+    pub fn rb_yjit_branch_stub_hit(branch_ptr: *const c_void, target_idx: u32, ec: EcPtr) -> *const c_void;
 
     pub fn rb_str_bytesize(str:VALUE) -> VALUE;
 }

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -556,6 +556,15 @@ extern "C" {
 extern "C" {
     pub fn rb_leaf_builtin_function(iseq: *const rb_iseq_t) -> *const rb_builtin_function;
 }
+extern "C" {
+    pub fn rb_set_cfp_pc(cfp: *mut rb_control_frame_struct, pc: *const VALUE);
+}
+extern "C" {
+    pub fn rb_set_cfp_sp(cfp: *mut rb_control_frame_struct, sp: *mut VALUE);
+}
+extern "C" {
+    pub fn rb_cfp_get_iseq(cfp: *mut rb_control_frame_struct) -> *mut rb_iseq_t;
+}
 #[repr(C)]
 pub struct rb_iv_index_tbl_entry {
     pub index: u32,

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -495,6 +495,21 @@ extern "C" {
 extern "C" {
     pub fn rb_ec_str_resurrect(ec: *mut rb_execution_context_struct, str_: VALUE) -> VALUE;
 }
+extern "C" {
+    pub fn rb_hash_new_with_size(size: st_index_t) -> VALUE;
+}
+extern "C" {
+    pub fn rb_hash_resurrect(hash: VALUE) -> VALUE;
+}
+extern "C" {
+    pub fn rb_obj_ensure_iv_index_mapping(obj: VALUE, id: ID) -> u32;
+}
+extern "C" {
+    pub fn rb_gvar_get(arg1: ID) -> VALUE;
+}
+extern "C" {
+    pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rb_builtin_function {
@@ -552,19 +567,4 @@ pub struct rb_cvar_class_tbl_entry {
     pub index: u32,
     pub global_cvar_state: rb_serial_t,
     pub class_value: VALUE,
-}
-extern "C" {
-    pub fn rb_hash_new_with_size(size: st_index_t) -> VALUE;
-}
-extern "C" {
-    pub fn rb_hash_resurrect(hash: VALUE) -> VALUE;
-}
-extern "C" {
-    pub fn rb_obj_ensure_iv_index_mapping(obj: VALUE, id: ID) -> u32;
-}
-extern "C" {
-    pub fn rb_gvar_get(arg1: ID) -> VALUE;
-}
-extern "C" {
-    pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
 }

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -83,14 +83,3 @@ pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> *con
         None => std::ptr::null()
     }
 }
-
-/// Called from C code when a branch stub is hit
-/// NOTE: this should be wrapped in RB_VM_LOCK_ENTER(), rb_vm_barrier() on the C side
-#[no_mangle]
-pub extern "C" fn rb_yjit_branch_stub_hit(/* branch_t *branch, */ target_idx: u32, ec: EcPtr) -> *const u8
-{
-    // TODO: figure out what to pass instead of a branch pointer?
-
-    // TODO
-    todo!("branch_stub_hit not implemented");
-}


### PR DESCRIPTION
- Re-include some headers for bindgen
- Port most of branch_stub_hit()
- gen_single_block(): Use the starting context from the block

This pushes the most common btest failure to:
```
not yet implemented: gen_direct_jump() unimplemented
```
Progress!
