### PR TITLE
Sever dependency on Cargo in release mode

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -47,6 +47,7 @@ jobs:
         ]
         configure: [
           "--enable-yjit=dev",
+          "--enable-yjit",
         ]
         yjit_opts: [
           "--yjit",

--- a/configure.ac
+++ b/configure.ac
@@ -3762,10 +3762,6 @@ AS_CASE(["${YJIT_SUPPORT}"],
     AS_IF([test x"$enable_jit_support" = "xno"],
         AC_MSG_ERROR([--disable-jit-support but --enable-yjit. YJIT requires JIT support])
     )
-    AC_CHECK_TOOL(CARGO, [cargo], [no])
-    AS_IF([test x"$CARGO" = "xno"],
-        AC_MSG_ERROR([cargo is required. Installation instructions available at https://www.rust-lang.org/tools/install])
-    )
     AC_CHECK_TOOL(RUSTC, [rustc], [no])
     AS_IF([test x"$RUSTC" = "xno"],
         AC_MSG_ERROR([rustc is required. Installation instructions available at https://www.rust-lang.org/tools/install])
@@ -3775,6 +3771,10 @@ AS_CASE(["${YJIT_SUPPORT}"],
              CARGO_BUILD_ARGS='--release'],
             [rb_rust_target_subdir=debug
              CARGO_BUILD_ARGS='--features stats,disasm,asm_comments'
+             AC_CHECK_TOOL(CARGO, [cargo], [no])
+             AS_IF([test x"$CARGO" = "xno"],
+                AC_MSG_ERROR([cargo is required. Installation instructions available at https://www.rust-lang.org/tools/install])
+             )
              AC_DEFINE(RUBY_DEBUG, 1)])
     YJIT_LIBS="yjit/target/${rb_rust_target_subdir}/libyjit.a"
     YJIT_OBJ='yjit.$(OBJEXT)'
@@ -3783,11 +3783,12 @@ AS_CASE(["${YJIT_SUPPORT}"],
 
 
 dnl These variables end up in ::RbConfig::CONFIG
-AC_SUBST(YJIT_SUPPORT) dnl what flavor of YJIT the Ruby build includes
-AC_SUBST(CARGO) dnl Cargo executable Rust builds
-AC_SUBST(CARGO_BUILD_ARGS) dnl for selecting Rust build profiles
-AC_SUBST(YJIT_LIBS) dnl for optionally building the Rust parts
-AC_SUBST(YJIT_OBJ) dnl for optionally building the C parts
+AC_SUBST(YJIT_SUPPORT)dnl what flavor of YJIT the Ruby build includes
+AC_SUBST(RUSTC)dnl Rust compiler command
+AC_SUBST(CARGO)dnl Cargo command for Rust builds
+AC_SUBST(CARGO_BUILD_ARGS)dnl for selecting Rust build profiles
+AC_SUBST(YJIT_LIBS)dnl for optionally building the Rust parts of YJIT
+AC_SUBST(YJIT_OBJ)dnl for optionally building the C parts of YJIT
 
 AC_ARG_ENABLE(install-static-library,
 	AS_HELP_STRING([--disable-install-static-library], [do not install static ruby library]),

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -27,6 +27,7 @@ CC_WRAPPER = @XCC_WRAPPER@
 CC = @CC@
 CPP = @CPP@
 LD = @LD@
+RUSTC = @RUSTC@
 CARGO = @CARGO@
 YACC = bison
 PURIFY =

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -35,6 +35,8 @@ debug-assertions = true
 overflow-checks = true
 
 [profile.release]
+# NOTE: --enable-yjit builds use `rustc` without going through Cargo. You
+# might want to update the `rustc` invocation if you change this profile.
 opt-level = 3
 # The extra robustness that comes from checking for arithmetic overflow is
 # worth the performance cost for the compiler.

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1897,7 +1897,6 @@ fn free_block(blockref: &BlockRef)
 // Some runtime checks for integrity of a program location
 pub fn verify_blockid(blockid: BlockId)
 {
-    #[cfg(debug_assertions)]
     unsafe {
         assert!(rb_IMEMO_TYPE_P(blockid.iseq.into(), imemo_iseq) != 0);
         assert!(blockid.idx < get_iseq_encoded_size(blockid.iseq));

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -140,13 +140,6 @@ fn disasm_iseq(iseq: IseqPtr) -> String {
 /// Produce a list of instructions compiled for an isew
 #[no_mangle]
 pub extern "C" fn rb_yjit_insns_compiled(_ec: EcPtr, _ruby_self: VALUE, iseqw: VALUE) -> VALUE {
-    #[cfg(not(feature = "disasm"))]
-    {
-        let _ = iseqw;
-        return Qnil;
-    }
-
-    #[cfg(feature = "disasm")]
     {
         // TODO:
         //if unsafe { CLASS_OF(iseqw) != rb_cISeq } {
@@ -183,7 +176,6 @@ pub extern "C" fn rb_yjit_insns_compiled(_ec: EcPtr, _ruby_self: VALUE, iseqw: V
     }
 }
 
-#[cfg(feature = "disasm")]
 fn insns_compiled(iseq: IseqPtr) -> Vec<(String, u32)> {
     let mut insn_vec = Vec::new();
 


### PR DESCRIPTION
We want to build offline in release mode and currently `cargo --offline`
does not do what we want. In release mode, run `rustc` directly and
don't check for Cargo in `configure`. Reword the build prompt to include
the current build mode.

No CI changes yet, but this can be used to check that we build without
any external crates. For release mode users it's potentially a boon to
not need to install Cargo.
