### PR TITLE
GC interpo fixups and some progress towards booting test-all

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -740,6 +740,14 @@ rb_yjit_for_each_iseq(iseq_callback callback)
     rb_objspace_each_objects(for_each_iseq_i, (void *)callback);
 }
 
+// For running write barriers from Rust. Required when we add a new edge in the
+// object graph from `old` to `young`.
+void
+rb_yjit_obj_written(VALUE old, VALUE young, const char *file, int line)
+{
+    rb_obj_written(old, Qundef, young, file, line);
+}
+
 // Acquire the VM lock and then signal all other Ruby threads (ractors) to
 // contend for the VM lock, putting them to sleep. YJIT uses this to evict
 // threads running inside generated code so among other things, it can

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
         .header("vm_callinfo.h")
 
         // Some C functions that were expressly for Rust YJIT in this
-        // file. TODO: Might want to move them later.
+        // file. TODO(alan): doesn't work in out-of-src builds.
         .header("yjit.c")
 
         // Don't want to copy over C comment
@@ -211,6 +211,7 @@ fn main() {
         .allowlist_function("rb_iseq_reset_jit_func")
         .allowlist_function("rb_yjit_dump_iseq_loc")
         .allowlist_function("rb_yjit_for_each_iseq")
+        .allowlist_function("rb_yjit_obj_written")
 
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1954,6 +1954,7 @@ pub fn invalidate_block_version(blockref: &BlockRef)
         // }
 
         // Create a stub for this branch target
+        mem::drop(branch); // end RefCell borrow as get_branch_target() can borrow the branch.
         let mut branch_target = get_branch_target(
             block.blockid,
             &block.ctx,
@@ -1971,6 +1972,7 @@ pub fn invalidate_block_version(blockref: &BlockRef)
             branch_target = block.entry_exit;
         }
 
+        branch = branchref.borrow_mut();
         branch.dst_addrs[target_idx] = branch_target;
 
         // Check if the invalidated block immediately follows

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -460,9 +460,19 @@ pub extern "C" fn rb_yjit_iseq_free(payload: *mut c_void)
         }
     };
 
-    // Drop the payload with Box::from_raw().
+    use crate::invariants;
+
+    // Take ownership of the payload with Box::from_raw().
+    // It drops right before this function returns.
     // SAFETY: We got the pointer from Box::into_raw().
-    let _ = unsafe { Box::from_raw(payload) };
+    let payload = unsafe { Box::from_raw(payload) };
+
+    // Remove all blocks in the payload from global invariants table.
+    for versions in &payload.version_map {
+        for block in versions {
+            invariants::block_assumptions_free(&block);
+        }
+    }
 }
 
 /// GC callback for marking GC objects in the the per-iseq payload.
@@ -716,7 +726,8 @@ pub fn limit_block_versions(blockid: BlockId, ctx: &Context) -> Context
 }
 
 /// Keep track of a block version. Block should be fully constructed.
-fn add_block_version(blockref: &BlockRef)
+/// Uses `cb` for running write barriers.
+fn add_block_version(blockref: &BlockRef, cb: &CodeBlock)
 {
     let block = blockref.borrow();
 
@@ -727,28 +738,23 @@ fn add_block_version(blockref: &BlockRef)
 
     version_list.push(blockref.clone());
 
-    /*
-    {
-        // By writing the new block to the iseq, the iseq now
-        // contains new references to Ruby objects. Run write barriers.
-        cme_dependency_t *cme_dep;
-        rb_darray_foreach(block->cme_dependencies, cme_dependency_idx, cme_dep) {
-            RB_OBJ_WRITTEN(iseq, Qundef, cme_dep->receiver_klass);
-            RB_OBJ_WRITTEN(iseq, Qundef, cme_dep->callee_cme);
-        }
-
-        // Run write barriers for all objects in generated code.
-        uint32_t *offset_element;
-        rb_darray_foreach(block->gc_object_offsets, offset_idx, offset_element) {
-            uint32_t offset_to_value = *offset_element;
-            uint8_t *value_address = cb_get_ptr(cb, offset_to_value);
-
-            VALUE object;
-            memcpy(&object, value_address, SIZEOF_VALUE);
-            RB_OBJ_WRITTEN(iseq, Qundef, object);
-        }
+    // By writing the new block to the iseq, the iseq now
+    // contains new references to Ruby objects. Run write barriers.
+    let iseq: VALUE = block.blockid.iseq.into();
+    for dep in block.iter_cme_deps() {
+        obj_written!(iseq, dep.receiver_klass);
+        obj_written!(iseq, dep.callee_cme.into());
     }
-    */
+
+    // Run write barriers for all objects in generated code.
+    for offset in &block.gc_object_offsets {
+        let value_address: *const u8 = cb.get_ptr(offset.as_usize()).raw_ptr();
+        // Creating an unaligned pointer is well defined unlike in C.
+        let value_address: *const VALUE = value_address.cast();
+
+        let object = unsafe { value_address.read_unaligned() };
+        obj_written!(iseq, object);
+    }
 
     incr_counter!(compiled_block_count);
 }
@@ -1309,7 +1315,7 @@ fn gen_block_series_body(blockid: BlockId, start_ctx: &Context, ec: EcPtr, cb: &
     batch.push(first_block.clone()); // Keep track of this block version
 
     // Add the block version to the VersionMap for this ISEQ
-    add_block_version(&first_block);
+    add_block_version(&first_block, cb);
 
     // Loop variable
     let mut last_blockref = first_block.clone();
@@ -1358,7 +1364,7 @@ fn gen_block_series_body(blockid: BlockId, start_ctx: &Context, ec: EcPtr, cb: &
         let new_blockref = result.unwrap();
 
         // Add the block version to the VersionMap for this ISEQ
-        add_block_version(&new_blockref);
+        add_block_version(&new_blockref, cb);
 
         // Connect the last branch and the new block
         last_branch.blocks[0] = Some(new_blockref.clone());

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -680,6 +680,9 @@ extern "C" {
 extern "C" {
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
 }
+extern "C" {
+    pub fn rb_vm_insn_decode(encoded: VALUE) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 pub struct rb_iv_index_tbl_entry {
     pub index: u32,
@@ -786,6 +789,14 @@ extern "C" {
     pub fn rb_yjit_for_each_iseq(callback: iseq_callback);
 }
 extern "C" {
+    pub fn rb_yjit_obj_written(
+        old: VALUE,
+        young: VALUE,
+        file: *const ::std::os::raw::c_char,
+        line: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
     pub fn rb_yjit_vm_lock_then_barrier(
         file: *const ::std::os::raw::c_char,
         line: ::std::os::raw::c_int,
@@ -793,7 +804,4 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_yjit_vm_unlock(file: *const ::std::os::raw::c_char, line: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn rb_vm_insn_decode(encoded: VALUE) -> ::std::os::raw::c_int;
 }

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -169,12 +169,12 @@ pub extern "C" fn rb_yjit_cme_invalidate(callee_cme: *const rb_callable_method_e
         return;
     }
 
-    Invariants::get_instance().cme_validity.remove(&callee_cme).map(|blocks| {
+    if let Some(blocks) = Invariants::get_instance().cme_validity.remove(&callee_cme) {
         for block in blocks.iter() {
             invalidate_block_version(block);
             incr_counter!(invalidate_method_lookup);
         }
-    });
+    }
 }
 
 /// Callback for when rb_callable_method_entry(klass, mid) is going to change.


### PR DESCRIPTION
Run write barriers in add_block_version() and yank block references from
`Invariants` when iseqs are free'd. This makes fixes hard crashes with
`RUBY_YJIT_ENABLE=1 make test-all` and reveals some Ruby exceptions.
More debugging is needed to boot the suite.

---

> This makes fixes hard crashes with `RUBY_YJIT_ENABLE=1 make test-all`

Ah never mind, it still crashes, I just didn't run the full build so was getting Ruby exceptions. I get

`Assertion Failed: ./vm_core.h:1489:VM_BH_ISEQ_BLOCK_P:imemo_type_p(captured->code.val, imemo_iseq)`

or

`thread '<unnamed>' panicked at 'already borrowed: BorrowMutError', src/core.rs:1677:36`

Smells like a use-after-free.
