### PR TITLE
Add .as_usize() for better numeric casting

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1417,7 +1417,7 @@ fn gen_newarray(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: 
     lea(cb, C_ARG_REGS[2], values_ptr);
     call_ptr(cb, REG0, rb_ec_ary_new_from_values as *const u8);
 
-    ctx.stack_pop(n.usize());
+    ctx.stack_pop(n.as_usize());
     let stack_ret = ctx.stack_push(Type::Array);
     mov(cb, stack_ret, RAX);
 
@@ -1630,7 +1630,7 @@ fn gen_getlocal_wc0(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, o
     mov(cb, REG0, mem_opnd(64, REG0, offs));
 
     // Write the local at SP
-    let stack_top = ctx.stack_push_local(local_idx.usize());
+    let stack_top = ctx.stack_push_local(local_idx.as_usize());
     mov(cb, stack_top, REG0);
 
     KeepCompiling
@@ -1723,7 +1723,7 @@ fn gen_setlocal_wc0(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, o
     */
 
     let slot_idx = jit_get_arg(jit, 0).as_i32();
-    let local_idx = slot_to_local_idx(jit.get_iseq(), slot_idx).usize();
+    let local_idx = slot_to_local_idx(jit.get_iseq(), slot_idx).as_usize();
 
     // Load environment pointer EP (level 0) from CFP
     gen_get_ep(cb, REG0, 0);
@@ -2044,7 +2044,7 @@ fn gen_get_ivar(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: 
     // FIXME: Mapping the index could fail when there is too many ivar names. If we're
     // compiling for a branch stub that can cause the exception to be thrown from the
     // wrong PC.
-    let ivar_index:usize = unsafe { rb_obj_ensure_iv_index_mapping(comptime_receiver, ivar_name) }.usize();
+    let ivar_index:usize = unsafe { rb_obj_ensure_iv_index_mapping(comptime_receiver, ivar_name) }.as_usize();
 
     // Pop receiver if it's on the temp stack
     if reg0_opnd != InsnOpnd::SelfOpnd {
@@ -5232,7 +5232,7 @@ impl CodegenGlobals {
 
         #[cfg(not(test))]
         let (mut cb, mut ocb) = {
-            let page_size = unsafe { rb_yjit_get_page_size() }.usize();
+            let page_size = unsafe { rb_yjit_get_page_size() }.as_usize();
             let mem_block: *mut u8 = unsafe { alloc_exec_mem(mem_size.try_into().unwrap()) };
             let cb = CodeBlock::new(mem_block, mem_size / 2, page_size);
             let ocb = OutlinedCb::wrap(CodeBlock::new(unsafe { mem_block.add(mem_size / 2) }, mem_size / 2, page_size));

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5,6 +5,7 @@ use crate::core::*;
 use crate::invariants::*;
 use crate::options::*;
 use crate::stats::*;
+use crate::utils::IntoUsize;
 use InsnOpnd::*;
 use CodegenStatus::*;
 
@@ -769,7 +770,7 @@ pub fn gen_single_block(blockref: &BlockRef, ec: EcPtr, cb: &mut CodeBlock, ocb:
 
         // Set the current instruction
         jit.insn_idx = insn_idx;
-        jit.opcode = opcode.try_into().unwrap();
+        jit.opcode = opcode;
         jit.pc = pc;
         jit.side_exit_for_pc = None;
 
@@ -1416,7 +1417,7 @@ fn gen_newarray(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: 
     lea(cb, C_ARG_REGS[2], values_ptr);
     call_ptr(cb, REG0, rb_ec_ary_new_from_values as *const u8);
 
-    ctx.stack_pop(n as usize);
+    ctx.stack_pop(n.usize());
     let stack_ret = ctx.stack_push(Type::Array);
     mov(cb, stack_ret, RAX);
 
@@ -1629,7 +1630,7 @@ fn gen_getlocal_wc0(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, o
     mov(cb, REG0, mem_opnd(64, REG0, offs));
 
     // Write the local at SP
-    let stack_top = ctx.stack_push_local(local_idx.try_into().unwrap());
+    let stack_top = ctx.stack_push_local(local_idx.usize());
     mov(cb, stack_top, REG0);
 
     KeepCompiling
@@ -1722,7 +1723,7 @@ fn gen_setlocal_wc0(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, o
     */
 
     let slot_idx = jit_get_arg(jit, 0).as_i32();
-    let local_idx = slot_to_local_idx(jit.get_iseq(), slot_idx) as usize;
+    let local_idx = slot_to_local_idx(jit.get_iseq(), slot_idx).usize();
 
     // Load environment pointer EP (level 0) from CFP
     gen_get_ep(cb, REG0, 0);
@@ -2043,7 +2044,7 @@ fn gen_get_ivar(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, ocb: 
     // FIXME: Mapping the index could fail when there is too many ivar names. If we're
     // compiling for a branch stub that can cause the exception to be thrown from the
     // wrong PC.
-    let ivar_index:usize = unsafe { rb_obj_ensure_iv_index_mapping(comptime_receiver, ivar_name) } as usize;
+    let ivar_index:usize = unsafe { rb_obj_ensure_iv_index_mapping(comptime_receiver, ivar_name) }.usize();
 
     // Pop receiver if it's on the temp stack
     if reg0_opnd != InsnOpnd::SelfOpnd {
@@ -5231,7 +5232,7 @@ impl CodegenGlobals {
 
         #[cfg(not(test))]
         let (mut cb, mut ocb) = {
-            let page_size = unsafe { rb_yjit_get_page_size().try_into().unwrap() };
+            let page_size = unsafe { rb_yjit_get_page_size() }.usize();
             let mem_block: *mut u8 = unsafe { alloc_exec_mem(mem_size.try_into().unwrap()) };
             let cb = CodeBlock::new(mem_block, mem_size / 2, page_size);
             let ocb = OutlinedCb::wrap(CodeBlock::new(unsafe { mem_block.add(mem_size / 2) }, mem_size / 2, page_size));

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -7,6 +7,7 @@ use crate::asm::x86_64::*;
 use crate::codegen::*;
 use crate::options::*;
 use crate::stats::*;
+use crate::utils::IntoUsize;
 use InsnOpnd::*;
 use TempMapping::*;
 use core::ffi::{c_void};
@@ -380,7 +381,7 @@ fn get_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload
 fn get_version_list(blockid: BlockId) -> &'static mut VersionList
 {
     let payload = get_iseq_payload(blockid.iseq);
-    let insn_idx = blockid.idx as usize;
+    let insn_idx = blockid.idx.usize();
 
     // Expand the version map as necessary
     if insn_idx >= payload.version_map.len() {
@@ -393,7 +394,7 @@ fn get_version_list(blockid: BlockId) -> &'static mut VersionList
 // Count the number of block versions matching a given blockid
 fn get_num_versions(blockid: BlockId) -> usize
 {
-    let insn_idx = blockid.idx as usize;
+    let insn_idx = blockid.idx.usize();
     let payload = get_iseq_payload(blockid.iseq);
 
     payload.version_map.get(insn_idx).map(|versions| versions.len()).unwrap_or(0)
@@ -633,7 +634,7 @@ impl Context {
             return self.stack_push_mapping((mapping, Type::Unknown));
         }
 
-        let stack_size = self.stack_size as usize;
+        let stack_size: usize = self.stack_size.into();
 
         // Keep track of the type and mapping of the value
         if stack_size < MAX_TEMP_TYPES {
@@ -690,7 +691,7 @@ impl Context {
 
         // Clear the types of the popped values
         for i in 0..n {
-            let idx = ((self.stack_size as usize) - i - 1) as usize;
+            let idx: usize = (self.stack_size as usize) - i - 1;
 
             if idx < MAX_TEMP_TYPES {
                 self.temp_types[idx] = Type::Unknown;
@@ -723,7 +724,7 @@ impl Context {
             StackOpnd(idx) => {
                 let idx = idx as u16;
                 assert!(idx < self.stack_size);
-                let stack_idx = (self.stack_size - 1 - idx) as usize;
+                let stack_idx: usize = (self.stack_size - 1 - idx).into();
 
                 // If outside of tracked range, do nothing
                 if stack_idx >= MAX_TEMP_TYPES {
@@ -1231,7 +1232,7 @@ pub extern "C" fn rb_yjit_rust_branch_stub_hit(branch_ptr: *const c_void, target
 
     let branch_size_on_entry = branch.code_size();
 
-    let target_idx: usize = target_idx as usize;
+    let target_idx: usize = target_idx.usize();
     let target = branch.targets[target_idx];
     let target_ctx = branch.target_ctxs[target_idx];
 
@@ -1376,7 +1377,7 @@ fn get_branch_target(
         // Add an incoming branch for this version
         block.incoming.push(branchref.clone());
         let mut branch = branchref.borrow_mut();
-        branch.blocks[target_idx as usize] = Some(blockref.clone());
+        branch.blocks[target_idx.usize()] = Some(blockref.clone());
 
         // Return a pointer to the compiled code for the block
         return block.start_addr.unwrap();

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -381,7 +381,7 @@ fn get_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload
 fn get_version_list(blockid: BlockId) -> &'static mut VersionList
 {
     let payload = get_iseq_payload(blockid.iseq);
-    let insn_idx = blockid.idx.usize();
+    let insn_idx = blockid.idx.as_usize();
 
     // Expand the version map as necessary
     if insn_idx >= payload.version_map.len() {
@@ -394,7 +394,7 @@ fn get_version_list(blockid: BlockId) -> &'static mut VersionList
 // Count the number of block versions matching a given blockid
 fn get_num_versions(blockid: BlockId) -> usize
 {
-    let insn_idx = blockid.idx.usize();
+    let insn_idx = blockid.idx.as_usize();
     let payload = get_iseq_payload(blockid.iseq);
 
     payload.version_map.get(insn_idx).map(|versions| versions.len()).unwrap_or(0)
@@ -1232,7 +1232,7 @@ pub extern "C" fn rb_yjit_rust_branch_stub_hit(branch_ptr: *const c_void, target
 
     let branch_size_on_entry = branch.code_size();
 
-    let target_idx: usize = target_idx.usize();
+    let target_idx: usize = target_idx.as_usize();
     let target = branch.targets[target_idx];
     let target_ctx = branch.target_ctxs[target_idx];
 
@@ -1377,7 +1377,7 @@ fn get_branch_target(
         // Add an incoming branch for this version
         block.incoming.push(branchref.clone());
         let mut branch = branchref.borrow_mut();
-        branch.blocks[target_idx.usize()] = Some(blockref.clone());
+        branch.blocks[target_idx.as_usize()] = Some(blockref.clone());
 
         // Return a pointer to the compiled code for the block
         return block.start_addr.unwrap();

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1256,7 +1256,7 @@ pub extern "C" fn rb_yjit_rust_branch_stub_hit(branch_ptr: *const c_void, target
         let original_interp_sp = get_cfp_sp(cfp);
 
         let reconned_pc = rb_iseq_pc_at_idx(rb_cfp_get_iseq(cfp), target.idx);
-        let reconned_sp = original_interp_sp.add(target_ctx.sp_offset as usize);
+        let reconned_sp = original_interp_sp.offset(target_ctx.sp_offset.into());
 
         // Update the PC in the current CFP, because it may be out of sync in JITted code
         rb_set_cfp_pc(cfp, reconned_pc);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -24,7 +24,7 @@
 //! You might be wondering about why this is different from the [FFI example]
 //! in the Nomicon, an official book about Unsafe Rust.
 //!
-//! There is no #[link] attribute because we are not linking against an external
+//! There is no `#[link]` attribute because we are not linking against an external
 //! library, but rather implicitly asserting that we'll supply a concrete definition
 //! for all C functions we call, similar to how pure C projects put functions
 //! across different compilation units and link them together.
@@ -262,7 +262,7 @@ pub fn get_ruby_vm_frozen_core() -> VALUE
 }
 
 /// Opaque iseq type for opaque iseq pointers from vm_core.h
-/// See: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
+/// See: <https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs>
 #[repr(C)]
 pub struct rb_iseq_t {
     _data: [u8; 0],

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -1,32 +1,47 @@
-/// Trait for casting [u32] and [u64] to [usize] that allows you to say `.usize()`.
+/// Trait for casting to [usize] that allows you to say `.as_usize()`.
 /// Implementation conditional on the the cast preserving the numeric value on
-/// all inputs, like on x86_64 and ARM64.
+/// all inputs and being inexpensive.
 ///
 /// [usize] is only guaranteed to be more than 16-bit wide, so we can't use
-/// we can't use `.into()` to cast an `u32` or an `u64` to a `usize` even
-/// though in all the platforms YJIT supports these two casts are pretty much
-/// no-ops. We could say `as usize` or `try_convert().unwrap()` everywhere
+/// `.into()` to cast an `u32` or an `u64` to a `usize` even though in all
+/// the platforms YJIT supports these two casts are pretty much no-ops.
+/// We could say `as usize` or `.try_convert().unwrap()` everywhere
 /// for those casts but they both have undesirable consequences if and when
-/// we decide to support 32-bit platforms. They are also more verbose than
-/// saying `.usize()`. Unfortunately we can't implement [::core::convert::From]
-/// for [usize] since both the trait and the type are external 😞. Naming
-/// the conversion method `into()` also runs into naming conflicts.
+/// we decide to support 32-bit platforms. Unfortunately we can't implement
+/// [::core::convert::From] for [usize] since both the trait and the type are
+/// external 😞. Naming the method `into()` also runs into naming conflicts.
 pub(crate) trait IntoUsize {
     /// Convert to usize. Implementation conditional on width of [usize].
-    fn usize(self) -> usize;
+    fn as_usize(self) -> usize;
 }
 
 #[cfg(target_pointer_width = "64")]
 impl IntoUsize for u64 {
-    fn usize(self) -> usize {
+    fn as_usize(self) -> usize {
         self as usize
     }
 }
 
 #[cfg(target_pointer_width = "64")]
 impl IntoUsize for u32 {
-    fn usize(self) -> usize {
+    fn as_usize(self) -> usize {
         self as usize
+    }
+}
+
+impl IntoUsize for u16 {
+    /// Alias for `.into()`. For convenience so you could use the trait for
+    /// all unsgined types.
+    fn as_usize(self) -> usize {
+        self.into()
+    }
+}
+
+impl IntoUsize for u8 {
+    /// Alias for `.into()`. For convenience so you could use the trait for
+    /// all unsgined types.
+    fn as_usize(self) -> usize {
+        self.into()
     }
 }
 
@@ -36,14 +51,14 @@ mod tests {
     fn min_max_preserved_after_cast_to_usize() {
         use crate::utils::IntoUsize;
 
-        let min:usize = u64::MIN.usize();
+        let min:usize = u64::MIN.as_usize();
         assert_eq!(min, u64::MIN.try_into().unwrap());
-        let max:usize = u64::MAX.usize();
+        let max:usize = u64::MAX.as_usize();
         assert_eq!(max, u64::MAX.try_into().unwrap());
 
-        let min:usize = u32::MIN.usize();
+        let min:usize = u32::MIN.as_usize();
         assert_eq!(min, u32::MIN.try_into().unwrap());
-        let max:usize = u32::MAX.usize();
+        let max:usize = u32::MAX.as_usize();
         assert_eq!(max, u32::MAX.try_into().unwrap());
     }
 }

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -8,7 +8,7 @@ use std::os::raw;
 
 /// For tracking whether the user enabled YJIT through command line arguments or environment
 /// variables. AtomicBool to avoid `unsafe`. On x86 it compiles to simple movs.
-/// See https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
+/// See <https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html>
 /// See [rb_yjit_enabled_p]
 static YJIT_ENABLED: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
- Introduce .usize() for casting convenience. implemented for u32 and u64 for now. For u8 and u16 we can use the builtin `.into()`. See doc comment for details.
- Fix incorrect `as usize` cast
