### PR TITLE
Conscise IR disassembly

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -391,7 +391,6 @@ impl Assembler
     pub fn new_label(&mut self, name: &str) -> Target
     {
         let label_idx = self.label_names.len();
-        dbg!(label_idx);
 
         self.label_names.push(name.to_string());
         Target::Label(label_idx)

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -272,7 +272,6 @@ impl Assembler
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {
-            dbg!("creating label, idx={}", idx);
             let label_idx = cb.new_label(name.to_string());
             assert!(label_idx == idx);
         }


### PR DESCRIPTION
The output from `dbg!` was too verbose. For `test_jo` the output went
from 37 lines to 5 lines. The added index helps parsing InsnOut
indicies.

Samples from `cargo test -- --nocapture --test-threads=1`:

```
test backend::tests::test_jo ... [src/backend/ir.rs:589] &self = Assembler
    000 Load(Mem64[Reg(3) + 8]) -> Out64(0)
    001 Sub(Out64(0), 1_i64) -> Out64(1)
    002 Load(Out64(1)) -> Out64(2)
    003 Add(Out64(2), Mem64[Reg(3)]) -> Out64(3)
    004 Jo() target=CodePtr(CodePtr(0x5)) -> Out64(4)
    005 Mov(Mem64[Reg(3)], Out64(3)) -> Out64(5)

test backend::tests::test_reuse_reg ... [src/backend/ir.rs:589] &self = Assembler
    000 Load(Mem64[Reg(3)]) -> Out64(0)
    001 Add(Out64(0), 1_u64) -> Out64(1)
    002 Load(Mem64[Reg(3) + 8]) -> Out64(2)
    003 Add(Out64(2), 1_u64) -> Out64(3)
    004 Add(Out64(1), 1_u64) -> Out64(4)
    005 Add(Out64(1), Out64(4)) -> Out64(5)
    006 Store(Mem64[Reg(3)], Out64(4)) -> Out64(6)
    007 Store(Mem64[Reg(3) + 8], Out64(5)) -> Out64(7)
```