### PR TITLE
Rust constant caches

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4926,8 +4926,13 @@ vm_opt_newarray_min(rb_execution_context_t *ec, rb_num_t num, const VALUE *ptr)
 
 #define IMEMO_CONST_CACHE_SHAREABLE IMEMO_FL_USER0
 
-// For each getconstant, associate the ID that corresponds to the first operand
-// to that instruction with the inline cache.
+// This is the iterator used by vm_ic_compile for rb_iseq_each. It is used as a
+// callback for each instruction within the ISEQ, and is meant to return a
+// boolean indicating whether or not to keep iterating.
+//
+// This is used to walk through the ISEQ and find all getconstant instructions
+// between the starting opt_getinlinecache and the ending opt_setinlinecache and
+// associating the inline cache with the constant name components on the VM.
 static bool
 vm_ic_compile_i(VALUE *code, VALUE insn, size_t index, void *ic)
 {

--- a/vm_method.c
+++ b/vm_method.c
@@ -149,7 +149,7 @@ rb_clear_constant_cache_for_id(ID id)
         ruby_vm_constant_cache_invalidations += ics->num_entries;
     }
 
-    rb_yjit_constant_state_changed();
+    rb_yjit_constant_state_changed(id);
 }
 
 static void

--- a/yjit.h
+++ b/yjit.h
@@ -50,7 +50,7 @@ void rb_yjit_collect_binding_set(void);
 bool rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec);
 void rb_yjit_init(void);
 void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop);
-void rb_yjit_constant_state_changed(void);
+void rb_yjit_constant_state_changed(ID id);
 void rb_yjit_iseq_mark(void *payload);
 void rb_yjit_iseq_update_references(void *payload);
 void rb_yjit_iseq_free(void *payload);
@@ -73,7 +73,7 @@ static inline void rb_yjit_collect_binding_set(void) {}
 static inline bool rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec) { return false; }
 static inline void rb_yjit_init(void) {}
 static inline void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop) {}
-static inline void rb_yjit_constant_state_changed(void) {}
+static inline void rb_yjit_constant_state_changed(ID id) {}
 static inline void rb_yjit_iseq_mark(void *payload) {}
 static inline void rb_yjit_iseq_update_references(void *payload) {}
 static inline void rb_yjit_iseq_free(void *payload) {}

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -227,6 +227,7 @@ fn main() {
         // From iseq.h
         .allowlist_function("rb_vm_insn_addr2opcode")
         .allowlist_function("rb_iseqw_to_iseq")
+        .allowlist_function("rb_iseq_each")
 
         // From builtin.h
         .allowlist_type("rb_builtin_function.*")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4605,9 +4605,9 @@ fn gen_opt_getinlinecache(jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBl
             return CantCompile;
         }
 
-        // Invalidate output code on any and all constant writes
-        // FIXME: This leaks when st_insert raises NoMemoryError
-        assume_stable_global_constant_state(jit, ocb);
+        // Invalidate output code on any constant writes associated with
+        // constants referenced within the current block.
+        assume_stable_constant_names(jit, ocb);
 
         jit_putobject(jit, ctx, cb, unsafe { (*ice).value });
     }

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -672,6 +672,22 @@ pub struct rb_builtin_function {
 extern "C" {
     pub fn rb_vm_insn_addr2opcode(addr: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
 }
+pub type rb_iseq_each_i = ::std::option::Option<
+    unsafe extern "C" fn(
+        code: *mut VALUE,
+        insn: VALUE,
+        index: size_t,
+        data: *mut ::std::os::raw::c_void,
+    ) -> bool,
+>;
+extern "C" {
+    pub fn rb_iseq_each(
+        iseq: *const rb_iseq_t,
+        start_index: size_t,
+        iterator: rb_iseq_each_i,
+        data: *mut ::std::os::raw::c_void,
+    );
+}
 extern "C" {
     pub fn rb_iseqw_to_iseq(iseqw: VALUE) -> *const rb_iseq_t;
 }

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -8,7 +8,9 @@ use crate::stats::*;
 use crate::asm::OutlinedCb;
 use crate::utils::IntoUsize;
 use crate::yjit::yjit_enabled_p;
+use crate::options::*;
 
+use std::os::raw::c_void;
 use std::collections::{HashMap, HashSet};
 use std::mem;
 
@@ -47,11 +49,15 @@ pub struct Invariants {
     /// running.
     single_ractor: HashSet<BlockRef>,
 
-    /// Tracks the set of blocks that are assuming that the global constant
-    /// state hasn't changed since the last time it was checked. This is
-    /// important for accessing constants and their fields which can change
-    /// between executions of a given block.
-    global_constant_state: HashSet<BlockRef>,
+    /// A map from an ID to the set of blocks that are assuming a constant with
+    /// that ID as part of its name has not been redefined. For example, if
+    /// a constant `A::B` is redefined, then all blocks that are assuming that
+    /// `A` and `B` have not be redefined must be invalidated.
+    constant_state_blocks: HashMap<ID, HashSet<BlockRef>>,
+
+    /// A map from a block to a set of IDs that it is assuming have not been
+    /// redefined.
+    block_constant_states: HashMap<BlockRef, HashSet<ID>>,
 }
 
 /// Private singleton instance of the invariants global struct.
@@ -67,7 +73,8 @@ impl Invariants {
                 basic_operator_blocks: HashMap::new(),
                 block_basic_operators: HashMap::new(),
                 single_ractor: HashSet::new(),
-                global_constant_state: HashSet::new(),
+                constant_state_blocks: HashMap::new(),
+                block_constant_states: HashMap::new(),
             });
         }
     }
@@ -133,11 +140,48 @@ pub fn assume_single_ractor_mode(jit: &mut JITState, ocb: &mut OutlinedCb) -> bo
     }
 }
 
-/// Tracks that a block is assuming that the global constant state has not
-/// changed since the last call to this function.
-pub fn assume_stable_global_constant_state(jit: &mut JITState, ocb: &mut OutlinedCb) {
+/// Walk through the ISEQ to go from the current opt_getinlinecache to the
+/// subsequent opt_setinlinecache and find all of the name components that are
+/// associated with this constant (which correspond to the getconstant
+/// arguments).
+pub fn assume_stable_constant_names(jit: &mut JITState, ocb: &mut OutlinedCb) {
+    /// Tracks that a block is assuming that the name component of a constant
+    /// has not changed since the last call to this function.
+    unsafe extern "C" fn assume_stable_constant_name(code: *mut VALUE, insn: VALUE, index: u64, data: *mut c_void) -> bool {
+        if insn.as_usize() == OP_OPT_SETINLINECACHE {
+            return false;
+        }
+
+        if insn.as_usize() == OP_GETCONSTANT {
+            let jit = &mut *(data as *mut JITState);
+
+            // The first operand to GETCONSTANT is always the ID associated with
+            // the constant lookup. We are grabbing this out in order to
+            // associate this block with the stability of this constant name.
+            let id = code.add(index.as_usize() + 1).read().as_u64() as ID;
+
+            let invariants = Invariants::get_instance();
+            invariants.constant_state_blocks.entry(id).or_insert(HashSet::new()).insert(jit.get_block());
+            invariants.block_constant_states.entry(jit.get_block()).or_insert(HashSet::new()).insert(id);
+        }
+
+        true
+    }
+
     jit_ensure_block_entry_exit(jit, ocb);
-    Invariants::get_instance().global_constant_state.insert(jit.get_block());
+
+    unsafe {
+        let iseq = jit.get_iseq();
+        let encoded = get_iseq_body_iseq_encoded(iseq);
+        let start_index = jit.get_pc().offset_from(encoded);
+
+        rb_iseq_each(
+            iseq,
+            start_index.try_into().unwrap(),
+            Some(assume_stable_constant_name),
+            jit as *mut _ as *mut c_void
+        );
+    };
 }
 
 /// Called when a basic operator is redefined. Note that all the blocks assuming
@@ -218,19 +262,34 @@ pub extern "C" fn rb_yjit_before_ractor_spawn() {
 
 /// Callback for when the global constant state changes.
 #[no_mangle]
-pub extern "C" fn rb_yjit_constant_state_changed() {
+pub extern "C" fn rb_yjit_constant_state_changed(id: ID) {
     // If YJIT isn't enabled, do nothing
     if !yjit_enabled_p() {
         return;
     }
 
-    // Clear the set of blocks inside Invariants
-    let blocks = mem::take(&mut Invariants::get_instance().global_constant_state);
+    if get_option!(global_constant_state) {
+        // If the global-constant-state option is set, then we're going to
+        // invalidate every block that depends on any constant.
 
-    // Invalidate the blocks
-    for block in &blocks {
-        invalidate_block_version(block);
-        incr_counter!(invalidate_constant_state_bump);
+        let constant_state = mem::take(&mut Invariants::get_instance().constant_state_blocks);
+
+        for (_, blocks) in constant_state.iter() {
+            for block in blocks.iter() {
+                invalidate_block_version(block);
+                incr_counter!(invalidate_constant_state_bump);
+            }
+        }
+    } else {
+        // If the global-constant-state option is not set, then we're only going
+        // to invalidate the blocks that are associated with the given ID.
+
+        if let Some(blocks) = Invariants::get_instance().constant_state_blocks.remove(&id) {
+            for block in &blocks {
+                invalidate_block_version(block);
+                incr_counter!(invalidate_constant_state_bump);
+            }
+        }
     }
 }
 
@@ -308,7 +367,15 @@ pub fn block_assumptions_free(blockref: &BlockRef) {
     }
 
     invariants.single_ractor.remove(&blockref);
-    invariants.global_constant_state.remove(&blockref);
+
+    // Remove tracking for constant state for a given ID.
+    if let Some(ids) = invariants.block_constant_states.remove(&blockref) {
+        for id in ids {
+            if let Some(blocks) = invariants.constant_state_blocks.get_mut(&id) {
+                blocks.remove(&blockref);
+            }
+        }
+    }
 }
 
 /// Callback from the opt_setinlinecache instruction in the interpreter.

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -29,6 +29,12 @@ pub struct Options {
 
     /// Verify context objects (debug mode only)
     pub verify_ctx: bool,
+
+    /// Whether or not to assume a global constant state (and therefore
+    /// invalidating code whenever any constant changes) versus assuming
+    /// constant name components (and therefore invalidating code whenever a
+    /// matching name component changes)
+    pub global_constant_state: bool,
 }
 
 // Initialize the options to default values
@@ -41,6 +47,7 @@ pub static mut OPTIONS: Options = Options {
     gen_stats : false,
     dump_insns: false,
     verify_ctx: false,
+    global_constant_state: false,
 };
 
 /// Macro to get an option value by name
@@ -102,6 +109,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()>
         ("stats", "") => { unsafe { OPTIONS.gen_stats = true }},
         ("dump-insns", "") => { unsafe { OPTIONS.dump_insns = true }},
         ("verify-ctx", "") => { unsafe { OPTIONS.verify_ctx = true }},
+        ("global-constant-state", "") => { unsafe { OPTIONS.global_constant_state = true }},
 
         // Option name not recognized
         _ => {


### PR DESCRIPTION
Currently YJIT codegen invalidates code blocks whenever any constant is
changed. This commit changes that behavior to only invalidate code
blocks associated with the IDs that are being changed.

Changing this code required changing a bit about the way we're walking
through the ISEQs. In order to reuse the rb_iseq_each iterator, it was
necessary to make another callback that would be called whenever a
getconstant instruction was hit. This makes it nicer to interact with on
the rust side, but a little difficult to understand on the C side since
there are nested callbacks. Hopefully I've mitigated that enough with
comments.