### PR TITLE
Touchups to pass `make btest`

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -304,6 +304,7 @@ rb_iseq_pc_at_idx(const rb_iseq_t *iseq, uint32_t insn_idx)
     return pc;
 }
 
+// Get the opcode given a program counter. Can return trace opcode variants.
 int
 rb_iseq_opcode_at_pc(const rb_iseq_t *iseq, const VALUE *pc)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -218,6 +218,9 @@ fn main() {
         .blocklist_type("FILE")
         .blocklist_type("_IO_.*")
 
+        // From internal/compile.h
+        .allowlist_function("rb_vm_insn_decode")
+
         // From iseq.h
         .allowlist_function("rb_vm_insn_addr2opcode")
         .allowlist_function("rb_iseqw_to_iseq")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -728,20 +728,13 @@ pub fn gen_single_block(blockid: BlockId, start_ctx: &Context, ec: EcPtr, cb: &m
         jit.pc = pc;
         jit.side_exit_for_pc = None;
 
-        // Disabled for now because invalidation isn't implemented
-        // and this currently prevents any tests from passing
-        /*
         // If previous instruction requested to record the boundary
         if jit.record_boundary_patch_point {
-            todo!();
-            /*
             // Generate an exit to this instruction and record it
-            uint32_t exit_pos = gen_exit(jit.pc, ctx, ocb);
+            let exit_pos = gen_exit(jit.pc, &ctx, ocb.unwrap());
             record_global_inval_patch(cb, exit_pos);
             jit.record_boundary_patch_point = false;
-            */
         }
-        */
 
         // In debug mode, verify our existing assumption
         //if (jit_at_current_insn(&jit)) {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -773,3 +773,6 @@ extern "C" {
 extern "C" {
     pub fn rb_yjit_vm_unlock(file: *const ::std::os::raw::c_char, line: ::std::os::raw::c_int);
 }
+extern "C" {
+    pub fn rb_vm_insn_decode(encoded: VALUE) -> ::std::os::raw::c_int;
+}

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -337,8 +337,14 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC) {
 
         // Ensure that the instruction the get_insn_idx is pointing to is in
         // fact a opt_getinlinecache instruction.
-        let opcode_pc = unsafe { code.add(get_insn_idx.as_usize()) };
-        assert!(unsafe { rb_iseq_opcode_at_pc(iseq, opcode_pc) } == OP_OPT_GETINLINECACHE.try_into().unwrap());
+        assert_eq!(
+            unsafe {
+                let opcode_pc = code.add(get_insn_idx.as_usize());
+                let translated_opcode: VALUE = opcode_pc.read();
+                rb_vm_insn_decode(translated_opcode)
+            },
+            OP_OPT_GETINLINECACHE.try_into().unwrap()
+        );
 
         // Find the matching opt_getinlinecache and invalidate all the blocks there
         // RUBY_ASSERT(insn_op_type(BIN(opt_getinlinecache), 1) == TS_IC);


### PR DESCRIPTION
```
$ make btest RUN_OPTS='--yjit-call-threshold=1' TESTOPTS=-j
generating known_errors.inc
known_errors.inc unchanged
building Rust YJIT
2022-03-22 18:06:39 -0400
Driver is ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin20]
Target is ruby 3.2.0dev (2022-03-22T22:04:18Z aw/pass-btest 5885b4cddd) +YJIT [x86_64-darwin21]
last_commit=Use rb_vm_insn_decode() to handle trace opcode in assert

/
Finished in 74.39 sec

Fiber count: 10000 (skipping)
PASS all 1726 tests
```
:tada:
