### PR TITLE
Take VM lock from Rust side. Move branch_stub_hit() to Rust

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -658,8 +658,9 @@ rb_RSTRUCT_SET(VALUE st, int k, VALUE v)
     RSTRUCT_SET(st, k, v);
 }
 
-const struct rb_callinfo*
-rb_get_call_data_ci(struct rb_call_data* cd) {
+const struct rb_callinfo *
+rb_get_call_data_ci(struct rb_call_data *cd)
+{
     return cd->ci;
 }
 
@@ -685,7 +686,8 @@ rb_yjit_branch_stub_hit(void *branch_ptr, uint32_t target_idx, rb_execution_cont
 }
 
 bool
-rb_BASIC_OP_UNREDEFINED_P(enum ruby_basic_operators bop, uint32_t klass) {
+rb_BASIC_OP_UNREDEFINED_P(enum ruby_basic_operators bop, uint32_t klass)
+{
     return BASIC_OP_UNREDEFINED_P(bop, klass);
 }
 

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -202,6 +202,8 @@ fn main() {
         .allowlist_function("rb_yjit_multi_ractor_p")
         .allowlist_function("rb_c_method_tracing_currently_enabled")
         .allowlist_function("rb_full_cfunc_return")
+        .allowlist_function("rb_yjit_vm_lock_then_barrier")
+        .allowlist_function("rb_yjit_vm_unlock")
 
         // Not sure why it's picking these up, but don't.
         .blocklist_type("FILE")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -684,3 +684,12 @@ extern "C" {
 extern "C" {
     pub fn rb_yjit_multi_ractor_p() -> bool;
 }
+extern "C" {
+    pub fn rb_yjit_vm_lock_then_barrier(
+        file: *const ::std::os::raw::c_char,
+        line: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
+    pub fn rb_yjit_vm_unlock(file: *const ::std::os::raw::c_char, line: ::std::os::raw::c_int);
+}


### PR DESCRIPTION
A lot of APIs we expose in yjit.h need the VM lock for ractor support
so being able to take the lock from the Rust side will be helpful.

Defining branch_stub_hit() in Rust lets us use LLVM to generate
a function with the SysV calling convention even on Windows. It's only
called from generated code so this keeps the generator portable.
