### PR TITLE
Leave c_method_tracing_currently_enabled in C, port gen_full_cfunc_return

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -196,6 +196,8 @@ fn main() {
         .allowlist_function("rb_set_cfp_(pc|sp)")
         .allowlist_function("rb_cfp_get_iseq")
         .allowlist_function("rb_yjit_multi_ractor_p")
+        .allowlist_function("rb_c_method_tracing_currently_enabled")
+        .allowlist_function("rb_full_cfunc_return")
 
         // Not sure why it's picking these up, but don't.
         .blocklist_type("FILE")

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -340,6 +340,8 @@ pub struct rb_execution_context_struct {
     _marker:
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
+/// Alias for rb_execution_context_struct used by CRuby sometimes
+pub type rb_execution_context_t = rb_execution_context_struct;
 
 /// Pointer to an execution context (rb_execution_context_struct)
 pub type EcPtr = *const rb_execution_context_struct;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -645,6 +645,12 @@ extern "C" {
     pub fn rb_yjit_get_page_size() -> u32;
 }
 extern "C" {
+    pub fn rb_c_method_tracing_currently_enabled(ec: *mut rb_execution_context_t) -> bool;
+}
+extern "C" {
+    pub fn rb_full_cfunc_return(ec: *mut rb_execution_context_t, return_value: VALUE);
+}
+extern "C" {
     pub fn rb_iseq_get_yjit_payload(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {


### PR DESCRIPTION
The PR fixes a couple of consecutive panics. With it I can call a trivial function: ./miniruby --yjit-call-threshold=1 -e "def main; puts 'bob'; end; main"

I've left full_cfunc_return in C since it's also basically all-C-no-Rust.