### PR TITLE
Fix crash with yjit-global-constant-state

### DIFF
--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -281,14 +281,14 @@ pub extern "C" fn rb_yjit_constant_state_changed(id: ID) {
             // If the global-constant-state option is set, then we're going to
             // invalidate every block that depends on any constant.
 
-            let constant_state = mem::take(&mut Invariants::get_instance().constant_state_blocks);
-
-            for (_, blocks) in constant_state.iter() {
-                for block in blocks.iter() {
-                    invalidate_block_version(block);
-                    incr_counter!(invalidate_constant_state_bump);
+            Invariants::get_instance().constant_state_blocks.keys().for_each(|id| {
+                if let Some(blocks) = Invariants::get_instance().constant_state_blocks.remove(&id) {
+                    for block in &blocks {
+                        invalidate_block_version(block);
+                        incr_counter!(invalidate_constant_state_bump);
+                    }
                 }
-            }
+            });
         } else {
             // If the global-constant-state option is not set, then we're only going
             // to invalidate the blocks that are associated with the given ID.


### PR DESCRIPTION
Previously when we were invalidating blocks for constant invalidation
with `--yjit-global-constant-state` set, it would crash in checking the
block entry/exits. This instead iterates through the blocks in the same
way as when the option is not set, which makes it work.

You can test this out with the following `test.rb` file:

```ruby
puts "=" * 500

FOO = 1
BAR = 1

def foo
  FOO
end

def bar
  BAR
end

foo
foo
foo

bar
bar
bar

FOO = 2

foo
foo
foo

bar
bar
bar
```

and the following patch:

```diff
diff --git a/yjit/src/invariants.rs b/yjit/src/invariants.rs
index 966f0ea533..88011f688a 100644
--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -276,24 +276,29 @@ pub extern "C" fn rb_yjit_constant_state_changed(id: ID) {
         return;
     }
 
+    println!("INVALIDATING {}", id);
     with_vm_lock(src_loc!(), || {
         if get_option!(global_constant_state) {
             // If the global-constant-state option is set, then we're going to
             // invalidate every block that depends on any constant.
 
-            let constant_state = mem::take(&mut Invariants::get_instance().constant_state_blocks);
+            Invariants::get_instance().constant_state_blocks.keys().for_each(|id| {
+                if let Some(blocks) = Invariants::get_instance().constant_state_blocks.remove(&id) {
+                    println!("  {} blocks", blocks.len());
 
-            for (_, blocks) in constant_state.iter() {
-                for block in blocks.iter() {
-                    invalidate_block_version(block);
-                    incr_counter!(invalidate_constant_state_bump);
+                    for block in &blocks {
+                        invalidate_block_version(block);
+                        incr_counter!(invalidate_constant_state_bump);
+                    }
                 }
-            }
+            });
         } else {
             // If the global-constant-state option is not set, then we're only going
             // to invalidate the blocks that are associated with the given ID.
 
             if let Some(blocks) = Invariants::get_instance().constant_state_blocks.remove(&id) {
+                println!("  {} blocks", blocks.len());
+
                 for block in &blocks {
                     invalidate_block_version(block);
                     incr_counter!(invalidate_constant_state_bump);
```

Then running `make -j runruby RUN_OPTS="--yjit --yjit-call-threshold=2"` and `make -j runruby RUN_OPTS="--yjit --yjit-call-threshold=2 --yjit-global-constant-state"`. When you do that, you see the difference in how many blocks it invalidates.