### PR TITLE
Improve the PC guard mechanism. Compute insn_idx at entry.

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -168,7 +168,7 @@ fn jit_next_insn_idx(jit: &JITState) -> u32
 // Meaning we are compiling the instruction that is next to execute
 fn jit_at_current_insn(jit: &JITState) -> bool
 {
-    let ec_pc:*mut VALUE = unsafe { get_cfp_pc(get_ec_cfp(jit.ec.unwrap())) };
+    let ec_pc: *mut VALUE = unsafe { get_cfp_pc(get_ec_cfp(jit.ec.unwrap())) };
     ec_pc == jit.pc
 }
 
@@ -385,7 +385,6 @@ fn verify_ctx(jit: &JITState, ctx: &Context)
         }
     }
 
-    /*
     // Verify local variable types
     let local_table_size = unsafe { get_iseq_body_local_table_size(jit.iseq) };
     let top_idx: usize = cmp::min(local_table_size as usize, MAX_TEMP_TYPES);
@@ -403,7 +402,6 @@ fn verify_ctx(jit: &JITState, ctx: &Context)
             );
         }
     }
-    */
 }
 
 /// Generate an exit to return to the interpreter
@@ -516,20 +514,19 @@ pub fn jit_ensure_block_entry_exit(jit: &mut JITState, ocb: &mut OutlinedCb)
 // parameters.  When a function with optional parameters is called, the entry
 // PC for the method isn't necessarily 0, but we always generated code that
 // assumes the entry point is 0.
-fn gen_pc_guard(cb: &mut CodeBlock, iseq: IseqPtr)
+fn gen_pc_guard(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32)
 {
     //RUBY_ASSERT(cb != NULL);
 
     let pc_opnd = mem_opnd(64, REG_CFP, RUBY_OFFSET_CFP_PC);
+    let expected_pc = unsafe { rb_iseq_pc_at_idx(iseq, 0) };
+    let expected_pc_opnd = const_ptr_opnd(expected_pc as *const u8);
     mov(cb, REG0, pc_opnd);
-    let encoded_iseq: *mut VALUE = unsafe { get_iseq_body_iseq_encoded(iseq) };
-    let encoded_iseq_opnd = const_ptr_opnd(encoded_iseq as *const u8);
-    mov(cb, REG1, encoded_iseq_opnd);
-    xor(cb, REG0, REG1);
+    mov(cb, REG1, expected_pc_opnd);
+    cmp(cb, REG0, REG1);
 
-    // xor should impact ZF, so we can jz here
-    let pc_is_zero = cb.new_label("pc_is_zero".to_string());
-    jz_label(cb, pc_is_zero);
+    let pc_match = cb.new_label("pc_match".to_string());
+    je_label(cb, pc_match);
 
     // We're not starting at the first PC, so we need to exit.
     gen_counter_incr!(cb, leave_start_pc_non_zero);
@@ -541,8 +538,8 @@ fn gen_pc_guard(cb: &mut CodeBlock, iseq: IseqPtr)
     mov(cb, RAX, imm_opnd(Qundef.into()));
     ret(cb);
 
-    // PC should be at the beginning
-    cb.write_label(pc_is_zero);
+    // PC should match the expected insn_idx
+    cb.write_label(pc_match);
     cb.link_labels();
 }
 
@@ -571,9 +568,6 @@ fn gen_full_cfunc_return(ocb: &mut OutlinedCb)
     ret(cb);
 }
 
-
-
-
 /// Generate a continuation for leave that exits to the interpreter at REG_CFP->pc.
 /// This is used by gen_leave() and gen_entry_prologue()
 fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr
@@ -598,7 +592,7 @@ fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr
 
 /// Compile an interpreter entry block to be inserted into an iseq
 /// Returns None if compilation fails.
-pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr) -> Option<CodePtr>
+pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32) -> Option<CodePtr>
 {
     const MAX_PROLOGUE_SIZE: usize = 1024;
 
@@ -637,7 +631,7 @@ pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr) -> Option<CodePtr>
     // compiled for is the same PC that the interpreter wants us to run with.
     // If they don't match, then we'll take a side exit.
     if unsafe { get_iseq_flags_has_opt(iseq) } {
-        gen_pc_guard(cb, iseq);
+        gen_pc_guard(cb, iseq, insn_idx);
     }
 
     // Verify MAX_PROLOGUE_SIZE

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -519,7 +519,7 @@ fn gen_pc_guard(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32)
     //RUBY_ASSERT(cb != NULL);
 
     let pc_opnd = mem_opnd(64, REG_CFP, RUBY_OFFSET_CFP_PC);
-    let expected_pc = unsafe { rb_iseq_pc_at_idx(iseq, 0) };
+    let expected_pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
     let expected_pc_opnd = const_ptr_opnd(expected_pc as *const u8);
     mov(cb, REG0, pc_opnd);
     mov(cb, REG1, expected_pc_opnd);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -509,9 +509,10 @@ pub fn jit_ensure_block_entry_exit(jit: &mut JITState, ocb: &mut OutlinedCb)
     }
 }
 
-// Generate a runtime guard that ensures the PC is at the start of the iseq,
-// otherwise take a side exit.  This is to handle the situation of optional
-// parameters.  When a function with optional parameters is called, the entry
+// Generate a runtime guard that ensures the PC is at the expected
+// instruction index in the iseq, otherwise takes a side-exit.
+// This is to handle the situation of optional parameters.
+// When a function with optional parameters is called, the entry
 // PC for the method isn't necessarily 0, but we always generated code that
 // assumes the entry point is 0.
 fn gen_pc_guard(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -513,8 +513,7 @@ pub fn jit_ensure_block_entry_exit(jit: &mut JITState, ocb: &mut OutlinedCb)
 // instruction index in the iseq, otherwise takes a side-exit.
 // This is to handle the situation of optional parameters.
 // When a function with optional parameters is called, the entry
-// PC for the method isn't necessarily 0, but we always generated code that
-// assumes the entry point is 0.
+// PC for the method isn't necessarily 0.
 fn gen_pc_guard(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32)
 {
     //RUBY_ASSERT(cb != NULL);

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1394,8 +1394,7 @@ pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> Option<CodePtr>
     let insn_idx: u32 = unsafe {
         let pc_zero = rb_iseq_pc_at_idx(iseq, 0);
         let ec_pc = get_cfp_pc(get_ec_cfp(ec));
-        let ptr_diff = (ec_pc as usize) - (pc_zero as usize);
-        (ptr_diff / SIZEOF_VALUE) as u32
+        ec_pc.offset_from(pc_zero).try_into().ok()?
     };
 
     // The entry context makes no assumptions about types

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -71,7 +71,7 @@ pub extern "C" fn rb_yjit_init_rust()
 /// NOTE: this should be wrapped in RB_VM_LOCK_ENTER(), rb_vm_barrier() on the C side
 #[no_mangle]
 pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> *const u8 {
-    let maybe_code_ptr = gen_entry_point(iseq, 0, ec);
+    let maybe_code_ptr = gen_entry_point(iseq, ec);
 
     match maybe_code_ptr {
         Some(ptr) => ptr.raw_ptr(),


### PR DESCRIPTION
This fixes the local type issue found by Noah with `verify_ctx`.

Should reduce in better usage of the code we compile with optional arguments because the PC we guard against is based on values we actually encounter.