### PR TITLE
Minor fix to TEST() - allow positive signed 32-bit immediate operands

### DIFF
--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1327,7 +1327,6 @@ pub fn test(cb: &mut CodeBlock, rm_opnd: X86Opnd, test_opnd: X86Opnd) {
         },
         X86Opnd::Imm(imm) => {
             // This mode only applies to 64-bit R/M operands with 32-bit signed immediates
-            assert!(imm.value < 0);
             assert!(imm.num_bits <= 32);
             assert!(rm_num_bits == 64);
 

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -381,6 +381,9 @@ fn test_test() {
     check_bytes("4885c0", |cb| test(cb, RAX, RAX));
     check_bytes("4885f0", |cb| test(cb, RAX, RSI));
     check_bytes("48f74640f7ffffff", |cb| test(cb, mem_opnd(64, RSI, 64), imm_opnd(!0x08)));
+    check_bytes("48f7464008000000", |cb| test(cb, mem_opnd(64, RSI, 64), imm_opnd(0x08)));
+    check_bytes("48f7c108000000", |cb| test(cb, RCX, imm_opnd(0x08)));
+    //check_bytes("48a9f7ffff0f", |cb| test(cb, RAX, imm_opnd(0x0FFFFFF7)));
 }
 
 #[test]


### PR DESCRIPTION
The third test there is commented out because I can't figure out how to get our assembler and yasm to agree. The (failing) bytes there are what I got from yasm for "TEST qword RAX, dword 0x0FFFFFF7".

With this fix applied, "./miniruby --yjit-call-threshold=1 -e 'a=2'" gets to a panic in branch_stub_hit(), which looks like the one that Alan's latest PR is aimed at.