### PR TITLE
Fix checking for unknown Type

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -90,6 +90,21 @@ impl Type {
         }
     }
 
+    /// Returns true when the type is not specific.
+    pub fn is_unknown(&self) -> bool {
+        match self {
+            Type::Unknown | Type::UnknownImm | Type::UnknownHeap => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true when we know the VALUE is a specific handle type,
+    /// such as a static symbol ([Type::ImmSymbol], i.e. true from RB_STATIC_SYM_P()).
+    /// Opposite of [Self::is_unknown].
+    pub fn is_specific(&self) -> bool {
+        !self.is_unknown()
+    }
+
     /// Check if the type is a heap object
     pub fn is_heap(&self) -> bool {
         match self {


### PR DESCRIPTION
There is now 3 different enum variants for unknown types so translating
C YJIT's `ty.type == ETYPE_UNKNOWN` to `ty == Type::Unknown` is incorrect
since they mean are not equivalent. For instance, when `ty` is
`Type::UnknownImm` C YJIT's would yield true while Rust YJIT would
yield false.

Add `is_unknown()` and `.is_specific()` to facilitate checking; use them
to restore C YJIT's logic.

Found when running `make test-all`, specifically:

    make test-all TESTOPTS=-j8 RUN_OPTS='--yjit' TESTS=test/ruby/test_assignment.rb
