### PR TITLE
Port global invalidation

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -3,6 +3,7 @@
 // in headers and prefixing function names.
 
 #include "internal.h"
+#include "internal/sanitizers.h"
 #include "internal/string.h"
 #include "internal/hash.h"
 #include "internal/variable.h"
@@ -94,28 +95,6 @@ rb_yjit_mark_executable(void *mem_block, uint32_t mem_size) {
         abort();
     }
 }
-
-// TODO: not yet ported
-/*
-void rb_yjit_mark_position_writeable(codeblock_t * cb, uint32_t write_pos)
-{
-#ifdef _WIN32
-    uint32_t pagesize = 0x1000; // 4KB
-#else
-    uint32_t pagesize = (uint32_t)sysconf(_SC_PAGESIZE);
-#endif
-    uint32_t aligned_position = (write_pos / pagesize) * pagesize;
-
-    if (cb->current_aligned_write_pos != aligned_position) {
-        cb->current_aligned_write_pos = aligned_position;
-        void *const page_addr = cb_get_ptr(cb, aligned_position);
-        if (mprotect(page_addr, pagesize, PROT_READ | PROT_WRITE)) {
-            fprintf(stderr, "Couldn't make JIT page (%p) writeable, errno: %s", page_addr, strerror(errno));
-            abort();
-        }
-    }
-}
-*/
 
 uint32_t
 rb_yjit_get_page_size(void)
@@ -289,13 +268,20 @@ void *
 rb_iseq_get_yjit_payload(const rb_iseq_t *iseq)
 {
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
-    return iseq->body->yjit_payload;
+    if (iseq->body) {
+        return iseq->body->yjit_payload;
+    }
+    else {
+        // Body is NULL when constructing the iseq.
+        return NULL;
+    }
 }
 
 void
 rb_iseq_set_yjit_payload(const rb_iseq_t *iseq, void *payload)
 {
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
+    RUBY_ASSERT_ALWAYS(iseq->body);
     RUBY_ASSERT_ALWAYS(NULL == iseq->body->yjit_payload);
     iseq->body->yjit_payload = payload;
 }
@@ -713,6 +699,35 @@ rb_assert_cme_handle(VALUE handle)
 {
     RUBY_ASSERT_ALWAYS(rb_objspace_markable_object_p(handle));
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(handle, imemo_ment));
+}
+
+typedef void (*iseq_callback)(const rb_iseq_t *);
+
+// Heap-walking callback for rb_yjit_for_each_iseq().
+static int
+for_each_iseq_i(void *vstart, void *vend, size_t stride, void *data)
+{
+    const iseq_callback callback = (iseq_callback)data;
+    VALUE v = (VALUE)vstart;
+    for (; v != (VALUE)vend; v += stride) {
+        void *ptr = asan_poisoned_object_p(v);
+        asan_unpoison_object(v, false);
+
+        if (rb_obj_is_iseq(v)) {
+            rb_iseq_t *iseq = (rb_iseq_t *)v;
+            callback(iseq);
+        }
+
+        asan_poison_object_if(ptr, v);
+    }
+    return 0;
+}
+
+// Iterate through the whole GC heap and invoke a callback for each iseq.
+void
+rb_yjit_for_each_iseq(iseq_callback callback)
+{
+    rb_objspace_each_objects(for_each_iseq_i, (void *)callback);
 }
 
 // Acquire the VM lock and then signal all other Ruby threads (ractors) to

--- a/yjit.c
+++ b/yjit.c
@@ -724,6 +724,7 @@ for_each_iseq_i(void *vstart, void *vend, size_t stride, void *data)
 }
 
 // Iterate through the whole GC heap and invoke a callback for each iseq.
+// Used for global code invalidation.
 void
 rb_yjit_for_each_iseq(iseq_callback callback)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -209,6 +209,7 @@ fn main() {
         .allowlist_function("rb_assert_(iseq|cme)_handle")
         .allowlist_function("rb_iseq_reset_jit_func")
         .allowlist_function("rb_yjit_dump_iseq_loc")
+        .allowlist_function("rb_yjit_for_each_iseq")
 
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -196,9 +196,6 @@ impl CodeBlock
         // doing bad accesses with it.
         assert!(pos < self.mem_size);
         self.write_pos = pos;
-
-        // Clear the error flag to allow checking for new errors.
-        self.dropped_bytes = false;
     }
 
     // Align the current write pointer to a multiple of bytes

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -196,6 +196,9 @@ impl CodeBlock
         // doing bad accesses with it.
         assert!(pos < self.mem_size);
         self.write_pos = pos;
+
+        // Clear the error flag to allow checking for new errors.
+        self.dropped_bytes = false;
     }
 
     // Align the current write pointer to a multiple of bytes
@@ -233,8 +236,7 @@ impl CodeBlock
 
     // Get a direct pointer to the current write position
     pub fn get_write_ptr(&mut self) -> CodePtr {
-         self.get_ptr(self.write_pos)
-
+        self.get_ptr(self.write_pos)
     }
 
     // Write a single byte at the current position

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -341,7 +341,7 @@ type VersionList = Vec<BlockRef>;
 
 /// Map from iseq indices to lists of versions for that given blockid
 /// An instance of this is stored on each iseq
-pub type VersionMap = Vec<VersionList>;
+type VersionMap = Vec<VersionList>;
 
 impl BlockRef {
     /// Constructor
@@ -396,9 +396,13 @@ pub struct IseqPayload
 }
 
 impl IseqPayload {
-    // Empty the version map on the payload and return it
-    pub fn take_version_map(&mut self) -> VersionMap {
-        mem::take(&mut self.version_map)
+    /// Remove all block versions from the payload and then return them as an iterator
+    pub fn clear_all_blocks(&mut self) -> impl Iterator<Item = BlockRef> {
+        // Empty the blocks
+        let version_map = mem::take(&mut self.version_map);
+
+        // Turn it into an iterator that owns the blocks and return
+        version_map.into_iter().flat_map(|versions| versions)
     }
 }
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -397,7 +397,7 @@ pub struct IseqPayload
 
 impl IseqPayload {
     /// Remove all block versions from the payload and then return them as an iterator
-    pub fn clear_all_blocks(&mut self) -> impl Iterator<Item = BlockRef> {
+    pub fn take_all_blocks(&mut self) -> impl Iterator<Item = BlockRef> {
         // Empty the blocks
         let version_map = mem::take(&mut self.version_map);
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -760,6 +760,10 @@ extern "C" {
 extern "C" {
     pub fn rb_assert_cme_handle(handle: VALUE);
 }
+pub type iseq_callback = ::std::option::Option<unsafe extern "C" fn(arg1: *const rb_iseq_t)>;
+extern "C" {
+    pub fn rb_yjit_for_each_iseq(callback: iseq_callback);
+}
 extern "C" {
     pub fn rb_yjit_vm_lock_then_barrier(
         file: *const ::std::os::raw::c_char,

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -416,7 +416,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all()
                 //
                 // Empty all blocks on the iseq so we don't compile new blocks that jump to the
                 // invalidated region.
-                let blocks = payload.clear_all_blocks();
+                let blocks = payload.take_all_blocks();
                 for blockref in blocks {
                     block_assumptions_free(&blockref);
                 }

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -416,11 +416,9 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all()
                 //
                 // Empty all blocks on the iseq so we don't compile new blocks that jump to the
                 // invalidated region.
-                let version_map = payload.take_version_map();
-                for versions in &version_map {
-                    for blockref in versions {
-                        block_assumptions_free(&blockref);
-                    }
+                let blocks = payload.clear_all_blocks();
+                for blockref in blocks {
+                    block_assumptions_free(&blockref);
                 }
             }
 

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -397,87 +397,58 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all()
         return;
     }
 
-    todo!("rb_yjit_tracing_invalidate_all");
-/*
+    use crate::asm::x86_64::jmp_ptr;
+
     // Stop other ractors since we are going to patch machine code.
-    RB_VM_LOCK_ENTER();
-    rb_vm_barrier();
+    with_vm_lock(src_loc!(), || {
+        // Make it so all live block versions are no longer valid branch targets
+        unsafe { rb_yjit_for_each_iseq(Some(invalidate_all_blocks_for_tracing)) };
 
-    // Make it so all live block versions are no longer valid branch targets
-    rb_objspace_each_objects(tracing_invalidate_all_i, NULL);
+        extern "C" fn invalidate_all_blocks_for_tracing(iseq: IseqPtr) {
+            if let Some(payload) = unsafe { load_iseq_payload(iseq) } {
+                // C comment:
+                //   Leaking the blocks for now since we might have situations where
+                //   a different ractor is waiting for the VM lock in branch_stub_hit().
+                //   If we free the block that ractor can wake up with a dangling block.
+                //
+                // Deviation: since we ref count the the blocks now, we might be deallocating and
+                //   not leak the block.
+                //
+                // Empty all blocks on the iseq so we don't compile new blocks that jump to the
+                // invalidated region.
+                let version_map = payload.take_version_map();
+                for versions in &version_map {
+                    for blockref in versions {
+                        block_assumptions_free(&blockref);
+                    }
+                }
+            }
 
-    // Apply patches
-    const uint32_t old_pos = cb->write_pos;
-    rb_darray_for(global_inval_patches, patch_idx) {
-        struct codepage_patch patch = rb_darray_get(global_inval_patches, patch_idx);
-        cb.set_pos(patch.inline_patch_pos);
-        uint8_t *jump_target = cb_get_ptr(ocb, patch.outlined_target_pos);
-        jmp_ptr(cb, jump_target);
-    }
-    cb.set_pos(old_pos);
-
-    // Freeze invalidated part of the codepage. We only want to wait for
-    // running instances of the code to exit from now on, so we shouldn't
-    // change the code. There could be other ractors sleeping in
-    // branch_stub_hit(), for example. We could harden this by changing memory
-    // protection on the frozen range.
-    RUBY_ASSERT_ALWAYS(yjit_codepage_frozen_bytes <= old_pos && "frozen bytes should increase monotonically");
-    yjit_codepage_frozen_bytes = old_pos;
-
-    cb_mark_all_executable(ocb);
-    cb_mark_all_executable(cb);
-    RB_VM_LOCK_LEAVE();
-*/
-}
-
-/*
-static int
-tracing_invalidate_all_i(void *vstart, void *vend, size_t stride, void *data)
-{
-    VALUE v = (VALUE)vstart;
-    for (; v != (VALUE)vend; v += stride) {
-        void *ptr = asan_poisoned_object_p(v);
-        asan_unpoison_object(v, false);
-
-        if (rb_obj_is_iseq(v)) {
-            rb_iseq_t *iseq = (rb_iseq_t *)v;
-            invalidate_all_blocks_for_tracing(iseq);
+            // Reset output code entry point
+            unsafe { rb_iseq_reset_jit_func(iseq) };
         }
 
-        asan_poison_object_if(ptr, v);
-    }
-    return 0;
-}
+        let cb = CodegenGlobals::get_inline_cb();
 
-static void
-invalidate_all_blocks_for_tracing(const rb_iseq_t *iseq)
-{
-    struct rb_iseq_constant_body *body = iseq->body;
-    if (!body) return; // iseq yet to be initialized
-
-    ASSERT_vm_locking();
-
-    // Empty all blocks on the iseq so we don't compile new blocks that jump to the
-    // invalidted region.
-    // TODO Leaking the blocks for now since we might have situations where
-    // a different ractor is waiting in branch_stub_hit(). If we free the block
-    // that ractor can wake up with a dangling block.
-    rb_darray_for(body->yjit_blocks, version_array_idx) {
-        rb_yjit_block_array_t version_array = rb_darray_get(body->yjit_blocks, version_array_idx);
-        rb_darray_for(version_array, version_idx) {
-            // Stop listening for invalidation events like basic operation redefinition.
-            block_t *block = rb_darray_get(version_array, version_idx);
-            yjit_unlink_method_lookup_dependency(block);
-            yjit_block_assumptions_free(block);
+        // Apply patches
+        let old_pos = cb.get_write_pos();
+        let patches = CodegenGlobals::take_global_inval_patches();
+        for patch in &patches {
+            cb.set_write_ptr(patch.inline_patch_pos);
+            jmp_ptr(cb, patch.outlined_target_pos);
+            assert!(!cb.has_dropped_bytes(), "patches should have space and jump offsets should fit in JMP rel32");
         }
-        rb_darray_free(version_array);
-    }
-    rb_darray_free(body->yjit_blocks);
-    body->yjit_blocks = NULL;
+        cb.set_pos(old_pos);
 
-#if USE_MJIT
-    // Reset output code entry point
-    body->jit_func = NULL;
-#endif
+        // Freeze invalidated part of the codepage. We only want to wait for
+        // running instances of the code to exit from now on, so we shouldn't
+        // change the code. There could be other ractors sleeping in
+        // branch_stub_hit(), for example. We could harden this by changing memory
+        // protection on the frozen range.
+        assert!(CodegenGlobals::get_inline_frozen_bytes() <= old_pos, "frozen bytes should increase monotonically");
+        CodegenGlobals::set_inline_frozen_bytes(old_pos);
+
+        CodegenGlobals::get_outlined_cb().unwrap().mark_all_executable();
+        cb.mark_all_executable();
+    });
 }
-*/

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -434,7 +434,9 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all()
         for patch in &patches {
             cb.set_write_ptr(patch.inline_patch_pos);
             jmp_ptr(cb, patch.outlined_target_pos);
-            assert!(!cb.has_dropped_bytes(), "patches should have space and jump offsets should fit in JMP rel32");
+
+            // FIXME: Can't easily check we actually wrote out the JMP at the moment.
+            // assert!(!cb.has_dropped_bytes(), "patches should have space and jump offsets should fit in JMP rel32");
         }
         cb.set_pos(old_pos);
 


### PR DESCRIPTION
Passes all but 1 btest! Needs some debugging...

```shell
alanwu ~/s/g/S/ruby-master (aw/global-inval) [2]> make btest RUN_OPTS='--yjit-call-threshold=1' TESTOPTS=-j

...

|F#1629 test_yjit.rb:1992:
     events = []
     obj = Object.new
     obj.instance_variable_set(:@tp, TracePoint.new(:line) { |tp| events << tp.lineno })
     def obj.to_a
       @tp.enable(target: method(:compiled))
       []
     end

     # Enable tracing in the middle of the splatarray instruction
     def obj.compiled(obj)
       * = *obj
       __LINE__
     end

     obj.compiled([])
     line = obj.compiled(obj)
     events[0] = (events[0] == line)

     events
  #=> "[false]" (expected "[true]")
/
Finished in 68.94 sec

Fiber count: 10000 (skipping)
FAIL 1/0 tests failed
```
