### PR TITLE
Fix wrong offset for RStruct.as.ary

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2837,3 +2837,18 @@ assert_equal '', %q{
   foo
   foo
 }
+
+# Make sure we're correctly reading RStruct's as.ary union for embedded RStructs
+assert_equal '3,12', %q{
+  pt_struct = Struct.new(:x, :y)
+  p = pt_struct.new(3, 12)
+  def pt_inspect(pt)
+    "#{pt.x},#{pt.y}"
+  end
+
+  # Make sure pt_inspect is JITted
+  10.times { pt_inspect(p) }
+
+  # Make sure it's returning '3,12' instead of e.g. '3,false'
+  pt_inspect(p)
+}

--- a/bootstraptest/test_yjit_rust_port.rb
+++ b/bootstraptest/test_yjit_rust_port.rb
@@ -313,3 +313,18 @@ assert_equal '2022', %q{
 
   contrivance(special_missing, :binding)
 }
+
+# Make sure we're correctly reading RStruct's as.ary union for embedded RStructs
+assert_equal '3,12', %q{
+  pt_struct = Struct.new(:x, :y)
+  p = pt_struct.new(3, 12)
+  def pt_inspect(pt)
+    "#{pt.x},#{pt.y}"
+  end
+
+  # Make sure pt_inspect is JITted
+  10.times { pt_inspect(p) }
+
+  # Make sure it's returning '3,12' instead of e.g. '3,false'
+  pt_inspect(p)
+}

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -758,7 +758,7 @@ pub const RUBY_OFFSET_RARRAY_AS_HEAP_PTR:i32 = 32;  // struct RArray, subfield "
 pub const RUBY_OFFSET_RARRAY_AS_ARY:i32 = 16; // struct RArray, subfield "as.ary"
 
 pub const RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR:i32 = 24;  // struct RStruct, subfield "as.heap.ptr"
-pub const RUBY_OFFSET_RSTRUCT_AS_ARY:i32 = 24; // struct RStruct, subfield "as.ary"
+pub const RUBY_OFFSET_RSTRUCT_AS_ARY:i32 = 16; // struct RStruct, subfield "as.ary"
 
 pub const RUBY_OFFSET_ROBJECT_AS_ARY:i32 = 16; // struct RObject, subfield "as.ary"
 pub const RUBY_OFFSET_ROBJECT_AS_HEAP_NUMIV:i32 = 16; // struct RObject, subfield "as.heap.numiv"


### PR DESCRIPTION
Fixes https://github.com/Shopify/ruby/issues/233