### PR TITLE
Enable the unused_variables lint

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -157,8 +157,7 @@ impl CodeBlock
     /// If not, this becomes an inline no-op.
     #[inline]
     pub fn add_comment(&mut self, comment: &str) {
-        #[cfg(feature="asm_comments")]
-        {
+        if cfg!(feature = "asm_comments") {
             let cur_ptr = self.get_write_ptr().into_usize();
             let this_line_comments = self.asm_comments.get(&cur_ptr);
 
@@ -282,7 +281,7 @@ impl CodeBlock
                 let mut cur = val;
 
                 // Write out the bytes
-                for byte in 0..(num_bits / 8) {
+                for _byte in 0..(num_bits / 8) {
                     self.write_byte((cur & 0xff) as u8);
                     cur >>= 8;
                 }

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -451,7 +451,7 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
     let rm_mod = match rm_opnd {
         X86Opnd::Reg(_) => 3,
         X86Opnd::IPRel(_) => 0,
-        X86Opnd::Mem(mem) => {
+        X86Opnd::Mem(_mem) => {
             match rm_opnd.disp_size() {
                 0 => 0,
                 8 => 1,
@@ -678,7 +678,7 @@ pub fn call_rel32(cb: &mut CodeBlock, rel32: i32) {
 
 /// call - Call a pointer, encode with a 32-bit offset if possible
 pub fn call_ptr(cb: &mut CodeBlock, scratch_opnd: X86Opnd, dst_ptr: *const u8) {
-    if let X86Opnd::Reg(scratch_reg) = scratch_opnd {
+    if let X86Opnd::Reg(_scratch_reg) = scratch_opnd {
         // Pointer to the end of this call instruction
         let end_ptr = cb.get_ptr(cb.write_pos + 5);
 
@@ -1037,7 +1037,7 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
 
 /// movsx - Move with sign extension (signed integers)
 pub fn movsx(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
-    if let X86Opnd::Reg(dst_reg) = dst {
+    if let X86Opnd::Reg(_dst_reg) = dst {
         assert!(matches!(src, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
 
         let src_num_bits = src.num_bits();
@@ -1182,7 +1182,7 @@ pub fn push(cb: &mut CodeBlock, opnd: X86Opnd) {
             }
             write_opcode(cb, 0x50, reg);
         },
-        X86Opnd::Mem(mem) => {
+        X86Opnd::Mem(_mem) => {
             write_rm(cb, false, false, X86Opnd::None, opnd, 6, &[0xff]);
         },
         _ => unreachable!()
@@ -1200,7 +1200,7 @@ pub fn ret(cb: &mut CodeBlock) {
 }
 
 // Encode a single-operand shift instruction
-fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, op_mem_cl_pref: u8, op_mem_imm_pref: u8, op_ext: u8, opnd0: X86Opnd, opnd1: X86Opnd) {
+fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, _op_mem_cl_pref: u8, op_mem_imm_pref: u8, op_ext: u8, opnd0: X86Opnd, opnd1: X86Opnd) {
     assert!(matches!(opnd0, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
 
     // Check the size of opnd0

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -143,7 +143,7 @@ pub fn jit_get_arg(jit: &JITState, arg_idx: isize) -> VALUE
 // Load a VALUE into a register and keep track of the reference if it is on the GC heap.
 pub fn jit_mov_gc_ptr(jit:&mut JITState, cb: &mut CodeBlock, reg:X86Opnd, ptr: VALUE)
 {
-    assert!( matches!(reg, X86Opnd::Reg(x)) );
+    assert!( matches!(reg, X86Opnd::Reg(_)) );
     assert!( reg.num_bits() == 64 );
 
     // Load the pointer constant into the specified register
@@ -1124,7 +1124,7 @@ mod tests {
         let (mut jit, mut context, mut cb, mut ocb) = setup_codegen();
         let status = gen_nop(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(context.diff(&Context::new()), 0);
         assert_eq!(cb.get_write_pos(), 0);
     }
@@ -1135,7 +1135,7 @@ mod tests {
         let mut context = Context::new_with_stack_size(1);
         let status = gen_pop(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(context.diff(&Context::new()), 0);
     }
 
@@ -1145,7 +1145,7 @@ mod tests {
         context.stack_push(Type::Fixnum);
         let status = gen_dup(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
 
         // Did we duplicate the type information for the Fixnum type?
         assert_eq!(Type::Fixnum, context.get_opnd_type(StackOpnd(0)));
@@ -1166,7 +1166,7 @@ mod tests {
 
         let status = gen_dupn(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
 
         assert_eq!(Type::Fixnum, context.get_opnd_type(StackOpnd(3)));
         assert_eq!(Type::Flonum, context.get_opnd_type(StackOpnd(2)));
@@ -1187,7 +1187,7 @@ mod tests {
         let (_, tmp_type_top) = context.get_opnd_mapping(StackOpnd(0));
         let (_, tmp_type_next) = context.get_opnd_mapping(StackOpnd(1));
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(tmp_type_top, Type::Fixnum);
         assert_eq!(tmp_type_next, Type::Flonum);
     }
@@ -1199,7 +1199,7 @@ mod tests {
 
         let (_, tmp_type_top) = context.get_opnd_mapping(StackOpnd(0));
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(tmp_type_top, Type::Nil);
         assert!(cb.get_write_pos() > 0);
     }
@@ -1217,7 +1217,7 @@ mod tests {
 
         let (_, tmp_type_top) = context.get_opnd_mapping(StackOpnd(0));
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(tmp_type_top, Type::True);
         assert!(cb.get_write_pos() > 0);
     }
@@ -1236,7 +1236,7 @@ mod tests {
 
         let (_, tmp_type_top) = context.get_opnd_mapping(StackOpnd(0));
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(tmp_type_top, Type::Fixnum);
         assert!(cb.get_write_pos() > 0);
     }
@@ -1250,7 +1250,7 @@ mod tests {
         let (_, tmp_type_top) = context.get_opnd_mapping(StackOpnd(0));
 
         // Right now we're not testing the generated machine code to make sure a literal 1 or 0 was pushed. I've checked locally.
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert_eq!(tmp_type_top, Type::Fixnum);
     }
 
@@ -1259,7 +1259,7 @@ mod tests {
         let (mut jit, mut context, mut cb, mut ocb) = setup_codegen();
         let status = gen_putself(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
         assert!(cb.get_write_pos() > 0);
     }
 
@@ -1276,7 +1276,7 @@ mod tests {
 
         let status = gen_setn(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
 
         assert_eq!(Type::String, context.get_opnd_type(StackOpnd(2)));
         assert_eq!(Type::Flonum, context.get_opnd_type(StackOpnd(1)));
@@ -1297,7 +1297,7 @@ mod tests {
 
         let status = gen_topn(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
 
         assert_eq!(Type::Flonum, context.get_opnd_type(StackOpnd(2)));
         assert_eq!(Type::String, context.get_opnd_type(StackOpnd(1)));
@@ -1319,7 +1319,7 @@ mod tests {
 
         let status = gen_adjuststack(&mut jit, &mut context, &mut cb, &mut ocb);
 
-        assert!(matches!(KeepCompiling, status));
+        assert_eq!(status, KeepCompiling);
 
         assert_eq!(Type::Flonum, context.get_opnd_type(StackOpnd(0)));
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3453,9 +3453,6 @@ fn gen_send_cfunc(
         }
     }
 
-    // Callee method ID
-    let mid = unsafe { vm_ci_mid(ci) };
-
     // Create a side-exit to fall back to the interpreter
     let side_exit = get_side_exit(jit, ocb, ctx);
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1770,7 +1770,7 @@ pub fn gen_branch(
     regenerate_branch(cb, &mut branch);
 }
 
-fn gen_jump_branch(cb: &mut CodeBlock, target0: CodePtr, target1: Option<CodePtr>, shape: BranchShape)
+fn gen_jump_branch(cb: &mut CodeBlock, target0: CodePtr, _target1: Option<CodePtr>, shape: BranchShape)
 {
     if shape == BranchShape::Next1 {
         panic!("Branch shape Next1 not allowed in gen_jump_branch!");

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -310,6 +310,7 @@ pub fn insn_name(opcode: usize) -> String
     }
 }
 
+#[allow(unused_variables)]
 pub fn insn_len(opcode: usize) -> u32
 {
     #[cfg(test)]

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -8,9 +8,11 @@ use crate::yjit::yjit_enabled_p;
 /// Primitive called in yjit.rb
 /// Produce a string representing the disassembly for an ISEQ
 #[no_mangle]
-pub extern "C" fn rb_yjit_disasm_iseq(ec: EcPtr, ruby_self: VALUE, iseqw: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_disasm_iseq(_ec: EcPtr, _ruby_self: VALUE, iseqw: VALUE) -> VALUE {
+
     #[cfg(not(feature = "disasm"))]
     {
+        let _ = iseqw;
         return Qnil;
     }
 

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -139,9 +139,10 @@ fn disasm_iseq(iseq: IseqPtr) -> String {
 /// Primitive called in yjit.rb
 /// Produce a list of instructions compiled for an isew
 #[no_mangle]
-pub extern "C" fn rb_yjit_insns_compiled(ec: EcPtr, ruby_self: VALUE, iseqw: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_insns_compiled(_ec: EcPtr, _ruby_self: VALUE, iseqw: VALUE) -> VALUE {
     #[cfg(not(feature = "disasm"))]
     {
+        let _ = iseqw;
         return Qnil;
     }
 

--- a/yjit/src/lib.rs
+++ b/yjit/src/lib.rs
@@ -1,7 +1,6 @@
 // Silence dead code warnings until we are done porting YJIT
 #![allow(unused_imports)]
 #![allow(dead_code)]
-#![allow(unused_variables)]
 #![allow(unused_assignments)]
 #![allow(unused_macros)]
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -151,7 +151,7 @@ make_counters!(
 /// Primitive called in yjit.rb
 /// Check if stats generation is enabled
 #[no_mangle]
-pub extern "C" fn rb_yjit_stats_enabled_p(ec: EcPtr, ruby_self: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_stats_enabled_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
     #[cfg(feature = "stats")]
     if get_option!(gen_stats) {
         return Qtrue
@@ -163,7 +163,7 @@ pub extern "C" fn rb_yjit_stats_enabled_p(ec: EcPtr, ruby_self: VALUE) -> VALUE 
 /// Primitive called in yjit.rb.
 /// Export all YJIT statistics as a Ruby hash.
 #[no_mangle]
-pub extern "C" fn rb_yjit_get_stats(ec: EcPtr, ruby_self: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_get_stats(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
     with_vm_lock(src_loc!(), || rb_yjit_gen_stats_dict())
 }
 
@@ -241,7 +241,7 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
 
 /// Primitive called in yjit.rb. Zero out all the counters.
 #[no_mangle]
-pub extern "C" fn rb_yjit_reset_stats_bang(ec: EcPtr, ruby_self: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_reset_stats_bang(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
     unsafe {
         EXIT_OP_COUNT = [0; VM_INSTRUCTION_SIZE];
         COUNTERS = Counters::default();

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -81,7 +81,7 @@ pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> *con
 
 /// Simulate a situation where we are out of executable memory
 #[no_mangle]
-pub extern "C" fn rb_yjit_simulate_oom_bang(ec: EcPtr, ruby_self: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_simulate_oom_bang(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
     // If YJIT is not enabled, do nothing
     if !yjit_enabled_p() {
         return Qnil;


### PR DESCRIPTION
I think this lint is worth the effort as it uncovered faulty tests
and can warn against bugs in the future. It's somewhat protects
against copy-paste bugs. See also: 8782e92931db6434c5b58e4357168831db633dff.

It's a bit tricky to keep things warning free when there is a lot of
conditional compilation, but it wasn't too bad.

I think it's best to review commit by commit.
