### PR TITLE
Validate C struct offsets on boot.

### DIFF
--- a/tool/yjit_struct_offs.rb
+++ b/tool/yjit_struct_offs.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+
+require 'erb'
+
+# Generate C getters for Ruby structure offsets, and Rust constants for same.
+# Output should be a Rust file of offsets and validations, and a C file of
+# offset getters.
+
+# Note that any type listed here will need to also have its header #included in yjit.c!
+
+STRUCT_OFFSETS = [
+    [ :RUBY_OFFSET_RBASIC_FLAGS, "struct RBasic", "flags" ],
+    [ :RUBY_OFFSET_RBASIC_KLASS, "struct RBasic", "klass" ],
+
+    [ :RUBY_OFFSET_RARRAY_AS_HEAP_LEN, "struct RArray", "as.heap.len" ],
+    [ :RUBY_OFFSET_RARRAY_AS_HEAP_PTR, "struct RArray", "as.heap.ptr" ],
+    [ :RUBY_OFFSET_RARRAY_AS_ARY, "struct RArray", "as.ary" ],
+
+    [ :RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR, "struct RStruct", "as.heap.ptr" ],
+    [ :RUBY_OFFSET_RSTRUCT_AS_ARY, "struct RStruct", "as.ary" ],
+
+    [ :RUBY_OFFSET_ROBJECT_AS_ARY, "struct RObject", "as.ary" ],
+    [ :RUBY_OFFSET_ROBJECT_AS_HEAP_NUMIV, "struct RObject", "as.heap.numiv" ],
+    [ :RUBY_OFFSET_ROBJECT_AS_HEAP_IVPTR, "struct RObject", "as.heap.ivptr" ],
+
+    # Constants from rb_control_frame_t in vm_core.h
+    [ :RUBY_OFFSET_CFP_PC, "rb_control_frame_t", "pc" ],
+    [ :RUBY_OFFSET_CFP_SP, "rb_control_frame_t", "sp" ],
+    [ :RUBY_OFFSET_CFP_ISEQ, "rb_control_frame_t", "iseq" ],
+    [ :RUBY_OFFSET_CFP_SELF, "rb_control_frame_t", "self" ],
+    [ :RUBY_OFFSET_CFP_EP, "rb_control_frame_t", "ep" ],
+    [ :RUBY_OFFSET_CFP_BLOCK_CODE, "rb_control_frame_t", "block_code" ],
+    [ :RUBY_OFFSET_CFP_BP, "rb_control_frame_t", "__bp__" ],
+    [ :RUBY_OFFSET_CFP_JIT_RETURN, "rb_control_frame_t", "jit_return" ],
+
+    # Constants from rb_execution_context_t in vm_core.h
+    [ :RUBY_OFFSET_EC_CFP, "rb_execution_context_t", "cfp" ],
+    [ :RUBY_OFFSET_EC_INTERRUPT_FLAG, "rb_execution_context_t", "interrupt_flag" ],
+    [ :RUBY_OFFSET_EC_INTERRUPT_MASK, "rb_execution_context_t", "interrupt_mask" ],
+    [ :RUBY_OFFSET_EC_THREAD_PTR, "rb_execution_context_t", "thread_ptr" ],
+
+    # Constants from rb_thread_t in vm_core.h
+    [ :RUBY_OFFSET_THREAD_SELF, "rb_thread_t", "self" ],
+
+    # Constants from iseq_inline_constant_cache (IC) and iseq_inline_constant_cache_entry (ICE) in vm_core.h
+    [ :RUBY_OFFSET_IC_ENTRY, "struct iseq_inline_constant_cache", "entry" ],
+    [ :RUBY_OFFSET_ICE_VALUE, "struct iseq_inline_constant_cache_entry", "value" ],
+
+]
+
+C_TMPL = <<C_TMPL_END
+<% STRUCT_OFFSETS.each do |const_name, c_struct, c_field| %>
+int
+get_<%= const_name %>()
+{
+    return offsetof(<%= c_struct %>, <%= c_field %>);
+}
+<% end %>
+C_TMPL_END
+
+File.open("yjit_struct_offsets.c", "w") do |f|
+    f.write ERB.new(C_TMPL).result
+end
+
+RS_TMPL = <<RS_TMPL_END
+<% STRUCT_OFFSETS.each do |const_name, c_struct, c_field| %>
+// pub const <%= const_name %>:i32 = 0; // struct <%= c_struct %>, field <%= c_field.inspect %>
+<% end %>
+
+extern "C" {
+<% STRUCT_OFFSETS.each do |const_name, c_struct, c_field| %>
+    pub fn get_<%= const_name %>() -> i32;
+<% end %>
+}
+
+#[no_mangle]
+extern "C" fn rb_yjit_validate_offsets()
+{
+<% STRUCT_OFFSETS.each do |const_name, c_struct, c_field| %>
+    assert_eq!(<%= const_name %>, unsafe { get_<%= const_name %>() } );
+<% end %>
+}
+RS_TMPL_END
+
+File.open("yjit/src/struct_validate_offsets.inc.rs", "w") do |f|
+    f.write ERB.new(RS_TMPL).result
+end

--- a/yjit.c
+++ b/yjit.c
@@ -9,6 +9,7 @@
 #include "internal/variable.h"
 #include "internal/compile.h"
 #include "internal/class.h"
+#include "internal/struct.h"
 #include "gc.h"
 #include "vm_core.h"
 #include "vm_callinfo.h"
@@ -866,5 +867,7 @@ rb_yjit_init(void)
     VALUE yjit_root = TypedData_Make_Struct(0, struct yjit_root_struct, &yjit_root_type, root);
     rb_gc_register_mark_object(yjit_root);
 }
+
+#include "yjit_struct_offsets.c"
 
 #endif // if JIT_ENABLED && PLATFORM_SUPPORTED_P

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -98,6 +98,9 @@ pub type RedefinitionFlag = u32;
 // Textually include output from rust-bindgen as suggested by its user guide.
 include!("cruby_bindings.inc.rs");
 
+include!("struct_offsets.inc.rs");
+include!("struct_validate_offsets.inc.rs");
+
 // TODO: For #defines that affect memory layout, we need to check for them
 // on build and fail if they're wrong. e.g. USE_FLONUM *must* be true.
 
@@ -775,44 +778,7 @@ pub const RSTRUCT_EMBED_LEN_MASK:usize = RUBY_FL_USER_2 | RUBY_FL_USER_1;
 // From iseq.h
 pub const ISEQ_TRANSLATED:usize = RUBY_FL_USER_7;
 
-// We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
-// redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.
-pub const RUBY_OFFSET_RBASIC_FLAGS:i32 = 0;  // struct RBasic, field "flags"
-pub const RUBY_OFFSET_RBASIC_KLASS:i32 = 8;  // struct RBasic, field "klass"
-pub const RUBY_OFFSET_RARRAY_AS_HEAP_LEN:i32 = 16;  // struct RArray, subfield "as.heap.len"
-pub const RUBY_OFFSET_RARRAY_AS_HEAP_PTR:i32 = 32;  // struct RArray, subfield "as.heap.ptr"
-pub const RUBY_OFFSET_RARRAY_AS_ARY:i32 = 16; // struct RArray, subfield "as.ary"
-
-pub const RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR:i32 = 24;  // struct RStruct, subfield "as.heap.ptr"
-pub const RUBY_OFFSET_RSTRUCT_AS_ARY:i32 = 16; // struct RStruct, subfield "as.ary"
-
-pub const RUBY_OFFSET_ROBJECT_AS_ARY:i32 = 16; // struct RObject, subfield "as.ary"
-pub const RUBY_OFFSET_ROBJECT_AS_HEAP_NUMIV:i32 = 16; // struct RObject, subfield "as.heap.numiv"
-pub const RUBY_OFFSET_ROBJECT_AS_HEAP_IVPTR:i32 = 24; // struct RObject, subfield "as.heap.ivptr"
-
-// Constants from rb_control_frame_t vm_core.h
-pub const RUBY_OFFSET_CFP_PC: i32 = 0;
-pub const RUBY_OFFSET_CFP_SP: i32 = 8;
-pub const RUBY_OFFSET_CFP_ISEQ: i32 = 16;
-pub const RUBY_OFFSET_CFP_SELF: i32 = 24;
-pub const RUBY_OFFSET_CFP_EP: i32 = 32;
-pub const RUBY_OFFSET_CFP_BLOCK_CODE: i32 = 40;
-pub const RUBY_OFFSET_CFP_BP: i32 = 48; // field __bp__
-pub const RUBY_OFFSET_CFP_JIT_RETURN: i32 = 56;
 pub const RUBY_SIZEOF_CONTROL_FRAME: usize = 64;
-
-// Constants from rb_execution_context_t vm_core.h
-pub const RUBY_OFFSET_EC_CFP: i32 = 16;
-pub const RUBY_OFFSET_EC_INTERRUPT_FLAG: i32 = 32; // rb_atomic_t (u32)
-pub const RUBY_OFFSET_EC_INTERRUPT_MASK: i32 = 36; // rb_atomic_t (u32)
-pub const RUBY_OFFSET_EC_THREAD_PTR: i32 = 48;
-
-// Constants from rb_thread_t in vm_core.h
-pub const RUBY_OFFSET_THREAD_SELF: i32 = 16;
-
-// Constants from iseq_inline_constant_cache (IC) and iseq_inline_constant_cache_entry (ICE) in vm_core.h
-pub const RUBY_OFFSET_IC_ENTRY: i32 = 0;
-pub const RUBY_OFFSET_ICE_VALUE: i32 = 8;
 
 // TODO: need to dynamically autogenerate constants for all the YARV opcodes from insns.def
 // TODO: typing of these adds unnecessary casting

--- a/yjit/src/struct_offsets.inc.rs
+++ b/yjit/src/struct_offsets.inc.rs
@@ -1,0 +1,35 @@
+pub const RUBY_OFFSET_RBASIC_FLAGS:i32 = 0;  // struct RBasic, field "flags"
+pub const RUBY_OFFSET_RBASIC_KLASS:i32 = 8;  // struct RBasic, field "klass"
+pub const RUBY_OFFSET_RARRAY_AS_HEAP_LEN:i32 = 16;  // struct RArray, subfield "as.heap.len"
+pub const RUBY_OFFSET_RARRAY_AS_HEAP_PTR:i32 = 32;  // struct RArray, subfield "as.heap.ptr"
+pub const RUBY_OFFSET_RARRAY_AS_ARY:i32 = 16; // struct RArray, subfield "as.ary"
+
+pub const RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR:i32 = 24;  // struct RStruct, subfield "as.heap.ptr"
+pub const RUBY_OFFSET_RSTRUCT_AS_ARY:i32 = 16; // struct RStruct, subfield "as.ary"
+
+pub const RUBY_OFFSET_ROBJECT_AS_ARY:i32 = 16; // struct RObject, subfield "as.ary"
+pub const RUBY_OFFSET_ROBJECT_AS_HEAP_NUMIV:i32 = 16; // struct RObject, subfield "as.heap.numiv"
+pub const RUBY_OFFSET_ROBJECT_AS_HEAP_IVPTR:i32 = 24; // struct RObject, subfield "as.heap.ivptr"
+
+// Constants from rb_control_frame_t vm_core.h
+pub const RUBY_OFFSET_CFP_PC: i32 = 0;
+pub const RUBY_OFFSET_CFP_SP: i32 = 8;
+pub const RUBY_OFFSET_CFP_ISEQ: i32 = 16;
+pub const RUBY_OFFSET_CFP_SELF: i32 = 24;
+pub const RUBY_OFFSET_CFP_EP: i32 = 32;
+pub const RUBY_OFFSET_CFP_BLOCK_CODE: i32 = 40;
+pub const RUBY_OFFSET_CFP_BP: i32 = 48; // field __bp__
+pub const RUBY_OFFSET_CFP_JIT_RETURN: i32 = 56;
+
+// Constants from rb_execution_context_t vm_core.h
+pub const RUBY_OFFSET_EC_CFP: i32 = 16;
+pub const RUBY_OFFSET_EC_INTERRUPT_FLAG: i32 = 32; // rb_atomic_t (u32)
+pub const RUBY_OFFSET_EC_INTERRUPT_MASK: i32 = 36; // rb_atomic_t (u32)
+pub const RUBY_OFFSET_EC_THREAD_PTR: i32 = 48;
+
+// Constants from rb_thread_t in vm_core.h
+pub const RUBY_OFFSET_THREAD_SELF: i32 = 16;
+
+// Constants from iseq_inline_constant_cache (IC) and iseq_inline_constant_cache_entry (ICE) in vm_core.h
+pub const RUBY_OFFSET_IC_ENTRY: i32 = 0;
+pub const RUBY_OFFSET_ICE_VALUE: i32 = 8;


### PR DESCRIPTION
Make sure that Rust's offsets agree with them.

Note: this isn't currently integrated with configure. It's a script to generate C offset getters, plus a simple validation function. But it's not 100% clear how to hook it all up. I'm making this a draft PR for commentary, it's not polished and ready to go yet. So: we'll need to get configure to run tool/yjit_struct_offs.rb, or else check in src/yjit/struct_offsets.inc.rs.

As written this includes a "validate all the offsets on startup" phase. That's not a problem -- we're validating around 20 offsets, and each is a function call comparing two known-at-compile-time integers. Very quick.

It also links all the offset getters, which aren't very big, but add slightly to the binary size. The biggest problem is that it requires manually updating a header (struct_offsets.inc.rs) when we add an offset or an offset changes