### PR TITLE
Move String RVALUES between pools

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8202,7 +8202,7 @@ gc_compact_destination_pool(rb_objspace_t *objspace, rb_size_pool_t *src_pool, V
             }
             else {
                 GC_ASSERT(!STR_EMBED_P(src));
-                return src_pool;
+                return &size_pools[0];
             }
         default:
             return src_pool;

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -556,6 +556,9 @@ RSTRING_LENINT(VALUE str)
     return rb_long2int(RSTRING_LEN(str));
 }
 
+bool
+rb_str_shared_root_p(VALUE str);
+
 /**
  * Convenient macro to obtain the contents and length at once.
  *

--- a/internal/string.h
+++ b/internal/string.h
@@ -59,6 +59,10 @@ void rb_str_tmp_frozen_release(VALUE str, VALUE tmp);
 VALUE rb_setup_fake_str(struct RString *fake_str, const char *name, long len, rb_encoding *enc);
 VALUE rb_str_upto_each(VALUE, VALUE, int, int (*each)(VALUE, VALUE), VALUE);
 VALUE rb_str_upto_endless_each(VALUE, int (*each)(VALUE, VALUE), VALUE);
+void rb_str_make_embedded(VALUE);
+size_t rb_str_size_as_embedded(VALUE);
+bool rb_str_pool_moveable_p(VALUE);
+void rb_str_update_shared_ary(VALUE str, VALUE old_root, VALUE new_root);
 RUBY_SYMBOL_EXPORT_END
 
 MJIT_SYMBOL_EXPORT_BEGIN

--- a/string.c
+++ b/string.c
@@ -221,17 +221,51 @@ str_embed_capa(VALUE str)
 #endif
 }
 
+bool
+rb_str_pool_moveable_p(VALUE str)
+{
+    return !FL_TEST(str, STR_NOFREE|STR_SHARED_ROOT|STR_SHARED);
+}
+
 static inline size_t
-str_embed_size(long capa)
+rb_str_embed_size(long capa)
 {
     return offsetof(struct RString, as.embed.ary) + capa;
+}
+
+bool
+rb_str_shared_root_p(VALUE str)
+{
+    return FL_TEST_RAW(str, STR_SHARED_ROOT);
+}
+
+size_t
+rb_str_size_as_embedded(VALUE str)
+{
+    size_t real_size;
+#if USE_RVARGC
+    if (STR_EMBED_P(str)) {
+        real_size = rb_str_embed_size(RSTRING(str)->as.embed.len) + TERM_LEN(str);
+    }
+    /* if the string is not currently embedded, but it can be embedded, how
+     * much space would it require */
+    else if (rb_str_pool_moveable_p(str)) {
+        real_size = rb_str_embed_size(RSTRING(str)->as.heap.len) + TERM_LEN(str);
+    }
+    else {
+#endif
+        real_size = sizeof(struct RString);
+#if USE_RVARGC
+    }
+#endif
+    return real_size;
 }
 
 static inline bool
 STR_EMBEDDABLE_P(long len, long termlen)
 {
 #if USE_RVARGC
-    return rb_gc_size_allocatable_p(str_embed_size(len + termlen));
+    return rb_gc_size_allocatable_p(rb_str_embed_size(len + termlen));
 #else
     return len <= RSTRING_EMBED_LEN_MAX + 1 - termlen;
 #endif
@@ -262,6 +296,41 @@ rb_str_make_independent(VALUE str)
     if (str_dependent_p(str)) {
         str_make_independent(str);
     }
+}
+
+void
+rb_str_make_embedded(VALUE str) {
+    assert(rb_str_pool_moveable_p(str));
+    assert(!STR_EMBED_P(str));
+
+    char *buf = RSTRING_PTR(str);
+    long len = RSTRING_LEN(str);
+
+    STR_SET_EMBED(str);
+    STR_SET_EMBED_LEN(str, len);
+
+    memmove(RSTRING_PTR(str), buf, len);
+    ruby_xfree(buf);
+}
+
+void
+rb_str_update_shared_ary(VALUE str, VALUE old_root, VALUE new_root)
+{
+    // if the root location hasn't changed, we don't need to update
+    if (new_root == old_root) {
+        return;
+    }
+
+    // if the root string isn't embedded, we don't need to touch the ponter.
+    // it already points to the shame shared buffer
+    if (!STR_EMBED_P(new_root)) {
+        return;
+    }
+
+    size_t offset = (size_t)((uintptr_t)RSTRING(str)->as.heap.ptr - (uintptr_t)RSTRING(old_root)->as.embed.ary);
+
+    RUBY_ASSERT(RSTRING(str)->as.heap.ptr >= RSTRING(old_root)->as.embed.ary);
+    RSTRING(str)->as.heap.ptr = RSTRING(new_root)->as.embed.ary + offset;
 }
 
 void
@@ -849,7 +918,7 @@ str_alloc(VALUE klass, size_t size)
 static inline VALUE
 str_alloc_embed(VALUE klass, size_t capa)
 {
-    size_t size = str_embed_size(capa);
+    size_t size = rb_str_embed_size(capa);
     assert(rb_gc_size_allocatable_p(size));
 #if !USE_RVARGC
     assert(size <= sizeof(struct RString));
@@ -1693,7 +1762,7 @@ ec_str_alloc(struct rb_execution_context_struct *ec, VALUE klass, size_t size)
 static inline VALUE
 ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t capa)
 {
-    size_t size = str_embed_size(capa);
+    size_t size = rb_str_embed_size(capa);
     assert(rb_gc_size_allocatable_p(size));
 #if !USE_RVARGC
     assert(size <= sizeof(struct RString));

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -212,8 +212,6 @@ class TestGCCompact < Test::Unit::TestCase
   def test_moving_strings_between_size_pools
     assert_separately([], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
-      require 'objspace'
-      require 'json'
       moveables = []
       small_slots = []
       large_slots = []

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -230,7 +230,6 @@ class TestGCCompact < Test::Unit::TestCase
   end
 
   def test_embedding_strings_that_moved_to_a_larger_size_pool
-    omit
     require 'objspace'
     require 'json'
     list = generate_strings_resized_up
@@ -241,7 +240,6 @@ class TestGCCompact < Test::Unit::TestCase
   end
 
   def test_embedding_strings_that_moved_to_a_smaller_size_pool
-    omit
     require 'objspace'
     require 'json'
     list = generate_strings_resized_down


### PR DESCRIPTION
And re-embed any strings that can now fit inside the slot they've been
moved to