### PR TITLE
BOP assumptions

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1893,7 +1893,7 @@ rb_vm_check_redefinition_opt_method(const rb_method_entry_t *me, VALUE klass)
         if (st_lookup(vm_opt_method_def_table, (st_data_t)me->def, &bop)) {
             int flag = vm_redefinition_check_flag(klass);
             if (flag != 0) {
-                rb_yjit_bop_redefined(klass, me, (enum ruby_basic_operators)bop);
+                rb_yjit_bop_redefined(flag, (enum ruby_basic_operators)bop);
                 ruby_vm_redefined_flag[bop] |= flag;
             }
         }

--- a/yjit.c
+++ b/yjit.c
@@ -537,6 +537,12 @@ rb_yjit_branch_stub_hit(void *branch_ptr, uint32_t target_idx, rb_execution_cont
 
     return ret;
 }
+
+bool
+rb_BASIC_OP_UNREDEFINED_P(enum ruby_basic_operators bop, uint32_t klass) {
+    return BASIC_OP_UNREDEFINED_P(bop, klass);
+}
+
 #include "yjit_iface.c"
 
 #endif // if JIT_ENABLED && PLATFORM_SUPPORTED_P

--- a/yjit.h
+++ b/yjit.h
@@ -52,7 +52,7 @@ void rb_yjit_collect_binding_alloc(void);
 void rb_yjit_collect_binding_set(void);
 bool rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec);
 void rb_yjit_init(void);
-void rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop);
+void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop);
 void rb_yjit_constant_state_changed(void);
 void rb_yjit_iseq_mark(const struct rb_iseq_constant_body *body);
 void rb_yjit_iseq_update_references(const struct rb_iseq_constant_body *body);
@@ -75,7 +75,7 @@ static inline void rb_yjit_collect_binding_alloc(void) {}
 static inline void rb_yjit_collect_binding_set(void) {}
 static inline bool rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec) { return false; }
 static inline void rb_yjit_init(void) {}
-static inline void rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop) {}
+static inline void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop) {}
 static inline void rb_yjit_constant_state_changed(void) {}
 static inline void rb_yjit_iseq_mark(const struct rb_iseq_constant_body *body) {}
 static inline void rb_yjit_iseq_update_references(const struct rb_iseq_constant_body *body) {}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1096,11 +1096,9 @@ fn gen_opt_plus(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: 
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
 
-        /*
-        if (!assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)) {
-            return YJIT_CANT_COMPILE;
+        if !assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_PLUS) {
+            return CantCompile;
         }
-        */
 
         // Check that both operands are fixnums
         guard_two_fixnums(ctx, cb, side_exit);
@@ -2348,11 +2346,9 @@ fn gen_fixnum_cmp(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
 
-        /*
-        if (!assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_LT)) {
+        if !assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_LT) {
             return CantCompile;
         }
-        */
 
         // Check that both operands are fixnums
         guard_two_fixnums(ctx, cb, side_exit);
@@ -2410,12 +2406,10 @@ fn gen_equality_specialized(jit: &mut JITState, ctx: &mut Context, cb: &mut Code
     let b_opnd = ctx.stack_opnd(0);
 
     if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
-        /*
-        if (!assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_EQ)) {
+        if !assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_EQ) {
             // if overridden, emit the generic version
             return false;
         }
-        */
 
         guard_two_fixnums(ctx, cb, side_exit);
 
@@ -2726,11 +2720,9 @@ fn gen_opt_and(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: &
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
 
-        /*
-        if (!assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_AND)) {
+        if !assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_AND) {
             return CantCompile;
         }
-        */
 
         // Check that both operands are fixnums
         guard_two_fixnums(ctx, cb, side_exit);
@@ -2771,11 +2763,9 @@ fn gen_opt_or(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: &m
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
 
-        /*
-        if (!assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_OR)) {
+        if !assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_OR) {
             return CantCompile;
         }
-        */
 
         // Check that both operands are fixnums
         guard_two_fixnums(ctx, cb, side_exit);
@@ -2816,11 +2806,9 @@ fn gen_opt_minus(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb:
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
 
-        /*
-        if (!assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)) {
+        if !assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_MINUS) {
             return CantCompile;
         }
-        */
 
         // Check that both operands are fixnums
         guard_two_fixnums(ctx, cb, side_exit);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -492,12 +492,12 @@ fn get_side_exit(jit: &mut JITState, ocb: &mut OutlinedCb, ctx: &Context) -> Cod
     }
 }
 
-/*
 // Ensure that there is an exit for the start of the block being compiled.
 // Block invalidation uses this exit.
-static void
-jit_ensure_block_entry_exit(jitstate_t *jit)
-{
+pub fn jit_ensure_block_entry_exit(jit: &mut JITState) {
+    todo!();
+
+    /*
     block_t *block = jit->block;
     if (block->entry_exit) return;
 
@@ -511,8 +511,8 @@ jit_ensure_block_entry_exit(jitstate_t *jit)
         uint32_t pos = gen_exit(pc, &block->ctx, ocb);
         block->entry_exit = cb_get_ptr(ocb, pos);
     }
+    */
 }
-*/
 
 // Generate a runtime guard that ensures the PC is at the start of the iseq,
 // otherwise take a side exit.  This is to handle the situation of optional

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1590,7 +1590,7 @@ verify_blockid(const blockid_t blockid)
 */
 
 // Invalidate one specific block version
-fn invalidate_block_version(block: &BlockRef)
+pub fn invalidate_block_version(block: &BlockRef)
 {
     todo!("invalidate_block_version not yet implemented");
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -206,6 +206,9 @@ extern "C" {
     #[link_name = "rb_RB_TYPE_P"]
     pub fn RB_TYPE_P(obj: VALUE, t: ruby_value_type) -> bool;
 
+    #[link_name = "rb_BASIC_OP_UNREDEFINED_P"]
+    pub fn BASIC_OP_UNREDEFINED_P(bop: ruby_basic_operators, klass: u32) -> bool;
+
     // Ruby only defines these in vm_insnhelper.c, not in any header.
     // Parsing it would result in a lot of duplicate definitions.
     pub fn rb_vm_opt_mod(recv: VALUE, obj: VALUE) -> VALUE;

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -90,6 +90,10 @@ use std::os::raw::{c_int, c_uint, c_long, c_char, c_void};
 // static asserts. u64 and not usize to play nice with lowering to x86.
 pub type size_t = u64;
 
+/// A type alias for the redefinition flags coming from CRuby. These are just
+/// shifted 1s but not explicitly an enum.
+pub type RedefinitionFlag = u32;
+
 // Textually include output from rust-bindgen as suggested by its user guide.
 include!("cruby_bindings.inc.rs");
 
@@ -207,7 +211,7 @@ extern "C" {
     pub fn RB_TYPE_P(obj: VALUE, t: ruby_value_type) -> bool;
 
     #[link_name = "rb_BASIC_OP_UNREDEFINED_P"]
-    pub fn BASIC_OP_UNREDEFINED_P(bop: ruby_basic_operators, klass: u32) -> bool;
+    pub fn BASIC_OP_UNREDEFINED_P(bop: ruby_basic_operators, klass: RedefinitionFlag) -> bool;
 
     // Ruby only defines these in vm_insnhelper.c, not in any header.
     // Parsing it would result in a lot of duplicate definitions.

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -4,7 +4,9 @@
 use crate::core::*;
 use crate::cruby::*;
 use crate::codegen::*;
-use crate::yjit::{yjit_enabled_p};
+use crate::stats::*;
+use crate::yjit::yjit_enabled_p;
+use std::collections::HashMap;
 
 // Invariants to track:
 // assume_bop_not_redefined(jit, INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
@@ -12,54 +14,79 @@ use crate::yjit::{yjit_enabled_p};
 // assume_single_ractor_mode(jit)
 // assume_stable_global_constant_state(jit);
 
+/// A type alias for the redefinition flags coming from CRuby. These are just
+/// shifted 1s but not explicitly an enum.
+type RedefinitionFlag = u32;
 
+/// Used to track all of the various block references that contain assumptions
+/// about the state of the virtual machine.
+pub struct Invariants {
+    bops: HashMap<(RedefinitionFlag, ruby_basic_operators), Vec<BlockRef>>
+}
 
+/// Private singleton instance of the invariants global struct.
+static mut INVARIANTS: Option<Invariants> = None;
 
-
-
-// Hash table of BOP blocks
-//static st_table *blocks_assuming_bops;
-
-fn assume_bop_not_redefined(block: &BlockRef, redefined_flag: usize, bop: usize) -> bool
-{
-    todo!();
-
-    // TODO: we'll want to export
-    // BASIC_OP_UNREDEFINED_P(bop, redefined_flag)
-    // from the C side
-
-    /*
-    if (BASIC_OP_UNREDEFINED_P(bop, redefined_flag)) {
-        RUBY_ASSERT(blocks_assuming_bops);
-
-        jit_ensure_block_entry_exit(jit);
-        st_insert(blocks_assuming_bops, (st_data_t)jit->block, 0);
-        return true;
+impl Invariants {
+    pub fn init() {
+        // Wrapping this in unsafe to assign directly to a global.
+        unsafe { INVARIANTS = Some(Invariants { bops: HashMap::new() }); }
     }
-    else {
+
+    /// Get a mutable reference to the codegen globals instance
+    pub fn get_instance() -> &'static mut Invariants {
+        unsafe { INVARIANTS.as_mut().unwrap() }
+    }
+
+    /// Returns the vector of blocks that are currently assuming the given basic
+    /// operator on the given class has not been redefined.
+    pub fn get_bop_assumptions(klass: RedefinitionFlag, bop: ruby_basic_operators) -> &'static mut Vec<BlockRef> {
+        Invariants::get_instance().bops.entry((klass, bop)).or_insert(Vec::new())
+    }
+}
+
+/// A public function that can be called from within the code generation
+/// functions to ensure that the block being generated is invalidated when the
+/// basic operator is redefined.
+pub fn assume_bop_not_redefined(jit: &mut JITState, klass: RedefinitionFlag, bop: ruby_basic_operators) -> bool {
+    if unsafe { BASIC_OP_UNREDEFINED_P(bop, klass) } {
+        jit_ensure_block_entry_exit(jit);
+        Invariants::get_bop_assumptions(klass, bop).push(jit.get_block());
+        return true;
+    } else {
         return false;
     }
-    */
 }
 
-/*
-/// Called when a basic operation is redefined
-void
-rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop)
-{
-    if (blocks_assuming_bops) {
-#if YJIT_STATS
-        yjit_runtime_counters.invalidate_bop_redefined += blocks_assuming_bops->num_entries;
-#endif
-
-        st_foreach(blocks_assuming_bops, block_set_invalidate_i, 0);
+/// Called when a basic operation is redefined.
+#[no_mangle]
+pub extern "C" fn rb_yjit_bop_redefined(klass: RedefinitionFlag, bop: ruby_basic_operators) {
+    for block in Invariants::get_bop_assumptions(klass, bop).iter() {
+        invalidate_block_version(block);
+        incr_counter!(invalidate_bop_redefined);
     }
 }
-*/
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    #[test]
+    fn test_get_bop_assumptions() {
+        Invariants::init();
 
+        let block = Block::new(BLOCKID_NULL, &Context::default());
+        let bops = &mut Invariants::get_instance().bops;
 
+        // Configure the set of assumptions such that one block is assuming
+        // Integer#+ is not redefined and one block is assuming String#+ is not
+        // redefined.
+        bops.insert((INTEGER_REDEFINED_OP_FLAG, BOP_PLUS), vec![block.clone()]);
+        bops.insert((STRING_REDEFINED_OP_FLAG, BOP_PLUS), vec![block.clone()]);
+
+        assert_eq!(Invariants::get_bop_assumptions(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS).len(), 1);
+    }
+}
 
 
 

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -14,10 +14,6 @@ use std::collections::HashMap;
 // assume_single_ractor_mode(jit)
 // assume_stable_global_constant_state(jit);
 
-/// A type alias for the redefinition flags coming from CRuby. These are just
-/// shifted 1s but not explicitly an enum.
-type RedefinitionFlag = u32;
-
 /// Used to track all of the various block references that contain assumptions
 /// about the state of the virtual machine.
 pub struct Invariants {

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -1,6 +1,7 @@
 use crate::cruby::{EcPtr, IseqPtr};
 use crate::codegen::*;
 use crate::core::*;
+use crate::invariants::*;
 use crate::options::*;
 
 use std::sync::atomic::{AtomicBool,Ordering};
@@ -53,12 +54,8 @@ pub extern "C" fn rb_yjit_init_rust()
     // TODO: set a panic handler so the we don't print a message
     //       everytime we panic.
     let result = std::panic::catch_unwind(|| {
-
         CodegenGlobals::init();
-
-
-        // TODO:
-        //Invariants::init() ?
+        Invariants::init();
 
         YJIT_ENABLED.store(true, Ordering::Release);
     });

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -371,19 +371,6 @@ iseq_end_index(VALUE self)
 }
 */
 
-/* Called when a basic operation is redefined */
-void
-rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop)
-{
-    if (blocks_assuming_bops) {
-#if YJIT_STATS
-        yjit_runtime_counters.invalidate_bop_redefined += blocks_assuming_bops->num_entries;
-#endif
-
-        st_foreach(blocks_assuming_bops, block_set_invalidate_i, 0);
-    }
-}
-
 /* Called when the constant state changes */
 void
 rb_yjit_constant_state_changed(void)


### PR DESCRIPTION
Effectively this PR implements `assume_bop_not_redefined`. It adds a global `Invariants` struct that tracks the basic operation assumptions, adds them whenever `assume_bop_not_redefined` is called, and invalidates them whenever `rb_yjit_bop_redefined` is called.