### PR TITLE
Arm64 progress

### DIFF
--- a/yjit/src/asm/arm64/inst/breakpoint.rs
+++ b/yjit/src/asm/arm64/inst/breakpoint.rs
@@ -1,0 +1,55 @@
+/// The struct that represents an A64 breakpoint instruction that can be encoded.
+///
+/// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
+/// | 31 30 29 28 | 27 26 25 24 | 23 22 21 20 | 19 18 17 16 | 15 14 13 12 | 11 10 09 08 | 07 06 05 04 | 03 02 01 00 |
+/// |  1  1  0  1    0  1  0  0    0  0  1                                                          0    0  0  0  0 |
+/// |                                      imm16..................................................                  |
+/// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
+///
+pub struct Breakpoint {
+    /// The value to be captured by ESR_ELx.ISS
+    imm16: u16
+}
+
+impl Breakpoint {
+    /// BRK
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BRK--Breakpoint-instruction-
+    pub fn brk(imm16: u16) -> Self {
+        Self { imm16 }
+    }
+}
+
+/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en#control
+const FAMILY: u32 = 0b101;
+
+impl From<Breakpoint> for u32 {
+    /// Convert an instruction into a 32-bit value.
+    fn from(inst: Breakpoint) -> Self {
+        let imm16 = inst.imm16 as u32;
+
+        0
+        | (0b11 << 30)
+        | (FAMILY << 26)
+        | (1 << 21)
+        | (imm16 << 5)
+    }
+}
+
+impl From<Breakpoint> for [u8; 4] {
+    /// Convert an instruction into a 4 byte array.
+    fn from(inst: Breakpoint) -> [u8; 4] {
+        let result: u32 = inst.into();
+        result.to_le_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_brk() {
+        let result: u32 = Breakpoint::brk(7).into();
+        assert_eq!(0xd42000e0, result);
+    }
+}

--- a/yjit/src/asm/arm64/inst/logical_imm.rs
+++ b/yjit/src/asm/arm64/inst/logical_imm.rs
@@ -40,25 +40,31 @@ pub struct LogicalImm {
 }
 
 impl LogicalImm {
-    /// AND (immediate)
+    /// AND (bitmask immediate)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/AND--immediate---Bitwise-AND--immediate--?lang=en
     pub fn and(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::And, sf: num_bits.into() }
     }
 
-    /// ANDS (immediate)
+    /// ANDS (bitmask immediate)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--immediate---Bitwise-AND--immediate---setting-flags-?lang=en
     pub fn ands(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::Ands, sf: num_bits.into() }
     }
 
-    /// ORR (immediate)
+    /// MOV (bitmask immediate)
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--bitmask-immediate---Move--bitmask-immediate---an-alias-of-ORR--immediate--?lang=en
+    pub fn mov(rd: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
+        Self { rd, rn: 0b11111, imm, opc: Opc::Orr, sf: num_bits.into() }
+    }
+
+    /// ORR (bitmask immediate)
     /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--immediate---Bitwise-OR--immediate--
     pub fn orr(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::Orr, sf: num_bits.into() }
     }
 
-    /// TST (immediate)
+    /// TST (bitmask immediate)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TST--immediate---Test-bits--immediate---an-alias-of-ANDS--immediate--?lang=en
     pub fn tst(rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self::ands(31, rn, imm, num_bits)
@@ -107,6 +113,13 @@ mod tests {
         let inst = LogicalImm::ands(0, 1, 7.try_into().unwrap(), 64);
         let result: u32 = inst.into();
         assert_eq!(0xf2400820, result);
+    }
+
+    #[test]
+    fn test_mov() {
+        let inst = LogicalImm::mov(0, 0x5555555555555555.try_into().unwrap(), 64);
+        let result: u32 = inst.into();
+        assert_eq!(0xb200f3e0, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/inst/logical_imm.rs
+++ b/yjit/src/asm/arm64/inst/logical_imm.rs
@@ -5,6 +5,9 @@ enum Opc {
     /// The AND operation.
     And = 0b00,
 
+    /// The ORR operation.
+    Orr = 0b01,
+
     /// The ANDS operation.
     Ands = 0b11
 }
@@ -12,7 +15,7 @@ enum Opc {
 /// The struct that represents an A64 bitwise immediate instruction that can be
 /// encoded.
 ///
-/// AND/ANDS (immediate)
+/// AND/ORR/ANDS (immediate)
 /// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
 /// | 31 30 29 28 | 27 26 25 24 | 23 22 21 20 | 19 18 17 16 | 15 14 13 12 | 11 10 09 08 | 07 06 05 04 | 03 02 01 00 |
 /// |           1    0  0  1  0    0                                                                                |
@@ -47,6 +50,12 @@ impl LogicalImm {
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--immediate---Bitwise-AND--immediate---setting-flags-?lang=en
     pub fn ands(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::Ands, sf: num_bits.into() }
+    }
+
+    /// ORR (immediate)
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--immediate---Bitwise-OR--immediate--
+    pub fn orr(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
+        Self { rd, rn, imm, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// TST (immediate)
@@ -98,6 +107,13 @@ mod tests {
         let inst = LogicalImm::ands(0, 1, 7.try_into().unwrap(), 64);
         let result: u32 = inst.into();
         assert_eq!(0xf2400820, result);
+    }
+
+    #[test]
+    fn test_orr() {
+        let inst = LogicalImm::orr(0, 1, 7.try_into().unwrap(), 64);
+        let result: u32 = inst.into();
+        assert_eq!(0xb2400820, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/inst/logical_reg.rs
+++ b/yjit/src/asm/arm64/inst/logical_reg.rs
@@ -1,5 +1,14 @@
 use super::super::arg::Sf;
 
+/// Whether or not this is a NOT instruction.
+enum N {
+    /// This is not a NOT instruction.
+    No = 0,
+
+    /// This is a NOT instruction.
+    Yes = 1
+}
+
 /// The type of shift to perform on the second operand register.
 enum Shift {
     LSL = 0b00, // logical shift left (unsigned)
@@ -26,8 +35,8 @@ enum Opc {
 /// AND/ORR/ANDS (shifted register)
 /// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
 /// | 31 30 29 28 | 27 26 25 24 | 23 22 21 20 | 19 18 17 16 | 15 14 13 12 | 11 10 09 08 | 07 06 05 04 | 03 02 01 00 |
-/// |           0    1  0  1  0          0                                                                          |
-/// | sf opc..                    shift    rm..............   imm6............... rn.............. rd.............. |
+/// |           0    1  0  1  0                                                                                     |
+/// | sf opc..                    shift N  rm..............   imm6............... rn.............. rd.............. |
 /// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
 ///
 pub struct LogicalReg {
@@ -43,6 +52,9 @@ pub struct LogicalReg {
     /// The register number of the second operand register.
     rm: u8,
 
+    /// Whether or not this is a NOT instruction.
+    n: N,
+
     /// The type of shift to perform on the second operand register.
     shift: Shift,
 
@@ -57,31 +69,37 @@ impl LogicalReg {
     /// AND (shifted register)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/AND--shifted-register---Bitwise-AND--shifted-register--?lang=en
     pub fn and(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
-        Self { rd, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::And, sf: num_bits.into() }
+        Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::And, sf: num_bits.into() }
     }
 
     /// ANDS (shifted register)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--shifted-register---Bitwise-AND--shifted-register---setting-flags-?lang=en
     pub fn ands(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
-        Self { rd, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
+        Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
     }
 
     /// MOV (register)
     /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--register---Move--register---an-alias-of-ORR--shifted-register--?lang=en
     pub fn mov(rd: u8, rm: u8, num_bits: u8) -> Self {
-        Self { rd, rn: 0b11111, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
+        Self { rd, rn: 0b11111, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
+    }
+
+    /// ORN (shifted register)
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORN--shifted-register---Bitwise-OR-NOT--shifted-register--
+    pub fn orn(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
+        Self { rd, rn, imm6: 0, rm, n: N::Yes, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// ORR (shifted register)
     /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--shifted-register---Bitwise-OR--shifted-register--
     pub fn orr(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
-        Self { rd, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
+        Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// TST (shifted register)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TST--shifted-register---Test--shifted-register---an-alias-of-ANDS--shifted-register--?lang=en
     pub fn tst(rn: u8, rm: u8, num_bits: u8) -> Self {
-        Self { rd: 31, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
+        Self { rd: 31, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
     }
 }
 
@@ -98,6 +116,7 @@ impl From<LogicalReg> for u32 {
         | ((inst.opc as u32) << 29)
         | (FAMILY << 25)
         | ((inst.shift as u32) << 22)
+        | ((inst.n as u32) << 21)
         | ((inst.rm as u32) << 16)
         | (imm6 << 10)
         | ((inst.rn as u32) << 5)
@@ -136,6 +155,13 @@ mod tests {
         let inst = LogicalReg::mov(0, 1, 64);
         let result: u32 = inst.into();
         assert_eq!(0xaa0103e0, result);
+    }
+
+    #[test]
+    fn test_orn() {
+        let inst = LogicalReg::orn(0, 1, 2, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0xaa220020, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/inst/logical_reg.rs
+++ b/yjit/src/asm/arm64/inst/logical_reg.rs
@@ -13,6 +13,9 @@ enum Opc {
     /// The AND operation.
     And = 0b00,
 
+    /// The ORR operation.
+    Orr = 0b01,
+
     /// The ANDS operation.
     Ands = 0b11
 }
@@ -20,7 +23,7 @@ enum Opc {
 /// The struct that represents an A64 logical register instruction that can be
 /// encoded.
 ///
-/// AND/ANDS (shifted register)
+/// AND/ORR/ANDS (shifted register)
 /// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
 /// | 31 30 29 28 | 27 26 25 24 | 23 22 21 20 | 19 18 17 16 | 15 14 13 12 | 11 10 09 08 | 07 06 05 04 | 03 02 01 00 |
 /// |           0    1  0  1  0          0                                                                          |
@@ -61,6 +64,12 @@ impl LogicalReg {
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--shifted-register---Bitwise-AND--shifted-register---setting-flags-?lang=en
     pub fn ands(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
+    }
+
+    /// ORR (shifted register)
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--shifted-register---Bitwise-OR--shifted-register--
+    pub fn orr(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
+        Self { rd, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// TST (shifted register)
@@ -114,6 +123,13 @@ mod tests {
         let inst = LogicalReg::ands(0, 1, 2, 64);
         let result: u32 = inst.into();
         assert_eq!(0xea020020, result);
+    }
+
+    #[test]
+    fn test_orr() {
+        let inst = LogicalReg::orr(0, 1, 2, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0xaa020020, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/inst/logical_reg.rs
+++ b/yjit/src/asm/arm64/inst/logical_reg.rs
@@ -84,6 +84,12 @@ impl LogicalReg {
         Self { rd, rn: 0b11111, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
+    /// MVN (shifted register)
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MVN--Bitwise-NOT--an-alias-of-ORN--shifted-register--?lang=en
+    pub fn mvn(rd: u8, rm: u8, num_bits: u8) -> Self {
+        Self { rd, rn: 0b11111, imm6: 0, rm, n: N::Yes, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
+    }
+
     /// ORN (shifted register)
     /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORN--shifted-register---Bitwise-OR-NOT--shifted-register--
     pub fn orn(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
@@ -155,6 +161,13 @@ mod tests {
         let inst = LogicalReg::mov(0, 1, 64);
         let result: u32 = inst.into();
         assert_eq!(0xaa0103e0, result);
+    }
+
+    #[test]
+    fn test_mvn() {
+        let inst = LogicalReg::mvn(0, 1, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0xaa2103e0, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/inst/logical_reg.rs
+++ b/yjit/src/asm/arm64/inst/logical_reg.rs
@@ -66,6 +66,12 @@ impl LogicalReg {
         Self { rd, rn, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
     }
 
+    /// MOV (register)
+    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--register---Move--register---an-alias-of-ORR--shifted-register--?lang=en
+    pub fn mov(rd: u8, rm: u8, num_bits: u8) -> Self {
+        Self { rd, rn: 0b11111, imm6: 0, rm, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
+    }
+
     /// ORR (shifted register)
     /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--shifted-register---Bitwise-OR--shifted-register--
     pub fn orr(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
@@ -123,6 +129,13 @@ mod tests {
         let inst = LogicalReg::ands(0, 1, 2, 64);
         let result: u32 = inst.into();
         assert_eq!(0xea020020, result);
+    }
+
+    #[test]
+    fn test_mov() {
+        let inst = LogicalReg::mov(0, 1, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0xaa0103e0, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/inst/mod.rs
+++ b/yjit/src/asm/arm64/inst/mod.rs
@@ -4,6 +4,7 @@
 mod atomic;
 mod branch;
 mod branch_cond;
+mod breakpoint;
 mod call;
 mod data_imm;
 mod data_reg;
@@ -17,6 +18,7 @@ mod store;
 pub use atomic::Atomic;
 pub use branch::Branch;
 pub use branch_cond::BranchCond;
+pub use breakpoint::Breakpoint;
 pub use call::Call;
 pub use data_imm::DataImm;
 pub use data_reg::DataReg;

--- a/yjit/src/asm/arm64/inst/mod.rs
+++ b/yjit/src/asm/arm64/inst/mod.rs
@@ -12,6 +12,7 @@ mod load;
 mod logical_imm;
 mod logical_reg;
 mod mov;
+mod nop;
 mod shift_imm;
 mod store;
 
@@ -26,5 +27,6 @@ pub use load::Load;
 pub use logical_imm::LogicalImm;
 pub use logical_reg::LogicalReg;
 pub use mov::Mov;
+pub use nop::Nop;
 pub use shift_imm::ShiftImm;
 pub use store::Store;

--- a/yjit/src/asm/arm64/inst/nop.rs
+++ b/yjit/src/asm/arm64/inst/nop.rs
@@ -1,0 +1,44 @@
+/// The struct that represents an A64 nop instruction that can be encoded.
+///
+/// NOP
+/// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
+/// | 31 30 29 28 | 27 26 25 24 | 23 22 21 20 | 19 18 17 16 | 15 14 13 12 | 11 10 09 08 | 07 06 05 04 | 03 02 01 00 |
+/// |  1  1  0  1    0  1  0  1    0  0  0  0    0  0  1  1    0  0  1  0    0  0  0  0    0  0  0  1    1  1  1  1 |
+/// +-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
+///
+pub struct Nop;
+
+impl Nop {
+    /// NOP
+    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/NOP--No-Operation-
+    pub fn nop() -> Self {
+        Self {}
+    }
+}
+
+impl From<Nop> for u32 {
+    /// Convert an instruction into a 32-bit value.
+    fn from(inst: Nop) -> Self {
+        0b11010101000000110010000000011111
+    }
+}
+
+impl From<Nop> for [u8; 4] {
+    /// Convert an instruction into a 4 byte array.
+    fn from(inst: Nop) -> [u8; 4] {
+        let result: u32 = inst.into();
+        result.to_le_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nop() {
+        let inst = Nop::nop();
+        let result: u32 = inst.into();
+        assert_eq!(0xd503201f, result);
+    }
+}

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -8,7 +8,10 @@ mod opnd;
 
 use arg::*;
 use inst::*;
-use opnd::*;
+
+// We're going to make this public to make using these things easier in the
+// backend (so they don't have to have knowledge about the submodule).
+pub use opnd::*;
 
 /// Checks that a signed value fits within the specified number of bits.
 const fn imm_fits_bits(imm: i64, num_bits: u8) -> bool {

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -157,6 +157,20 @@ pub fn br(cb: &mut CodeBlock, rn: A64Opnd) {
     cb.write_bytes(&bytes);
 }
 
+/// BRK - create a breakpoint
+pub fn brk(cb: &mut CodeBlock, imm16: A64Opnd) {
+    let bytes: [u8; 4] = match imm16 {
+        A64Opnd::None => Breakpoint::brk(0).into(),
+        A64Opnd::UImm(imm16) => {
+            assert!(uimm_fits_bits(imm16, 16), "The immediate operand must be 16 bits or less.");
+            Breakpoint::brk(imm16 as u16).into()
+        },
+        _ => panic!("Invalid operand combination to brk instruction.")
+    };
+
+    cb.write_bytes(&bytes);
+}
+
 /// CMP - compare rn and rm, update flags
 pub fn cmp(cb: &mut CodeBlock, rn: A64Opnd, rm: A64Opnd) {
     let bytes: [u8; 4] = match (rn, rm) {
@@ -445,6 +459,16 @@ mod tests {
     #[test]
     fn test_br() {
         check_bytes("80021fd6", |cb| br(cb, X20));
+    }
+
+    #[test]
+    fn test_brk_none() {
+        check_bytes("000020d4", |cb| brk(cb, A64Opnd::None));
+    }
+
+    #[test]
+    fn test_brk_uimm() {
+        check_bytes("c00120d4", |cb| brk(cb, A64Opnd::new_uimm(14)));
     }
 
     #[test]

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -300,6 +300,20 @@ pub fn movz(cb: &mut CodeBlock, rd: A64Opnd, imm16: A64Opnd, shift: u8) {
     cb.write_bytes(&bytes);
 }
 
+/// ORN - perform a bitwise OR of rn and NOT rm, put the result in rd, don't update flags
+pub fn orn(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
+    let bytes: [u8; 4] = match (rd, rn, rm) {
+        (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::Reg(rm)) => {
+            assert!(rd.num_bits == rn.num_bits && rn.num_bits == rm.num_bits, "Expected registers to be the same size");
+
+            LogicalReg::orn(rd.reg_no, rn.reg_no, rm.reg_no, rd.num_bits).into()
+        },
+        _ => panic!("Invalid operand combination to orn instruction.")
+    };
+
+    cb.write_bytes(&bytes);
+}
+
 /// ORR - perform a bitwise OR of rn and rm, put the result in rd, don't update flags
 pub fn orr(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
     let bytes: [u8; 4] = match (rd, rn, rm) {
@@ -558,6 +572,11 @@ mod tests {
     #[test]
     fn test_movz() {
         check_bytes("600fa0d2", |cb| movz(cb, X0, A64Opnd::new_uimm(123), 16));
+    }
+
+    #[test]
+    fn test_orn() {
+        check_bytes("6a012caa", |cb| orn(cb, X10, X11, X12));
     }
 
     #[test]

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -226,6 +226,11 @@ pub fn ldaddal(cb: &mut CodeBlock, rs: A64Opnd, rt: A64Opnd, rn: A64Opnd) {
 /// LDUR - load a memory address into a register
 pub fn ldur(cb: &mut CodeBlock, rt: A64Opnd, rn: A64Opnd) {
     let bytes: [u8; 4] = match (rt, rn) {
+        (A64Opnd::Reg(rt), A64Opnd::Reg(rn)) => {
+            assert!(rt.num_bits == rn.num_bits, "All operands must be of the same size.");
+
+            Load::ldur(rt.reg_no, rn.reg_no, 0, rt.num_bits).into()
+        },
         (A64Opnd::Reg(rt), A64Opnd::Mem(rn)) => {
             assert!(rt.num_bits == rn.num_bits, "Expected registers to be the same size");
             assert!(imm_fits_bits(rn.disp.into(), 9), "Expected displacement to be 9 bits or less");
@@ -574,8 +579,13 @@ mod tests {
     }
 
     #[test]
-    fn test_ldur() {
+    fn test_ldur_memory() {
         check_bytes("20b047f8", |cb| ldur(cb, X0, A64Opnd::new_mem(64, X1, 123)));
+    }
+
+    #[test]
+    fn test_ldur_register() {
+        check_bytes("200040f8", |cb| ldur(cb, X0, X1));
     }
 
     #[test]

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -14,7 +14,7 @@ pub use arg::*;
 pub use opnd::*;
 
 /// Checks that a signed value fits within the specified number of bits.
-const fn imm_fits_bits(imm: i64, num_bits: u8) -> bool {
+pub const fn imm_fits_bits(imm: i64, num_bits: u8) -> bool {
     let minimum = if num_bits == 64 { i64::MIN } else { -2_i64.pow((num_bits as u32) - 1) };
     let maximum = if num_bits == 64 { i64::MAX } else { 2_i64.pow((num_bits as u32) - 1) - 1 };
 
@@ -22,7 +22,7 @@ const fn imm_fits_bits(imm: i64, num_bits: u8) -> bool {
 }
 
 /// Checks that an unsigned value fits within the specified number of bits.
-const fn uimm_fits_bits(uimm: u64, num_bits: u8) -> bool {
+pub const fn uimm_fits_bits(uimm: u64, num_bits: u8) -> bool {
     let maximum = if num_bits == 64 { u64::MAX } else { 2_u64.pow(num_bits as u32) - 1 };
 
     uimm <= maximum

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -314,6 +314,13 @@ pub fn mvn(cb: &mut CodeBlock, rd: A64Opnd, rm: A64Opnd) {
     cb.write_bytes(&bytes);
 }
 
+/// NOP - no-operation, used for alignment purposes
+pub fn nop(cb: &mut CodeBlock) {
+    let bytes: [u8; 4] = Nop::nop().into();
+
+    cb.write_bytes(&bytes);
+}
+
 /// ORN - perform a bitwise OR of rn and NOT rm, put the result in rd, don't update flags
 pub fn orn(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
     let bytes: [u8; 4] = match (rd, rn, rm) {
@@ -591,6 +598,11 @@ mod tests {
     #[test]
     fn test_mvn() {
         check_bytes("ea032baa", |cb| mvn(cb, X10, X11));
+    }
+
+    #[test]
+    fn test_nop() {
+        check_bytes("1f2003d5", |cb| nop(cb));
     }
 
     #[test]

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_ldur() {
-        check_bytes("20b047f8", |cb| ldur(cb, X0, A64Opnd::new_mem(X1, 123)));
+        check_bytes("20b047f8", |cb| ldur(cb, X0, A64Opnd::new_mem(64, X1, 123)));
     }
 
     #[test]
@@ -620,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_stur() {
-        check_bytes("6a0108f8", |cb| stur(cb, X10, A64Opnd::new_mem(X11, 128)));
+        check_bytes("6a0108f8", |cb| stur(cb, X10, A64Opnd::new_mem(64, X11, 128)));
     }
 
     #[test]

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -300,6 +300,20 @@ pub fn movz(cb: &mut CodeBlock, rd: A64Opnd, imm16: A64Opnd, shift: u8) {
     cb.write_bytes(&bytes);
 }
 
+/// MVN - move a value in a register to another register, negating it
+pub fn mvn(cb: &mut CodeBlock, rd: A64Opnd, rm: A64Opnd) {
+    let bytes: [u8; 4] = match (rd, rm) {
+        (A64Opnd::Reg(rd), A64Opnd::Reg(rm)) => {
+            assert!(rd.num_bits == rm.num_bits, "Expected registers to be the same size");
+
+            LogicalReg::mvn(rd.reg_no, rm.reg_no, rd.num_bits).into()
+        },
+        _ => panic!("Invalid operand combination to mvn instruction")
+    };
+
+    cb.write_bytes(&bytes);
+}
+
 /// ORN - perform a bitwise OR of rn and NOT rm, put the result in rd, don't update flags
 pub fn orn(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
     let bytes: [u8; 4] = match (rd, rn, rm) {
@@ -572,6 +586,11 @@ mod tests {
     #[test]
     fn test_movz() {
         check_bytes("600fa0d2", |cb| movz(cb, X0, A64Opnd::new_uimm(123), 16));
+    }
+
+    #[test]
+    fn test_mvn() {
+        check_bytes("ea032baa", |cb| mvn(cb, X10, X11));
     }
 
     #[test]

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -34,14 +34,10 @@ pub struct A64Mem
 }
 
 impl A64Mem {
-    pub fn new(reg: A64Opnd, disp: i32) -> Self {
+    pub fn new(num_bits: u8, reg: A64Opnd, disp: i32) -> Self {
         match reg {
             A64Opnd::Reg(reg) => {
-                Self {
-                    num_bits: reg.num_bits,
-                    base_reg_no: reg.reg_no,
-                    disp
-                }
+                Self { num_bits, base_reg_no: reg.reg_no, disp }
             },
             _ => panic!("Expected register operand")
         }
@@ -79,8 +75,8 @@ impl A64Opnd {
     }
 
     /// Creates a new memory operand.
-    pub fn new_mem(reg: A64Opnd, disp: i32) -> Self {
-        A64Opnd::Mem(A64Mem::new(reg, disp))
+    pub fn new_mem(num_bits: u8, reg: A64Opnd, disp: i32) -> Self {
+        A64Opnd::Mem(A64Mem::new(num_bits, reg, disp))
     }
 
     /// Convenience function to check if this operand is a register.
@@ -137,6 +133,7 @@ pub const X27: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 27 });
 pub const X28: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 28 });
 pub const X29: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 29 });
 pub const X30: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 30 });
+pub const X31: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 31 });
 
 // 32-bit registers
 pub const W0: A64Reg = A64Reg { num_bits: 32, reg_no: 0 };
@@ -170,6 +167,7 @@ pub const W27: A64Reg = A64Reg { num_bits: 32, reg_no: 27 };
 pub const W28: A64Reg = A64Reg { num_bits: 32, reg_no: 28 };
 pub const W29: A64Reg = A64Reg { num_bits: 32, reg_no: 29 };
 pub const W30: A64Reg = A64Reg { num_bits: 32, reg_no: 30 };
+pub const W31: A64Reg = A64Reg { num_bits: 32, reg_no: 31 };
 
 // C argument registers
 pub const C_ARG_REGS: [A64Opnd; 4] = [X0, X1, X2, X3];

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -11,6 +11,15 @@ pub struct A64Reg
     pub reg_no: u8,
 }
 
+impl A64Reg {
+    pub fn sub_reg(&self, num_bits: u8) -> Self {
+        assert!(num_bits == 32 || num_bits == 64);
+        assert!(num_bits <= self.num_bits);
+
+        Self { num_bits, reg_no: self.reg_no }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct A64Mem
 {
@@ -87,7 +96,12 @@ pub const X0_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 0 };
 pub const X1_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 1 };
 pub const X2_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 2 };
 pub const X3_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 3 };
+pub const X4_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 4 };
+pub const X5_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 5 };
 
+pub const X9_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 9 };
+pub const X10_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 10 };
+pub const X11_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 11 };
 pub const X12_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 12 };
 pub const X13_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 13 };
 
@@ -96,14 +110,14 @@ pub const X0: A64Opnd = A64Opnd::Reg(X0_REG);
 pub const X1: A64Opnd = A64Opnd::Reg(X1_REG);
 pub const X2: A64Opnd = A64Opnd::Reg(X2_REG);
 pub const X3: A64Opnd = A64Opnd::Reg(X3_REG);
-pub const X4: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 4 });
-pub const X5: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 5 });
+pub const X4: A64Opnd = A64Opnd::Reg(X4_REG);
+pub const X5: A64Opnd = A64Opnd::Reg(X5_REG);
 pub const X6: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 6 });
 pub const X7: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 7 });
 pub const X8: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 8 });
-pub const X9: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 9 });
-pub const X10: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 10 });
-pub const X11: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 11 });
+pub const X9: A64Opnd = A64Opnd::Reg(X9_REG);
+pub const X10: A64Opnd = A64Opnd::Reg(X10_REG);
+pub const X11: A64Opnd = A64Opnd::Reg(X11_REG);
 pub const X12: A64Opnd = A64Opnd::Reg(X12_REG);
 pub const X13: A64Opnd = A64Opnd::Reg(X13_REG);
 pub const X14: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 14 });

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -101,6 +101,10 @@ pub const X11_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 11 };
 pub const X12_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 12 };
 pub const X13_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 13 };
 
+pub const X24_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 24 };
+pub const X25_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 25 };
+pub const X26_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 26 };
+
 // 64-bit registers
 pub const X0: A64Opnd = A64Opnd::Reg(X0_REG);
 pub const X1: A64Opnd = A64Opnd::Reg(X1_REG);
@@ -126,9 +130,9 @@ pub const X20: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 20 });
 pub const X21: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 21 });
 pub const X22: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 22 });
 pub const X23: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 23 });
-pub const X24: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 24 });
-pub const X25: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 25 });
-pub const X26: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 26 });
+pub const X24: A64Opnd = A64Opnd::Reg(X24_REG);
+pub const X25: A64Opnd = A64Opnd::Reg(X25_REG);
+pub const X26: A64Opnd = A64Opnd::Reg(X26_REG);
 pub const X27: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 27 });
 pub const X28: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 28 });
 pub const X29: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 29 });

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -22,10 +22,7 @@ struct LabelRef {
     pos: usize,
 
     // Label which this refers to
-    label_idx: usize,
-
-    // An optional shift for the offset.
-    shift: Option<u8>
+    label_idx: usize
 }
 
 /// Block of memory into which instructions can be assembled
@@ -173,55 +170,26 @@ impl CodeBlock {
         self.get_ptr(self.write_pos)
     }
 
-    /// Write a single byte at the current position. The strategy determines if
-    /// we're keeping the other bits in place or zero-ing them out.
-    fn write_byte_with_strategy(&mut self, byte: u8, strategy: ByteWriteStrategy) {
+    /// Write a single byte at the current position.
+    pub fn write_byte(&mut self, byte: u8) {
         let write_ptr = self.get_write_ptr();
-        let result = match strategy {
-            ByteWriteStrategy::ZeroBits => self.mem_block.write_byte(write_ptr, byte),
-            ByteWriteStrategy::KeepBits => self.mem_block.or_byte(write_ptr, byte),
-        };
 
-        if result.is_ok() {
+        if self.mem_block.write_byte(write_ptr, byte).is_ok() {
             self.write_pos += 1;
         } else {
             self.dropped_bytes = true;
         }
     }
 
-    /// Write a single byte at the current position.
-    pub fn write_byte(&mut self, byte: u8) {
-        self.write_byte_with_strategy(byte, ByteWriteStrategy::ZeroBits)
-    }
-
-    /// Bitwise OR a single byte at the current position.
-    pub fn or_byte(&mut self, byte: u8) {
-        self.write_byte_with_strategy(byte, ByteWriteStrategy::KeepBits);
-    }
-
-    /// Write multiple bytes starting from the current position. The strategy
-    /// determines if we're keeping the other bits in place or zero-ing them
-    /// out.
-    fn write_bytes_with_strategy(&mut self, bytes: &[u8], strategy: ByteWriteStrategy) {
+    /// Write multiple bytes starting from the current position.
+    fn write_bytes(&mut self, bytes: &[u8]) {
         for byte in bytes {
-            self.write_byte_with_strategy(*byte, strategy);
+            self.write_byte(*byte);
         }
     }
 
-    /// Write multiple bytes starting from the current position.
-    pub fn write_bytes(&mut self, bytes: &[u8]) {
-        self.write_bytes_with_strategy(bytes, ByteWriteStrategy::ZeroBits);
-    }
-
-    /// Bitwise OR multiple bytes starting from the current position.
-    pub fn or_bytes(&mut self, bytes: &[u8]) {
-        self.write_bytes_with_strategy(bytes, ByteWriteStrategy::KeepBits);
-    }
-
     /// Write an integer over the given number of bits at the current position.
-    /// The strategy determines if we're keeping the other bits in place or
-    /// zero-ing them out.
-    fn write_int_with_strategy(&mut self, val: u64, num_bits: u32, strategy: ByteWriteStrategy) {
+    fn write_int(&mut self, val: u64, num_bits: u32) {
         assert!(num_bits > 0);
         assert!(num_bits % 8 == 0);
 
@@ -247,17 +215,6 @@ impl CodeBlock {
         }
     }
 
-    // Write a signed integer over a given number of bits at the current position
-    pub fn write_int(&mut self, val: u64, num_bits: u32) {
-        self.write_int_with_strategy(val, num_bits, ByteWriteStrategy::ZeroBits)
-    }
-
-    // Bitwise OR a signed integer over a given number of bits at the current
-    // position
-    pub fn or_int(&mut self, val: u64, num_bits: u32) {
-        self.write_int_with_strategy(val, num_bits, ByteWriteStrategy::KeepBits)
-    }
-
     /// Check if bytes have been dropped (unwritten because of insufficient space)
     pub fn has_dropped_bytes(&self) -> bool {
         self.dropped_bytes
@@ -279,15 +236,10 @@ impl CodeBlock {
 
     // Add a label reference at the current write position
     pub fn label_ref(&mut self, label_idx: usize) {
-        self.label_ref_with_shift(label_idx, None);
-    }
-
-    // Add a label reference at the current write position with a shift
-    pub fn label_ref_with_shift(&mut self, label_idx: usize, shift: Option<u8>) {
         assert!(label_idx < self.label_addrs.len());
 
         // Keep track of the reference
-        self.label_refs.push(LabelRef { pos: self.write_pos, label_idx, shift });
+        self.label_refs.push(LabelRef { pos: self.write_pos, label_idx });
     }
 
     // Link internal label references
@@ -307,12 +259,7 @@ impl CodeBlock {
             let offset = (label_addr as i64) - ((ref_pos + 4) as i64);
 
             self.set_pos(ref_pos);
-
-            if let Some(shift) = label_ref.shift {
-                self.or_int((offset as u64) >> shift, 32);
-            } else {
-                self.write_int(offset as u64, 32);
-            }
+            self.write_int(offset as u64, 32);
         }
 
         self.write_pos = orig_pos;

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -55,22 +55,6 @@ pub struct CodeBlock {
     dropped_bytes: bool,
 }
 
-/// When you're writing bytes into the memory block, most of the time you want
-/// to completely overwrite the existing bits. Sometimes however, we are
-/// patching code we've already written (like when going back and writing jump
-/// offsets). In that case you may want to keep the bits already written in
-/// place.
-#[derive(Clone, Copy)]
-enum ByteWriteStrategy {
-    /// Zero out the other bits at the write position. This corresponds to
-    /// calling write_byte on the virtual memory.
-    ZeroBits,
-
-    /// Keep the other bits in place at the write position. This corresponds to
-    /// calling or_byte on the virtual memory.
-    KeepBits
-}
-
 impl CodeBlock {
     /// Make a new CodeBlock
     pub fn new(mem_block: VirtualMem) -> Self {

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -28,7 +28,7 @@ struct LabelRef {
     width: usize,
 
     /// The object that knows how to encode the instruction.
-    encode: Box<dyn FnOnce(&mut CodeBlock, i64)>
+    encode: Box<dyn FnOnce(&mut CodeBlock, i64, i64)>
 }
 
 /// Block of memory into which instructions can be assembled
@@ -225,7 +225,7 @@ impl CodeBlock {
     }
 
     // Add a label reference at the current write position
-    pub fn label_ref<E: 'static>(&mut self, label_idx: usize, width: usize, encode: E) where E: FnOnce(&mut CodeBlock, i64) {
+    pub fn label_ref<E: 'static>(&mut self, label_idx: usize, width: usize, encode: E) where E: FnOnce(&mut CodeBlock, i64, i64) {
         assert!(label_idx < self.label_addrs.len());
 
         // Keep track of the reference
@@ -248,11 +248,8 @@ impl CodeBlock {
             let label_addr = self.label_addrs[label_idx];
             assert!(label_addr < self.mem_size);
 
-            // Compute the offset from the reference's end to the label
-            let offset = (label_addr as i64) - ((ref_pos + label_ref.width) as i64);
-
             self.set_pos(ref_pos);
-            (label_ref.encode)(self, offset);
+            (label_ref.encode)(self, (ref_pos + label_ref.width) as i64, label_addr as i64);
         }
 
         self.write_pos = orig_pos;

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -703,14 +703,10 @@ pub fn call_ptr(cb: &mut CodeBlock, scratch_opnd: X86Opnd, dst_ptr: *const u8) {
 
 /// call - Call to label with 32-bit offset
 pub fn call_label(cb: &mut CodeBlock, label_idx: usize) {
-    // Write the opcode
-    cb.write_byte(0xE8);
-
-    // Add a reference to the label
-    cb.label_ref(label_idx);
-
-    // Relative 32-bit offset to be patched
-    cb.write_int(0, 32);
+    cb.label_ref(label_idx, 5, |cb, offset| {
+        cb.write_byte(0xE8);
+        cb.write_int(offset as u64, 32);
+    });
 }
 
 /// call - Indirect call with an R/M operand
@@ -801,55 +797,54 @@ pub fn int3(cb: &mut CodeBlock) {
     cb.write_byte(0xcc);
 }
 
-// Encode a relative jump to a label (direct or conditional)
+// Encode a conditional relative jump to a label
 // Note: this always encodes a 32-bit offset
-fn write_jcc(cb: &mut CodeBlock, op0: u8, op1: u8, label_idx: usize) {
-    // Write the opcode
-    if op0 != 0xff {
-        cb.write_byte(op0);
-    }
-
-    cb.write_byte(op1);
-
-    // Add a reference to the label
-    cb.label_ref(label_idx);
-
-    // Relative 32-bit offset to be patched
-    cb.write_int( 0, 32);
+fn write_jcc(cb: &mut CodeBlock, op: u8, label_idx: usize) {
+    cb.label_ref(label_idx, 6, move |cb, offset| {
+        cb.write_byte(0x0F);
+        cb.write_byte(op);
+        cb.write_int(offset as u64, 32);
+    });
 }
 
 /// jcc - relative jumps to a label
-pub fn ja_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x87, label_idx); }
-pub fn jae_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x83, label_idx); }
-pub fn jb_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x82, label_idx); }
-pub fn jbe_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x86, label_idx); }
-pub fn jc_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x82, label_idx); }
-pub fn je_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x84, label_idx); }
-pub fn jg_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8F, label_idx); }
-pub fn jge_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8D, label_idx); }
-pub fn jl_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8C, label_idx); }
-pub fn jle_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8E, label_idx); }
-pub fn jna_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x86, label_idx); }
-pub fn jnae_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x82, label_idx); }
-pub fn jnb_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x83, label_idx); }
-pub fn jnbe_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x87, label_idx); }
-pub fn jnc_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x83, label_idx); }
-pub fn jne_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x85, label_idx); }
-pub fn jng_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8E, label_idx); }
-pub fn jnge_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8C, label_idx); }
-pub fn jnl_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8D, label_idx); }
-pub fn jnle_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8F, label_idx); }
-pub fn jno_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x81, label_idx); }
-pub fn jnp_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8b, label_idx); }
-pub fn jns_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x89, label_idx); }
-pub fn jnz_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x85, label_idx); }
-pub fn jo_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x80, label_idx); }
-pub fn jp_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8A, label_idx); }
-pub fn jpe_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8A, label_idx); }
-pub fn jpo_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x8B, label_idx); }
-pub fn js_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x88, label_idx); }
-pub fn jz_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x0F, 0x84, label_idx); }
-pub fn jmp_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0xFF, 0xE9, label_idx); }
+pub fn ja_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x87, label_idx); }
+pub fn jae_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x83, label_idx); }
+pub fn jb_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x82, label_idx); }
+pub fn jbe_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x86, label_idx); }
+pub fn jc_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x82, label_idx); }
+pub fn je_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x84, label_idx); }
+pub fn jg_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8F, label_idx); }
+pub fn jge_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8D, label_idx); }
+pub fn jl_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8C, label_idx); }
+pub fn jle_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8E, label_idx); }
+pub fn jna_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x86, label_idx); }
+pub fn jnae_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x82, label_idx); }
+pub fn jnb_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x83, label_idx); }
+pub fn jnbe_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x87, label_idx); }
+pub fn jnc_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x83, label_idx); }
+pub fn jne_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x85, label_idx); }
+pub fn jng_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8E, label_idx); }
+pub fn jnge_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8C, label_idx); }
+pub fn jnl_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8D, label_idx); }
+pub fn jnle_label(cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8F, label_idx); }
+pub fn jno_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x81, label_idx); }
+pub fn jnp_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8b, label_idx); }
+pub fn jns_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x89, label_idx); }
+pub fn jnz_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x85, label_idx); }
+pub fn jo_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x80, label_idx); }
+pub fn jp_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8A, label_idx); }
+pub fn jpe_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8A, label_idx); }
+pub fn jpo_label (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x8B, label_idx); }
+pub fn js_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x88, label_idx); }
+pub fn jz_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x84, label_idx); }
+
+pub fn jmp_label(cb: &mut CodeBlock, label_idx: usize) {
+    cb.label_ref(label_idx, 5, |cb, offset| {
+        cb.write_byte(0xE9);
+        cb.write_int(offset as u64, 32);
+    });
+}
 
 /// Encode a relative jump to a pointer at a 32-bit offset (direct or conditional)
 fn write_jcc_ptr(cb: &mut CodeBlock, op0: u8, op1: u8, dst_ptr: CodePtr) {

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -703,9 +703,9 @@ pub fn call_ptr(cb: &mut CodeBlock, scratch_opnd: X86Opnd, dst_ptr: *const u8) {
 
 /// call - Call to label with 32-bit offset
 pub fn call_label(cb: &mut CodeBlock, label_idx: usize) {
-    cb.label_ref(label_idx, 5, |cb, offset| {
+    cb.label_ref(label_idx, 5, |cb, src_addr, dst_addr| {
         cb.write_byte(0xE8);
-        cb.write_int(offset as u64, 32);
+        cb.write_int((dst_addr - src_addr) as u64, 32);
     });
 }
 
@@ -800,10 +800,10 @@ pub fn int3(cb: &mut CodeBlock) {
 // Encode a conditional relative jump to a label
 // Note: this always encodes a 32-bit offset
 fn write_jcc(cb: &mut CodeBlock, op: u8, label_idx: usize) {
-    cb.label_ref(label_idx, 6, move |cb, offset| {
+    cb.label_ref(label_idx, 6, move |cb, src_addr, dst_addr| {
         cb.write_byte(0x0F);
         cb.write_byte(op);
-        cb.write_int(offset as u64, 32);
+        cb.write_int((dst_addr - src_addr) as u64, 32);
     });
 }
 
@@ -840,9 +840,9 @@ pub fn js_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x88, la
 pub fn jz_label  (cb: &mut CodeBlock, label_idx: usize) { write_jcc(cb, 0x84, label_idx); }
 
 pub fn jmp_label(cb: &mut CodeBlock, label_idx: usize) {
-    cb.label_ref(label_idx, 5, |cb, offset| {
+    cb.label_ref(label_idx, 5, |cb, src_addr, dst_addr| {
         cb.write_byte(0xE9);
-        cb.write_int(offset as u64, 32);
+        cb.write_int((dst_addr - src_addr) as u64, 32);
     });
 }
 

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -277,7 +277,9 @@ impl Assembler
                 },
                 Op::Jbe => {
                     match insn.target.unwrap() {
-                        Target::CodePtr(_) => todo!(),
+                        Target::CodePtr(dst_ptr) => {
+                            emit_conditional_jump(cb, Condition::LE, dst_ptr);
+                        },
                         Target::Label(_) => todo!(),
                         _ => unreachable!()
                     };

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -262,8 +262,7 @@ impl Assembler
                 },
 
                 Op::Breakpoint => {
-                    // int3(cb)
-                    todo!();
+                    brk(cb, A64Opnd::None)
                 },
 
                 _ => panic!("unsupported instruction passed to arm64 backend: {:?}", insn.op)

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -253,10 +253,7 @@ impl Assembler
                             let dst_addr = dst_ptr.into_i64();
                             emit_jump(cb, src_addr, dst_addr);
                         },
-                        Target::Label(label_idx) => {
-                            cb.label_ref_with_shift(label_idx, Some(32 - 26));
-                            bl(cb, A64Opnd::new_uimm(0));
-                        },
+                        Target::Label(label_idx) => todo!(),
                         Target::FunPtr(_) => unreachable!()
                     };
                 },

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -135,6 +135,14 @@ impl Assembler
             }
         }
 
+        /// Emit a conditional jump instruction from the current address to a
+        /// target address.
+        fn emit_conditional_jump(cb: &mut CodeBlock, condition: Condition, dst_ptr: CodePtr) {
+            let src_addr = cb.get_write_ptr().into_i64() + 4;
+            let dst_addr = dst_ptr.into_i64();
+            bcond(cb, condition, A64Opnd::new_imm(dst_addr - src_addr));
+        }
+
         // NOTE: dear Kevin,
         // for arm, you may want to reserve 1 or 2 caller-save registers
         // to use as scracth registers (during the last phase of the codegen)
@@ -261,39 +269,43 @@ impl Assembler
                     };
                 },
                 Op::Je => {
-                    // match insn.target.unwrap() {
-                    //     Target::CodePtr(code_ptr) => je_ptr(cb, code_ptr),
-                    //     Target::Label(label_idx) => je_label(cb, label_idx),
-                    //     _ => unreachable!()
-                    // }
-                    todo!();
+                    match insn.target.unwrap() {
+                        Target::CodePtr(dst_ptr) => {
+                            emit_conditional_jump(cb, Condition::EQ, dst_ptr);
+                        },
+                        Target::Label(_) => todo!(),
+                        _ => unreachable!()
+                    };
                 },
                 Op::Jbe => {
-                    todo!();
+                    match insn.target.unwrap() {
+                        Target::CodePtr(_) => todo!(),
+                        Target::Label(_) => todo!(),
+                        _ => unreachable!()
+                    };
                 },
                 Op::Jz => {
-                    // match insn.target.unwrap() {
-                    //     Target::CodePtr(code_ptr) => jz_ptr(cb, code_ptr),
-                    //     Target::Label(label_idx) => jz_label(cb, label_idx),
-                    //     _ => unreachable!()
-                    // }
-                    todo!();
+                    match insn.target.unwrap() {
+                        Target::CodePtr(_) => todo!(),
+                        Target::Label(_) => todo!(),
+                        _ => unreachable!()
+                    };
                 },
                 Op::Jnz => {
-                    // match insn.target.unwrap() {
-                    //     Target::CodePtr(code_ptr) => jnz_ptr(cb, code_ptr),
-                    //     Target::Label(label_idx) => jnz_label(cb, label_idx),
-                    //     _ => unreachable!()
-                    // }
-                    todo!();
+                    match insn.target.unwrap() {
+                        Target::CodePtr(_) => todo!(),
+                        Target::Label(_) => todo!(),
+                        _ => unreachable!()
+                    };
                 },
                 Op::Jo => {
-                    // match insn.target.unwrap() {
-                    //     Target::CodePtr(code_ptr) => jo_ptr(cb, code_ptr),
-                    //     Target::Label(label_idx) => jo_label(cb, label_idx),
-                    //     _ => unreachable!()
-                    // }
-                    todo!();
+                    match insn.target.unwrap() {
+                        Target::CodePtr(dst_ptr) => {
+                            emit_conditional_jump(cb, Condition::VS, dst_ptr);
+                        },
+                        Target::Label(_) => todo!(),
+                        _ => unreachable!()
+                    };
                 },
                 Op::IncrCounter => {
                     ldaddal(cb, insn.opnds[0].into(), insn.opnds[0].into(), insn.opnds[1].into())

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -126,6 +126,15 @@ impl Assembler
             if offset < 128 * 1024 * 1024 && offset >= -128 * 1024 * 1024 {
                 // Encode how far we're jumping in # of instructions
                 bl(cb, A64Opnd::new_imm(offset / 4));
+
+                // We want instructions that are using registers and
+                // instructions that are using immediates to be the size in
+                // memory so that we can come back and patch without having to
+                // shift stuff around. So here we'll add enough nop instructions
+                // to make that happen. It works out well for us here since the
+                // code would have jumped away already anyway.
+                nop(cb);
+                nop(cb);
             } else {
                 // Since this is too far to jump directly, we'll load
                 // the value into a register and jump to it

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -254,15 +254,7 @@ impl Assembler
                             emit_jump(cb, src_addr, dst_addr);
                         },
                         Target::Label(label_idx) => {
-                            // We're going to write a label reference that knows
-                            // when it writes the actual offset it needs to
-                            // shift itself a couple of bits in to maintain the
-                            // correct encoding.
                             cb.label_ref_with_shift(label_idx, Some(32 - 26));
-
-                            // Here we're going to write a branch instruction
-                            // with a 0 offset so that later it can be patched
-                            // when we link all of the labels together.
                             bl(cb, A64Opnd::new_uimm(0));
                         },
                         Target::FunPtr(_) => unreachable!()

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -195,25 +195,23 @@ impl Assembler
                 // C function call
                 Op::CCall => {
                     // Temporary
-                    // assert!(insn.opnds.len() < C_ARG_REGS.len());
+                    assert!(insn.opnds.len() < C_ARG_REGS.len());
 
                     // For each operand
-                    // for (idx, opnd) in insn.opnds.iter().enumerate() {
-                    //     mov(cb, C_ARG_REGS[idx], insn.opnds[idx].into());
-                    // }
+                    for (idx, opnd) in insn.opnds.iter().enumerate() {
+                        mov(cb, C_ARG_REGS[idx], insn.opnds[idx].into());
+                    }
 
                     todo!();
                 },
 
                 Op::CRet => {
                     // TODO: bias allocation towards return register
-                    // if insn.opnds[0] != Opnd::Reg(C_RET_REG) {
-                    //     mov(cb, RAX, insn.opnds[0].into());
-                    // }
+                    if insn.opnds[0] != Opnd::Reg(C_RET_REG) {
+                        mov(cb, C_RET_OPND.into(), insn.opnds[0].into());
+                    }
 
-                    // ret(cb);
-
-                    todo!();
+                    ret(cb, A64Opnd::None)
                 }
 
                 // Compare
@@ -227,8 +225,7 @@ impl Assembler
                 },
 
                 Op::JmpOpnd => {
-                    // jmp_rm(cb, insn.opnds[0].into())
-                    todo!();
+                    br(cb, insn.opnds[0].into())
                 },
 
                 // Conditional jump to a label

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -30,6 +30,11 @@ pub const _C_ARG_OPNDS: [Opnd; 6] = [
 pub const C_RET_REG: Reg = X0_REG;
 pub const _C_RET_OPND: Opnd = Opnd::Reg(X0_REG);
 
+// These constants define the way we work with Arm64's stack pointer. The stack
+// pointer always needs to be aligned to a 16-byte boundary.
+pub const SP_REG: A64Opnd = X31;
+pub const SP_STEP: A64Opnd = A64Opnd::UImm(16);
+
 /// Map Opnd to A64Opnd
 impl From<Opnd> for A64Opnd {
     fn from(opnd: Opnd) -> Self {
@@ -167,12 +172,12 @@ impl Assembler
                     ldur(cb, insn.out.into(), insn.opnds[0].into());
                 },
                 Op::CPush => {
-                    add(cb, X31, X31, A64Opnd::new_uimm(16));
-                    mov(cb, A64Opnd::new_mem(64, X31, 0), insn.opnds[0].into());
+                    add(cb, SP_REG, SP_REG, SP_STEP);
+                    mov(cb, A64Opnd::new_mem(64, SP_REG, 0), insn.opnds[0].into());
                 },
                 Op::CPop => {
-                    mov(cb, insn.out.into(), A64Opnd::new_mem(64, X31, 0));
-                    sub(cb, X31, X31, A64Opnd::new_uimm(16));
+                    mov(cb, insn.out.into(), A64Opnd::new_mem(64, SP_REG, 0));
+                    sub(cb, SP_REG, SP_REG, SP_STEP);
                 },
                 Op::CCall => {
                     // Temporary

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -13,9 +13,9 @@ use crate::virtualmem::CodePtr;
 pub type Reg = A64Reg;
 
 // Callee-saved registers
-pub const _CFP: Opnd = Opnd::Reg(X9_REG);
-pub const _EC: Opnd = Opnd::Reg(X10_REG);
-pub const _SP: Opnd = Opnd::Reg(X11_REG);
+pub const _CFP: Opnd = Opnd::Reg(X24_REG);
+pub const _EC: Opnd = Opnd::Reg(X25_REG);
+pub const _SP: Opnd = Opnd::Reg(X26_REG);
 
 // C argument registers on this platform
 pub const _C_ARG_OPNDS: [Opnd; 6] = [
@@ -54,36 +54,6 @@ impl From<Opnd> for A64Opnd {
             Opnd::Value(_) => panic!("attempted to lower an Opnd::Value"),
         }
     }
-}
-
-/// When we're writing out jumps to labels, first we skip past a certain number
-/// of bytes. Then, when the offset between the label reference and the label
-/// itself can be calculated (after we've emitted the rest of the code), we go
-/// back in and patch the jump by reencoding the instruction.
-///
-/// On Arm64, if the jump is short enough we can use just one instruction and
-/// use the offset as an immediate. If the jump is too long, we need to first
-/// load it into a register, then use the branch register instruction. Similarly
-/// with conditional jumps, if it's short enough we can use a b.cond
-/// instruction, otherwise we need to load the destination into a register and
-/// then do some conditional jumping around to get the jump to happen.
-///
-/// Because of this branching logic, you don't necessarily know how many
-/// instructions are going to be encoded for any given jump. However, we _have_
-/// to know this information if we're jumping to a label because we need to
-/// write out a consistent number of instructions. In this case, we can write
-/// however many nop instructions we need to pad the shorter clauses such that
-/// the total number of instructions is consistent.
-///
-/// In cases where we're jumping to a known destination, we don't need to bother
-/// padding anything. However, if we're jumping to a label, we will. This enum
-/// represents those different cases.
-enum BranchPadding {
-    /// We're jumping to a label, so pad with necessary nop instructions.
-    Padding,
-
-    /// We're jumping to a known destination, so don't bother padding.
-    NoPadding,
 }
 
 impl Assembler
@@ -195,138 +165,56 @@ impl Assembler
     /// Returns a list of GC offsets
     pub fn arm64_emit(&mut self, cb: &mut CodeBlock) -> Vec<u32>
     {
-        /// Emit a jump instruction to the given target address. If it's within
-        /// the range where we can use the branch link instruction, then we'll
-        /// use that. Otherwise, we'll load the address into a register and use
-        /// the branch register instruction.
-        fn emit_jump(cb: &mut CodeBlock, src_addr: i64, dst_addr: i64, padding: BranchPadding) {
-            let offset = dst_addr - src_addr;
-
-            if bl_offset_fits_bits(offset) {
-                // Encode how far we're jumping in # of instructions
-                bl(cb, A64Opnd::new_imm(offset / 4));
-
-                // We want instructions that are using registers and
-                // instructions that are using immediates to be the same size in
-                // memory so that we can come back and patch without having to
-                // shift stuff around. So here we'll add enough nop instructions
-                // to make that happen. It works out well for us here since the
-                // code would have jumped away already anyway.
-                if matches!(padding, BranchPadding::Padding) {
-                    nop(cb);
-                    nop(cb);
-                }
-            } else {
-                // Since this is too far to jump directly, we'll load
-                // the value into a register and jump to it
-                mov(cb, X30, A64Opnd::new_uimm(src_addr as u64));
-                mov(cb, X29, A64Opnd::new_uimm(dst_addr as u64));
-                br(cb, X29);
-            }
-        }
-
         /// Emit a conditional jump instruction to a specific target. This is
-        /// called when lowering a direct jump instruction or when lowering a
-        /// ccall instruction. It delegates appropriate work to the emit_jump
-        /// function depending on the kind of target given.
-        fn emit_target_jump(cb: &mut CodeBlock, target: Target) {
+        /// called when lowering any of the conditional jump instructions.
+        fn emit_conditional_jump(cb: &mut CodeBlock, condition: Condition, target: Target) {
             match target {
                 Target::CodePtr(dst_ptr) => {
                     let src_addr = cb.get_write_ptr().into_i64() + 4;
-                    emit_jump(cb, src_addr, dst_ptr.into_i64(), BranchPadding::NoPadding);
-                },
-                Target::Label(label_idx) => {
-                    cb.label_ref(label_idx, 12, |cb, src_addr, dst_addr| {
-                        emit_jump(cb, src_addr, dst_addr, BranchPadding::Padding);
-                    });
-                },
-                Target::FunPtr(fun_ptr) => {
-                    let src_addr = cb.get_write_ptr().into_i64() + 4;
-                    emit_jump(cb, src_addr, fun_ptr as i64, BranchPadding::NoPadding);
-                }
-            };
-        }
+                    let dst_addr = dst_ptr.into_i64();
+                    let offset = dst_addr - src_addr;
 
-        /// Emit a conditional jump instruction. If the offset between the
-        /// instructions fits into the b.cond instruction, we'll use that.
-        /// Otherwise, we'll use a combination of a b.cond, a direct jump
-        /// forward, and loading the destination into a register and branching
-        /// to it.
-        fn emit_conditional_jump(cb: &mut CodeBlock, condition: Condition, src_addr: i64, dst_addr: i64, padding: BranchPadding) {
-            let offset = dst_addr - src_addr;
-            let fits_direct = bl_offset_fits_bits(offset);
-
-            // If the jump offset fits into the conditional jump as an immediate
-            // value and it's properly aligned, then we can use the b.cond
-            // instruction directly. Otherwise, we need to load the address into
-            // a register and use the branch register instruction.
-            if bcond_offset_fits_bits(offset) {
-                bcond(cb, condition, A64Opnd::new_imm(dst_addr - src_addr));
-
-                // Sometimes we need to align both clauses of this conditional
-                // because we're going to come back and patch the memory later.
-                // In that case we'll add enough nop instructions that both
-                // clauses are the same size in memory.
-                if matches!(padding, BranchPadding::Padding) {
-                    nop(cb);
-                    nop(cb);
-                    nop(cb);
-                    nop(cb);
-                }
-            } else {
-                // If the condition is met, then we'll skip past the next
-                // instruction, put the address in a register, and jump to it.
-                bcond(cb, condition, A64Opnd::new_imm(4));
-
-                // If the offset fits into a direct jump, then we'll use that
-                // and the number of instructions will be shorter. Otherwise
-                // we'll use the branch register instruction.
-                if fits_direct {
-                    if matches!(padding, BranchPadding::Padding) {
-                        // If we get to this instruction, then the condition
-                        // wasn't met, in which case we'll jump past the next
-                        // instruction that performs the direct jump.
-                        bl(cb, A64Opnd::new_imm(12));
-
-                        // Here we'll perform the direct jump to the target,
-                        // then encode some nops to keep it aligned.
-                        bl(cb, A64Opnd::new_imm(offset / 4));
-                        nop(cb);
-                        nop(cb);
+                    // If the jump offset fits into the conditional jump as an
+                    // immediate value and it's properly aligned, then we can
+                    // use the b.cond instruction directly. Otherwise, we need
+                    // to load the address into a register and use the branch
+                    // register instruction.
+                    if bcond_offset_fits_bits(offset) {
+                        bcond(cb, condition, A64Opnd::new_imm(dst_addr - src_addr));
                     } else {
-                        // If we get to this instruction, then the condition
-                        // wasn't met, in which case we'll jump past the next
-                        // instruction that performs the direct jump.
-                        bl(cb, A64Opnd::new_imm(4));
+                        // If the condition is met, then we'll skip past the
+                        // next instruction, put the address in a register, and
+                        // jump to it.
+                        bcond(cb, condition, A64Opnd::new_imm(4));
 
-                        // Here we'll perform the direct jump to the target.
-                        bl(cb, A64Opnd::new_imm(offset / 4));
+                        // If the offset fits into a direct jump, then we'll use
+                        // that and the number of instructions will be shorter.
+                        // Otherwise we'll use the branch register instruction.
+                        if b_offset_fits_bits(offset) {
+                            // If we get to this instruction, then the condition
+                            // wasn't met, in which case we'll jump past the
+                            // next instruction that performs the direct jump.
+                            b(cb, A64Opnd::new_imm(4));
+
+                            // Here we'll perform the direct jump to the target.
+                            b(cb, A64Opnd::new_imm(offset / 4));
+                        } else {
+                            // If we get to this instruction, then the condition
+                            // wasn't met, in which case we'll jump past the
+                            // next instruction that perform the direct jump.
+                            b(cb, A64Opnd::new_imm(8));
+                            mov(cb, X29, A64Opnd::new_uimm(dst_addr as u64));
+                            br(cb, X29);
+                        }
                     }
-                } else {
-                    // If we get to this instruction, then the condition wasn't
-                    // met, in which case we'll jump past the next instruction
-                    // that perform the direct jump.
-                    bl(cb, A64Opnd::new_imm(12));
-                    mov(cb, X30, A64Opnd::new_uimm(src_addr as u64));
-                    mov(cb, X29, A64Opnd::new_uimm(dst_addr as u64));
-                    br(cb, X29);
-                }
-            }
-        }
-
-        /// Emit a conditional jump instruction to a specific target. This is
-        /// called when lowering any of the conditional jump instructions. It
-        /// delegates appropriate work to the emit_conditional_jump function
-        /// depending on the kind of target given.
-        fn emit_target_conditional_jump(cb: &mut CodeBlock, condition: Condition, target: Target) {
-            match target {
-                Target::CodePtr(dst_ptr) => {
-                    let src_addr = cb.get_write_ptr().into_i64() + 4;
-                    emit_conditional_jump(cb, condition, src_addr, dst_ptr.into_i64(), BranchPadding::NoPadding);
                 },
                 Target::Label(label_idx) => {
-                    cb.label_ref(label_idx, 20, |cb, src_addr, dst_addr| {
-                        emit_conditional_jump(cb, condition, src_addr, dst_addr, BranchPadding::Padding);
+                    // Here we're going to save enough space for ourselves and
+                    // then come back and write the instruction once we know the
+                    // offset. We're going to assume we can fit into a single
+                    // b.cond instruction. It will panic otherwise.
+                    cb.label_ref(label_idx, 4, |cb, src_addr, dst_addr| {
+                        bcond(cb, condition, A64Opnd::new_imm(dst_addr - src_addr));
                     });
                 },
                 Target::FunPtr(_) => unreachable!()
@@ -406,7 +294,26 @@ impl Assembler
                         mov(cb, C_ARG_REGS[idx], insn.opnds[idx].into());
                     }
 
-                    emit_target_jump(cb, insn.target.unwrap());
+                    let src_addr = cb.get_write_ptr().into_i64() + 4;
+                    let dst_addr = insn.target.unwrap().unwrap_fun_ptr() as i64;
+
+                    // The offset between the two instructions in bytes. Note
+                    // that when we encode this into a bl instruction, we'll
+                    // divide by 4 because it accepts the number of instructions
+                    // to jump over.
+                    let offset = dst_addr - src_addr;
+
+                    // If the offset is short enough, then we'll use the branch
+                    // link instruction. Otherwise, we'll move the destination
+                    // and return address into appropriate registers and use the
+                    // branch register instruction.
+                    if b_offset_fits_bits(offset) {
+                        bl(cb, A64Opnd::new_imm(offset / 4));
+                    } else {
+                        mov(cb, X30, A64Opnd::new_uimm(src_addr as u64));
+                        mov(cb, X29, A64Opnd::new_uimm(dst_addr as u64));
+                        br(cb, X29);
+                    }
                 },
                 Op::CRet => {
                     // TODO: bias allocation towards return register
@@ -426,22 +333,55 @@ impl Assembler
                     br(cb, insn.opnds[0].into());
                 },
                 Op::Jmp => {
-                    emit_target_jump(cb, insn.target.unwrap());
+                    match insn.target.unwrap() {
+                        Target::CodePtr(dst_ptr) => {
+                            let src_addr = cb.get_write_ptr().into_i64() + 4;
+                            let dst_addr = dst_ptr.into_i64();
+
+                            // The offset between the two instructions in bytes.
+                            // Note that when we encode this into a b
+                            // instruction, we'll divide by 4 because it accepts
+                            // the number of instructions to jump over.
+                            let offset = dst_addr - src_addr;
+
+                            // If the offset is short enough, then we'll use the
+                            // branch instruction. Otherwise, we'll move the
+                            // destination into a register and use the branch
+                            // register instruction.
+                            if b_offset_fits_bits(offset) {
+                                b(cb, A64Opnd::new_imm(offset / 4));
+                            } else {
+                                mov(cb, X29, A64Opnd::new_uimm(dst_addr as u64));
+                                br(cb, X29);
+                            }
+                        },
+                        Target::Label(label_idx) => {
+                            // Here we're going to save enough space for
+                            // ourselves and then come back and write the
+                            // instruction once we know the offset. We're going
+                            // to assume we can fit into a single b instruction.
+                            // It will panic otherwise.
+                            cb.label_ref(label_idx, 4, |cb, src_addr, dst_addr| {
+                                b(cb, A64Opnd::new_imm((dst_addr - src_addr) / 4));
+                            });
+                        },
+                        _ => unreachable!()
+                    };
                 },
                 Op::Je => {
-                    emit_target_conditional_jump(cb, Condition::EQ, insn.target.unwrap());
+                    emit_conditional_jump(cb, Condition::EQ, insn.target.unwrap());
                 },
                 Op::Jbe => {
-                    emit_target_conditional_jump(cb, Condition::LS, insn.target.unwrap());
+                    emit_conditional_jump(cb, Condition::LS, insn.target.unwrap());
                 },
                 Op::Jz => {
-                    emit_target_conditional_jump(cb, Condition::EQ, insn.target.unwrap());
+                    emit_conditional_jump(cb, Condition::EQ, insn.target.unwrap());
                 },
                 Op::Jnz => {
-                    emit_target_conditional_jump(cb, Condition::NE, insn.target.unwrap());
+                    emit_conditional_jump(cb, Condition::NE, insn.target.unwrap());
                 },
                 Op::Jo => {
-                    emit_target_conditional_jump(cb, Condition::VS, insn.target.unwrap());
+                    emit_conditional_jump(cb, Condition::VS, insn.target.unwrap());
                 },
                 Op::IncrCounter => {
                     ldaddal(cb, insn.opnds[0].into(), insn.opnds[0].into(), insn.opnds[1].into());

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -276,6 +276,13 @@ pub enum Target
 
 impl Target
 {
+    pub fn unwrap_fun_ptr(&self) -> *const u8 {
+        match self {
+            Target::FunPtr(ptr) => *ptr,
+            _ => unreachable!("trying to unwrap {:?} into fun ptr", self)
+        }
+    }
+
     pub fn unwrap_label_idx(&self) -> usize {
         match self {
             Target::Label(idx) => *idx,

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -11,10 +11,10 @@ use crate::asm::x86_64::{X86Opnd, X86Imm, X86UImm, X86Reg, X86Mem, RegType};
 use crate::core::{Context, Type, TempMapping};
 use crate::codegen::{JITState};
 
-// #[cfg(target_arch = "x86_64")]
-// use crate::backend::x86_64::*;
+#[cfg(target_arch = "x86_64")]
+use crate::backend::x86_64::*;
 
-// #[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")]
 use crate::backend::arm64::*;
 
 pub const EC: Opnd = _EC;

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -11,10 +11,10 @@ use crate::asm::x86_64::{X86Opnd, X86Imm, X86UImm, X86Reg, X86Mem, RegType};
 use crate::core::{Context, Type, TempMapping};
 use crate::codegen::{JITState};
 
-#[cfg(target_arch = "x86_64")]
-use crate::backend::x86_64::*;
+// #[cfg(target_arch = "x86_64")]
+// use crate::backend::x86_64::*;
 
-#[cfg(target_arch = "aarch64")]
+// #[cfg(target_arch = "aarch64")]
 use crate::backend::arm64::*;
 
 pub const EC: Opnd = _EC;

--- a/yjit/src/backend/mod.rs
+++ b/yjit/src/backend/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(target_arch = "x86_64")]
-pub mod x86_64;
+// #[cfg(target_arch = "x86_64")]
+// pub mod x86_64;
 
-#[cfg(target_arch = "aarch64")]
+// #[cfg(target_arch = "aarch64")]
 pub mod arm64;
 
 pub mod ir;

--- a/yjit/src/backend/mod.rs
+++ b/yjit/src/backend/mod.rs
@@ -1,3 +1,8 @@
-pub mod x86_64;
+// #[cfg(target_arch = "x86_64")]
+// pub mod x86_64;
+
+// #[cfg(target_arch = "aarch64")]
+pub mod arm64;
+
 pub mod ir;
 mod tests;

--- a/yjit/src/backend/mod.rs
+++ b/yjit/src/backend/mod.rs
@@ -1,7 +1,7 @@
-// #[cfg(target_arch = "x86_64")]
-// pub mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
 
-// #[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")]
 pub mod arm64;
 
 pub mod ir;

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -186,6 +186,9 @@ impl Assembler
                     for (idx, opnd) in insn.opnds.iter().enumerate() {
                         mov(cb, C_ARG_REGS[idx], insn.opnds[idx].into());
                     }
+
+                    let ptr = insn.target.unwrap().unwrap_fun_ptr();
+                    call_ptr(cb, RAX, ptr);
                 },
 
                 Op::CRet => {

--- a/yjit/src/virtualmem.rs
+++ b/yjit/src/virtualmem.rs
@@ -98,7 +98,7 @@ impl<A: Allocator> VirtualMemory<A> {
 
     /// Retrieve a specific position for writing and validate that it is okay to
     /// write to that position.
-    pub fn get_position_for_writing(&mut self, write_ptr: CodePtr) -> Result<*mut u8, WriteError> {
+    fn as_mut_ptr(&mut self, write_ptr: CodePtr) -> Result<*mut u8, WriteError> {
         let page_size = self.page_size_bytes;
         let raw: *mut u8 = write_ptr.raw_ptr() as *mut u8;
         let page_addr = (raw as usize / page_size) * page_size;
@@ -160,14 +160,14 @@ impl<A: Allocator> VirtualMemory<A> {
 
     /// Write a single byte. The first write to a page makes it readable.
     pub fn write_byte(&mut self, write_ptr: CodePtr, byte: u8) -> Result<(), WriteError> {
-        let raw = self.get_position_for_writing(write_ptr)?;
+        let raw = self.as_mut_ptr(write_ptr)?;
         unsafe { raw.write(byte) };
         Ok(())
     }
 
     /// Bitwise OR a single byte. The first write to a page makes it readable.
     pub fn or_byte(&mut self, write_ptr: CodePtr, byte: u8) -> Result<(), WriteError> {
-        let raw = self.get_position_for_writing(write_ptr)?;
+        let raw = self.as_mut_ptr(write_ptr)?;
         unsafe { raw.write(byte | *raw) };
         Ok(())
     }

--- a/yjit/src/virtualmem.rs
+++ b/yjit/src/virtualmem.rs
@@ -154,7 +154,9 @@ impl<A: Allocator> VirtualMemory<A> {
             }
         }
 
+        // We have permission to write if we get here
         unsafe { raw.write(byte) };
+
         Ok(())
     }
 


### PR DESCRIPTION
Sorry to dump this all in one PR, but it was easier to keep it local to iterate a little faster. If you want to review one commit at a time it might be easier. This gets us quite a bit closer to being able to finish out the Arm64 side of the backend. It adds a bunch of instruction encodings, spends a lot of time working on the arm backend, then redoes the way we handle label refs to make it easier to do label jumps in arm. It doesn't actually do the arm label jumps yet, but it makes it possible.

@XrXr and @maximecb I would love your opinion on how it handles label jumps now. Basically the approach is to skip past a certain number of bytes known at JIT compile time, then come back and patch by reencoding the entire instruction. It does that by keeping around an `FnOnce` that it can call with the codeblock and the offset.

In total, here's the stuff in this PR:

* Instructions
  * brk (set breakpoint)
  * mov bitmask immediate (moving some immediates into registers)
  * orr bitmask immediate (logical OR on an immediate)
  * mov register (moving a value from one register to another)
  * mvn register (moving a value from one register to another and NOTing the value)
  * orn register (logical OR on a register into another register and NOTing the value)
  * orr register (logical ORR on a register)
* Backend interface
  * A64Reg.sub_reg
  * A64Mem.num_bits
  * _CFP, _EC, _SP, _C_ARG_OPNDS, _C_RET_OPND
  * Mapping operands down to A64Opnd
  * The beginnings of splitting for Arm64
  * A bunch of lowering for Arm64
* The way we handle label refs described above (and updates to the X86 backend accordingly)
