### PR TITLE
Draft: special-case String in jit_guard_known_klass

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -83,7 +83,7 @@ jobs:
             value: 'gcc-11 -O2 -fcf-protection -Wl,-z,now'
             container: gcc-11
             env:
-              # FIXME: Drop skiping options
+              # FIXME: Drop skipping options
               # https://bugs.ruby-lang.org/issues/18061
               # https://sourceware.org/annobin/annobin.html/Test-pie.html
               # https://sourceware.org/annobin/annobin.html/Test-notes.html

--- a/NEWS.md
+++ b/NEWS.md
@@ -156,6 +156,7 @@ Note: We're only listing outstanding class updates.
     * net-http 0.2.2
     * net-protocol 0.1.3
     * ostruct 0.5.5
+    * psych 5.0.0.dev
     * reline 0.3.1
     * securerandom 0.2.0
     * stringio 3.0.3

--- a/README.md
+++ b/README.md
@@ -27,14 +27,12 @@ It is simple, straightforward, and extensible.
   well as Windows, macOS, etc.) cf.
   https://github.com/ruby/ruby/blob/master/doc/maintainers.rdoc#label-Platform+Maintainers
 
-## How to get Ruby
+## How to get Ruby with Git
 
 For a complete list of ways to install Ruby, including using third-party tools
 like rvm, see:
 
 https://www.ruby-lang.org/en/downloads/
-
-### Git
 
 The mirror of the Ruby source tree can be checked out with the following command:
 
@@ -47,17 +45,6 @@ to see the list of branches:
 
 You may also want to use https://git.ruby-lang.org/ruby.git (actual master of Ruby source)
 if you are a committer.
-
-### Subversion
-
-Stable branches for older Ruby versions can be checked out with also the
-following command:
-
-    $ svn co https://svn.ruby-lang.org/repos/ruby/branches/ruby_2_6/ ruby
-
-Try the following command to see the list of branches:
-
-    $ svn ls https://svn.ruby-lang.org/repos/ruby/branches/
 
 ## Ruby home page
 

--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -70,5 +70,5 @@ with the Ruby script you'd like to run. You can use the following make targets:
 * `make lldb`: Runs `test.rb` using Miniruby in lldb
 * `make gdb`: Runs `test.rb` using Miniruby in gdb
 * `make runruby`: Runs `test.rb` using Ruby
-* `make lldb-runruby`: Runs `test.rb` using Ruby in lldb
-* `make gdb-runruby`: Runs `test.rb` using Ruby in gdb
+* `make lldb-ruby`: Runs `test.rb` using Ruby in lldb
+* `make gdb-ruby`: Runs `test.rb` using Ruby in gdb

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -6,17 +6,22 @@ in the Ruby core and in the Ruby standard library.
 
 ## Generating documentation
 
-Most Ruby documentation lives in the source files and is written in [RDoc format](https://ruby.github.io/rdoc/RDoc/Markup.html).
+Most Ruby documentation lives in the source files and is written in
+[RDoc format](rdoc-ref:RDoc::Markup).
 
-Some pages live under the `doc` folder and can be written in either `.rdoc` or `.md` format, determined by the file extension.
+Some pages live under the `doc` folder and can be written in either
+`.rdoc` or `.md` format, determined by the file extension.
 
-To generate the output of documentation changes in HTML in the `{build folder}/.ext/html` directory, run the following inside your build directory:
+To generate the output of documentation changes in HTML in the
+`{build folder}/.ext/html` directory, run the following inside your
+build directory:
 
-```
+```sh
 make html
 ```
 
-Then you can preview your changes by opening `{build folder}/.ext/html/index.html` file in your browser.
+Then you can preview your changes by opening
+`{build folder}/.ext/html/index.html` file in your browser.
 
 
 ## Goal
@@ -56,10 +61,10 @@ Use only US-ASCII-compatible characters in a C source file.
 
 If want to put ASCII-incompatible characters into the documentation
 for a C-coded class, module, or method, there are workarounds
-involving new files <tt>doc/*.rdoc</tt>:
+involving new files `doc/*.rdoc`:
 
-- For class `Foo` (defined in file <tt>foo.c</tt>),
-  create file <tt>doc/foo.rdoc</tt>, declare <tt>class Foo; end</tt>,
+- For class `Foo` (defined in file `foo.c`),
+  create file `doc/foo.rdoc`, declare `class Foo; end`,
   and place the class documentation above that declaration:
 
     ```ruby
@@ -67,8 +72,8 @@ involving new files <tt>doc/*.rdoc</tt>:
     class Foo; end
     ```
 
-- Similarly, for module `Bar` (defined in file <tt>bar.c</tt>,
-  create file <tt>doc/bar.rdoc</tt>, declare <tt>module Bar; end</tt>,
+- Similarly, for module `Bar` (defined in file `bar.c`,
+  create file `doc/bar.rdoc`, declare `module Bar; end`,
   and place the module documentation above that declaration:
 
     ```ruby
@@ -81,8 +86,8 @@ involving new files <tt>doc/*.rdoc</tt>:
   in the rendered documentation.
 
     Therefore it's best to use file inclusion:
-    
-    - Retain the call-seq in the C code.
+
+    - Retain the `call-seq` in the C code.
     - Use file inclusion (`:include:`) to include text from an .rdoc file.
 
     Example:
@@ -93,7 +98,7 @@ involving new files <tt>doc/*.rdoc</tt>:
      *    each_byte {|byte| ... } -> self
      *    each_byte               -> enumerator
      *
-     *  \:include: doc/string/each_byte.rdoc
+     *  :include: doc/string/each_byte.rdoc
      *
      */
     ```
@@ -104,13 +109,13 @@ Ruby is documented using RDoc.
 For information on \RDoc syntax and features, see the
 [RDoc Markup Reference](rdoc-ref:RDoc::Markup@RDoc+Markup+Reference).
 
-### Output from <tt>irb</tt>
+### Output from `irb`
 
 For code examples, consider using interactive Ruby,
 [irb](https://ruby-doc.org/stdlib/libdoc/irb/rdoc/IRB.html).
 
 For a code example that includes `irb` output,
-consider aligning <tt># => ...</tt> in successive lines.
+consider aligning `# => ...` in successive lines.
 Alignment may sometimes aid readability:
 
 ```ruby
@@ -135,7 +140,7 @@ This is unnecessary for the HTML output, but helps in the `ri` output.
 ### Auto-Linking
 
 In general, \RDoc's auto-linking should not be suppressed.
-For example, we should write `Array`, not <tt>\Array</tt>.
+For example, we should write `Array`, not `\Array`.
 
 We might consider whether to suppress when:
 
@@ -172,7 +177,7 @@ The documentation for a class or module may include a "What's Here" section.
 
 Guidelines:
 
-- The section title is <tt>What's Here</tt>.
+- The section title is `What's Here`.
 - Consider listing the parent class and any included modules; consider
   [links](rdoc-ref:RDoc::Markup@Links)
   to their "What's Here" sections if those exist.
@@ -210,18 +215,18 @@ For methods written in Ruby, \RDoc documents the calling sequence automatically.
 
 For methods written in C, \RDoc cannot determine what arguments
 the method accepts, so those need to be documented using \RDoc directive
-[:call-seq:](rdoc-ref:RDoc::Markup@Method+arguments).
+[`:call-seq:`](rdoc-ref:RDoc::Markup@Method+arguments).
 
 Example:
 
-```
+```c
 *  call-seq:
 *    array.count -> integer
 *    array.count(obj) -> integer
 *    array.count {|element| ... } -> integer
 ```
 
-When creating the <tt>call-seq</tt>, use the form
+When creating the `call-seq`, use the form
 
 ```
 receiver_type.method_name(arguments) {|block_arguments|} -> return_type
@@ -234,9 +239,9 @@ In the cases where method can return multiple different types, separate the
 types with "or".  If the method can return any type, use "object".  If the
 method returns the receiver, use "self".
 
-In cases where the method accepts optional arguments, use a <tt>call-seq</tt>
-with an optional argument if the method has the same behavior when an argument
-is omitted as when the argument is passed with the default value.  For example,
+In cases where the method accepts optional arguments, use a `call-seq` with
+an optional argument if the method has the same behavior when an argument is
+omitted as when the argument is passed with the default value.  For example,
 use:
 
 ```
@@ -250,13 +255,13 @@ obj.respond_to?(symbol) -> true or false
 obj.respond_to?(symbol, include_all) -> true or false
 ```
 
-However, as shown above for <tt>Array#count</tt>, use separate lines if the
+However, as shown above for `Array#count`, use separate lines if the
 behavior is different if the argument is omitted.
 
-Omit aliases from the call-seq, but mention them near the end (see below).
+Omit aliases from the `call-seq`, but mention them near the end (see below).
 
 
-A `call-seq` block should have <tt>{|x| ... }</tt>, not <tt>{|x| block }</tt> or <tt>{|x| code }</tt>.
+A `call-seq` block should have `{|x| ... }`, not `{|x| block }` or `{|x| code }`.
 
 A `call-seq` output should:
 
@@ -271,7 +276,7 @@ method does and why you would want to use it.  Ideally, this
 is a single sentence, but for more complex methods it may require
 an entire paragraph.
 
-For <tt>Array#count</tt>, the synopsis is:
+For `Array#count`, the synopsis is:
 
 ```
 Returns a count of specified elements.
@@ -328,9 +333,9 @@ the behavior, but do not provide any examples.
 
 Only document exceptions raised if they are not obvious.  For example,
 if you have stated earlier than an argument type must be an integer,
-you do not need to document that a \TypeError is raised if a non-integer
+you do not need to document that a `TypeError` is raised if a non-integer
 is passed.  Do not provide examples of exceptions being raised unless
-that is a common case, such as \Hash#fetch raising a \KeyError.
+that is a common case, such as `Hash#fetch` raising a `KeyError`.
 
 ### Aliases
 

--- a/ext/psych/lib/psych/versions.rb
+++ b/ext/psych/lib/psych/versions.rb
@@ -2,7 +2,7 @@
 
 module Psych
   # The version of Psych you are using
-  VERSION = '4.0.4.dev'
+  VERSION = '5.0.0.dev'
 
   if RUBY_ENGINE == 'jruby'
     DEFAULT_SNAKEYAML_VERSION = '1.28'.freeze

--- a/ext/psych/lib/psych/versions.rb
+++ b/ext/psych/lib/psych/versions.rb
@@ -2,7 +2,7 @@
 
 module Psych
   # The version of Psych you are using
-  VERSION = '4.0.3'
+  VERSION = '4.0.4.dev'
 
   if RUBY_ENGINE == 'jruby'
     DEFAULT_SNAKEYAML_VERSION = '1.28'.freeze

--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -26,7 +26,7 @@
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */
-#if defined(HAVE_FUNC_WEAK) && !defined(_WIN32) && !defined(__MINGW32__)
+#if defined(HAVE_FUNC_WEAK) && !defined(_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
 # define RUBY_DLN_CHECK_ABI
 #endif
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -102,10 +102,13 @@ require_relative "irb/easter-egg"
 #
 # == Configuration
 #
-# IRB reads from <code>~/.irbrc</code> when it's invoked.
+# IRB reads a personal initialization file when it's invoked.
+# IRB searches a file in the following order and loads the first one found.
 #
-# If <code>~/.irbrc</code> doesn't exist, +irb+ will try to read in the following order:
-#
+# * +$IRBRC+ (if +$IRBRC+ is set)
+# * +$XDG_CONFIG_HOME/irb/irbrc+ (if +$XDG_CONFIG_HOME+ is set)
+# * +~/.irbrc+
+# * +.config/irb/irbrc+
 # * +.irbrc+
 # * +irb.rc+
 # * +_irbrc+

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -67,11 +67,13 @@ module Timeout
       @message = message
 
       @mutex = Mutex.new
-      @done = false
+      @done = false # protected by @mutex
     end
 
     def done?
-      @done
+      @mutex.synchronize do
+        @done
+      end
     end
 
     def expired?(now)

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -77,7 +77,7 @@ module Timeout
     end
 
     def expired?(now)
-      now >= @deadline and !done?
+      now >= @deadline
     end
 
     def interrupt

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # Timeout long-running blocks
 #
 # == Synopsis
@@ -23,7 +23,7 @@
 # Copyright:: (C) 2000  Information-technology Promotion Agency, Japan
 
 module Timeout
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.0"
 
   # Raised by Timeout.timeout when the block times out.
   class Error < RuntimeError
@@ -50,9 +50,79 @@ module Timeout
   end
 
   # :stopdoc:
-  THIS_FILE = /\A#{Regexp.quote(__FILE__)}:/o
-  CALLER_OFFSET = ((c = caller[0]) && THIS_FILE =~ c) ? 1 : 0
-  private_constant :THIS_FILE, :CALLER_OFFSET
+  CONDVAR = ConditionVariable.new
+  QUEUE = Queue.new
+  QUEUE_MUTEX = Mutex.new
+  TIMEOUT_THREAD_MUTEX = Mutex.new
+  @timeout_thread = nil
+  private_constant :CONDVAR, :QUEUE, :QUEUE_MUTEX, :TIMEOUT_THREAD_MUTEX
+
+  class Request
+    attr_reader :deadline
+
+    def initialize(thread, timeout, exception_class, message)
+      @thread = thread
+      @deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      @exception_class = exception_class
+      @message = message
+
+      @mutex = Mutex.new
+      @done = false
+    end
+
+    def done?
+      @done
+    end
+
+    def expired?(now)
+      now >= @deadline and !done?
+    end
+
+    def interrupt
+      @mutex.synchronize do
+        unless @done
+          @thread.raise @exception_class, @message
+          @done = true
+        end
+      end
+    end
+
+    def finished
+      @mutex.synchronize do
+        @done = true
+      end
+    end
+  end
+  private_constant :Request
+
+  def self.ensure_timeout_thread_created
+    unless @timeout_thread
+      TIMEOUT_THREAD_MUTEX.synchronize do
+        @timeout_thread ||= Thread.new do
+          requests = []
+          while true
+            until QUEUE.empty? and !requests.empty? # wait to have at least one request
+              req = QUEUE.pop
+              requests << req unless req.done?
+            end
+            closest_deadline = requests.min_by(&:deadline).deadline
+
+            now = 0.0
+            QUEUE_MUTEX.synchronize do
+              while (now = Process.clock_gettime(Process::CLOCK_MONOTONIC)) < closest_deadline and QUEUE.empty?
+                CONDVAR.wait(QUEUE_MUTEX, closest_deadline - now)
+              end
+            end
+
+            requests.each do |req|
+              req.interrupt if req.expired?(now)
+            end
+            requests.reject!(&:done?)
+          end
+        end
+      end
+    end
+  end
   # :startdoc:
 
   # Perform an operation in a block, raising an error if it takes longer than
@@ -83,51 +153,32 @@ module Timeout
   def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
     return yield(sec) if sec == nil or sec.zero?
 
-    message ||= "execution expired".freeze
+    message ||= "execution expired"
 
     if Fiber.respond_to?(:current_scheduler) && (scheduler = Fiber.current_scheduler)&.respond_to?(:timeout_after)
       return scheduler.timeout_after(sec, klass || Error, message, &block)
     end
 
-    from = "from #{caller_locations(1, 1)[0]}" if $DEBUG
-    e = Error
-    bl = proc do |exception|
+    Timeout.ensure_timeout_thread_created
+    perform = Proc.new do |exc|
+      request = Request.new(Thread.current, sec, exc, message)
+      QUEUE_MUTEX.synchronize do
+        QUEUE << request
+        CONDVAR.signal
+      end
       begin
-        x = Thread.current
-        y = Thread.start {
-          Thread.current.name = from
-          begin
-            sleep sec
-          rescue => e
-            x.raise e
-          else
-            x.raise exception, message
-          end
-        }
         return yield(sec)
       ensure
-        if y
-          y.kill
-          y.join # make sure y is dead.
-        end
+        request.finished
       end
     end
-    if klass
-      begin
-        bl.call(klass)
-      rescue klass => e
-        message = e.message
-        bt = e.backtrace
-      end
-    else
-      bt = Error.catch(message, &bl)
-    end
-    level = -caller(CALLER_OFFSET).size-2
-    while THIS_FILE =~ bt[level]
-      bt.delete_at(level)
-    end
-    raise(e, message, bt)
-  end
 
+    if klass
+      perform.call(klass)
+    else
+      backtrace = Error.catch(&perform)
+      raise Error, message, backtrace
+    end
+  end
   module_function :timeout
 end

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -311,8 +311,7 @@ $(LIBRUBY_A):
 		  echo 'merging $(YJIT_LIBS) into $@' && \
 		  $(RMALL)    libyjit/ && \
 		  $(MAKEDIRS) libyjit/ && \
-		  $(CP) '$(YJIT_LIBS)' libyjit/ && \
-		  (cd libyjit/ && $(AR) -x libyjit.a) && \
+		  (cd libyjit/ && $(AR) -x ../$(YJIT_LIBS)) && \
 		  :  "$(AR) $(ARFLAGS) $@ libyjit/*.$(OBJEXT)" && \
 		  find libyjit/ -name '*.$(OBJEXT)' -exec $(AR) $(ARFLAGS) $@ '{}' '+' ; \
 		fi

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -311,6 +311,7 @@ $(LIBRUBY_A):
 		  $(ECHO0) 'merging $(YJIT_LIBS) into $@' && \
 		  $(RMALL)    libyjit/ && \
 		  $(MAKEDIRS) libyjit/ && \
+		  trap "$(RMALL) libyjit/" 0 && \
 		  (cd libyjit/ && $(AR) -x ../$(YJIT_LIBS)) && \
 		  :  "$(AR) $(ARFLAGS) $@ libyjit/*.$(OBJEXT)" && \
 		  find libyjit/ -name '*.$(OBJEXT)' -exec $(AR) $(ARFLAGS) $@ '{}' '+' ; \

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -307,8 +307,8 @@ $(LIBRUBY_A):
 		$(ECHO) linking static-library $@
 		$(Q) $(AR) $(ARFLAGS) $@ $(LIBRUBY_A_OBJS) $(INITOBJS)
 		$(Q) if [ 'no' != '$(YJIT_SUPPORT)' ]; then \
-		  set -eu && \
-		  echo 'merging $(YJIT_LIBS) into $@' && \
+		  set -eu$(V0:1=x) && \
+		  $(ECHO0) 'merging $(YJIT_LIBS) into $@' && \
 		  $(RMALL)    libyjit/ && \
 		  $(MAKEDIRS) libyjit/ && \
 		  (cd libyjit/ && $(AR) -x ../$(YJIT_LIBS)) && \

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -309,11 +309,12 @@ $(LIBRUBY_A):
 		$(Q) if [ 'no' != '$(YJIT_SUPPORT)' ]; then \
 		  set -eu && \
 		  echo 'merging $(YJIT_LIBS) into $@' && \
-		  $(RMALL)    '$(CARGO_TARGET_DIR)/libyjit/' && \
-		  $(MAKEDIRS) '$(CARGO_TARGET_DIR)/libyjit/' && \
-		  $(CP) '$(YJIT_LIBS)' '$(CARGO_TARGET_DIR)/libyjit/' && \
-		  (cd '$(CARGO_TARGET_DIR)/libyjit/' && $(AR) -x libyjit.a) && \
-		  find '$(CARGO_TARGET_DIR)/libyjit/' -name '*.o' -exec $(AR) $(ARFLAGS) $@ '{}' '+' ; \
+		  $(RMALL)    libyjit/ && \
+		  $(MAKEDIRS) libyjit/ && \
+		  $(CP) '$(YJIT_LIBS)' libyjit/ && \
+		  (cd libyjit/ && $(AR) -x libyjit.a) && \
+		  :  "$(AR) $(ARFLAGS) $@ libyjit/*.$(OBJEXT)" && \
+		  find libyjit/ -name '*.$(OBJEXT)' -exec $(AR) $(ARFLAGS) $@ '{}' '+' ; \
 		fi
 		@-$(RANLIB) $@ 2> /dev/null || true
 

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -139,4 +139,24 @@ class TestTimeout < Test::Unit::TestCase
     }
     assert(ok, bug11344)
   end
+
+  def test_fork
+    omit 'fork not supported' unless Process.respond_to?(:fork)
+    r, w = IO.pipe
+    pid = fork do
+      r.close
+      begin
+        r = Timeout.timeout(0.01) { sleep 5 }
+        w.write r.inspect
+      rescue Timeout::Error
+        w.write 'timeout'
+      ensure
+        w.close
+      end
+    end
+    w.close
+    Process.wait pid
+    assert_equal 'timeout', r.read
+    r.close
+  end
 end

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -10,6 +10,18 @@ class TestTimeout < Test::Unit::TestCase
     end
   end
 
+  def test_included
+    c = Class.new do
+      include Timeout
+      def test
+        timeout(1) { :ok }
+      end
+    end
+    assert_nothing_raised do
+      assert_equal :ok, c.new.test
+    end
+  end
+
   def test_yield_param
     assert_equal [5, :ok], Timeout.timeout(5){|s| [s, :ok] }
   end
@@ -43,6 +55,7 @@ class TestTimeout < Test::Unit::TestCase
         begin
           sleep 3
         rescue Exception => e
+          flunk "should not see any exception but saw #{e.inspect}"
         end
       end
     end

--- a/variable.c
+++ b/variable.c
@@ -2299,7 +2299,8 @@ autoload_feature_lookup_or_create(VALUE feature, struct autoload_data **autoload
         if (autoload_data_pointer) *autoload_data_pointer = autoload_data;
 
         rb_hash_aset(autoload_features, feature, autoload_data_value);
-    } else if (autoload_data_pointer) {
+    }
+    else if (autoload_data_pointer) {
         *autoload_data_pointer = rb_check_typeddata(autoload_data_value, &autoload_data_type);
     }
 
@@ -2323,7 +2324,9 @@ autoload_feature_clear_if_empty(VALUE argument)
 }
 #endif
 
-static struct st_table* autoload_table_lookup_or_create(VALUE module) {
+static struct st_table *
+autoload_table_lookup_or_create(VALUE module)
+{
     // Get or create an autoload table in the class instance variables:
     struct st_table *table = RCLASS_IV_TBL(module);
     VALUE autoload_table_value;
@@ -2654,7 +2657,9 @@ autoload_apply_constants(VALUE _arguments)
         struct autoload_const *autoload_const;
         struct autoload_const *next;
 
-        // We use safe iteration here because `autoload_const_set` will eventually invoke `autoload_delete` which will remove the constant from the linked list. In theory, once the `autoload_data->constants` linked list is empty, we can remove it.
+        // We use safe iteration here because `autoload_const_set` will eventually invoke
+        // `autoload_delete` which will remove the constant from the linked list. In theory, once
+        // the `autoload_data->constants` linked list is empty, we can remove it.
 
         // Iterate over all constants and assign them:
         ccan_list_for_each_safe(&arguments->autoload_data->constants, autoload_const, next, cnode) {
@@ -2680,7 +2685,10 @@ autoload_try_load(VALUE _arguments)
 {
     struct autoload_load_arguments *arguments = (struct autoload_load_arguments*)_arguments;
 
-    // We have tried to require the autoload feature, so we shouldn't bother trying again in any other threads. More specifically, `arguments->result` starts of as nil, but then contains the result of `require` which is either true or false. Provided it's not nil, it means some other thread has got as far as evaluating the require statement completely.
+    // We have tried to require the autoload feature, so we shouldn't bother trying again in any
+    // other threads. More specifically, `arguments->result` starts of as nil, but then contains the
+    // result of `require` which is either true or false. Provided it's not nil, it means some other
+    // thread has got as far as evaluating the require statement completely.
     if (arguments->result != Qnil) return arguments->result;
 
     // Try to require the autoload feature:
@@ -2694,7 +2702,8 @@ autoload_try_load(VALUE _arguments)
         arguments->result = Qfalse;
 
         rb_const_remove(arguments->module, arguments->name);
-    } else {
+    }
+    else {
         // Otherwise, it was loaded, copy the flags from the autoload constant:
         ce->flag |= arguments->flag;
     }

--- a/variable.c
+++ b/variable.c
@@ -2307,6 +2307,7 @@ autoload_feature_lookup_or_create(VALUE feature, struct autoload_data **autoload
     return autoload_data_value;
 }
 
+#if 0
 static VALUE
 autoload_feature_clear_if_empty(VALUE argument)
 {
@@ -2320,6 +2321,7 @@ autoload_feature_clear_if_empty(VALUE argument)
 
     return Qnil;
 }
+#endif
 
 static struct st_table* autoload_table_lookup_or_create(VALUE module) {
     // Get or create an autoload table in the class instance variables:

--- a/version.h
+++ b/version.h
@@ -15,7 +15,7 @@
 
 #define RUBY_RELEASE_YEAR 2022
 #define RUBY_RELEASE_MONTH 5
-#define RUBY_RELEASE_DAY 18
+#define RUBY_RELEASE_DAY 19
 
 #include "ruby/version.h"
 #include "ruby/internal/abi.h"

--- a/version.h
+++ b/version.h
@@ -15,7 +15,7 @@
 
 #define RUBY_RELEASE_YEAR 2022
 #define RUBY_RELEASE_MONTH 5
-#define RUBY_RELEASE_DAY 17
+#define RUBY_RELEASE_DAY 18
 
 #include "ruby/version.h"
 #include "ruby/internal/abi.h"

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -30,6 +30,13 @@ pub const REG0_8: X86Opnd = AL;
 pub const REG1: X86Opnd = RCX;
 // pub const REG1_32: X86Opnd = ECX;
 
+// A block that can be invalidated needs space to write a jump.
+// We'll reserve a minimum size for any block that could
+// be invalidated. In this case the JMP takes 5 bytes, but
+// gen_send_general will always MOV the receiving object
+// into place, so 3 bytes are always written automatically.
+pub const JUMP_SIZE_IN_BYTES:usize = 2;
+
 /// Status returned by code generation functions
 #[derive(PartialEq, Debug)]
 enum CodegenStatus {
@@ -3401,6 +3408,32 @@ fn jit_guard_known_klass(
             jit_chain_guard(JCC_JNE, jit, ctx, cb, ocb, max_chain_depth, side_exit);
             ctx.upgrade_opnd_type(insn_opnd, Type::Flonum);
         }
+    } else if unsafe { known_klass == rb_cString } && sample_instance.string_p() {
+        assert!(!val_type.is_imm());
+        if val_type != Type::String {
+            assert!(val_type.is_unknown());
+
+            // Need the check for immediate, because trying to look up the klass field of an immediate will segfault
+            if !val_type.is_heap() {
+                add_comment(cb, "guard not immediate (for string)");
+                assert!(Qfalse.as_i32() < Qnil.as_i32());
+                test(cb, REG0, imm_opnd(RUBY_IMMEDIATE_MASK as i64));
+                jit_chain_guard(JCC_JNZ, jit, ctx, cb, ocb, max_chain_depth, side_exit);
+                cmp(cb, REG0, imm_opnd(Qnil.into()));
+                jit_chain_guard(JCC_JBE, jit, ctx, cb, ocb, max_chain_depth, side_exit);
+            }
+
+            add_comment(cb, "guard object is string");
+            let klass_opnd = mem_opnd(64, REG0, RUBY_OFFSET_RBASIC_KLASS);
+            mov(cb, REG1, uimm_opnd(unsafe { rb_cString }.into()));
+            cmp(cb, klass_opnd, REG1);
+            jit_chain_guard(JCC_JNE, jit, ctx, cb, ocb, max_chain_depth, side_exit);
+
+            // Upgrading here causes an error with invalidation writing past end of block
+            ctx.upgrade_opnd_type(insn_opnd, Type::String);
+        } else {
+            add_comment(cb, "skip guard - known to be a string");
+        }
     } else if unsafe {
         FL_TEST(known_klass, VALUE(RUBY_FL_SINGLETON)) != VALUE(0)
             && sample_instance == rb_attr_get(known_klass, id__attached__ as ID)
@@ -3827,7 +3860,13 @@ fn gen_send_cfunc(
     if kw_arg.is_null() {
         let codegen_p = lookup_cfunc_codegen(unsafe { (*cme).def });
         if let Some(known_cfunc_codegen) = codegen_p {
+            let start_pos = cb.get_write_ptr().raw_ptr() as usize;
             if known_cfunc_codegen(jit, ctx, cb, ocb, ci, cme, block, argc, recv_known_klass) {
+                let written_bytes = cb.get_write_ptr().raw_ptr() as usize - start_pos;
+                if written_bytes < JUMP_SIZE_IN_BYTES {
+                    add_comment(cb, "Writing NOPs to leave room for later invalidation code");
+                    nop(cb, (JUMP_SIZE_IN_BYTES - written_bytes) as u32);
+                }
                 // cfunc codegen generated code. Terminate the block so
                 // there isn't multiple calls in the same block.
                 jump_to_next_insn(jit, ctx, cb, ocb);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -461,6 +461,11 @@ impl VALUE {
         self == Qnil
     }
 
+    /// Returns true or false depending whether the value is a string
+    pub fn string_p(self) -> bool {
+        unsafe { CLASS_OF(self) == rb_cString }
+    }
+
     /// Read the flags bits from the RBasic object, then return a Ruby type enum (e.g. RUBY_T_ARRAY)
     pub fn builtin_type(self) -> ruby_value_type {
         assert!(!self.special_const_p());


### PR DESCRIPTION
This PR lets YJIT skip the guards when it's sure from type information that a particular object is a string. However, it seems like that's very difficult to do in practice for strings. I'm putting up this draft PR against current CRuby head-of-master. But I don't think this is useful yet.

It might be possible to make it useful by adding a jit_rb_str_unary_plus function that knows it returns a string and then using unary plus to create the string receiver. In the mean time I think this is a curiosity, not a useful addition to YJIT.