### PR TITLE
Fix jumps

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -570,7 +570,7 @@ impl Assembler
                             // to assume we can fit into a single b instruction.
                             // It will panic otherwise.
                             cb.label_ref(label_idx, 4, |cb, src_addr, dst_addr| {
-                                b(cb, A64Opnd::new_imm((dst_addr - src_addr) / 4));
+                                b(cb, A64Opnd::new_imm((dst_addr - src_addr) / 4 + 1));
                             });
                         },
                         _ => unreachable!()

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -262,7 +262,7 @@ impl Assembler
                 Op::LeaLabel => {
                     let label_idx = insn.target.unwrap().unwrap_label_idx();
 
-                    cb.label_ref(label_idx, 4, |cb, src_addr, dst_addr| {
+                    cb.label_ref(label_idx, 7, |cb, src_addr, dst_addr| {
                         let disp = dst_addr - src_addr;
                         lea(cb, Self::SCRATCH0, mem_opnd(8, RIP, disp.try_into().unwrap()));
                     });


### PR DESCRIPTION
* On X86, the label ref was off on the number of bytes that it took to encode
* On AArch64, we were off by 1 instruction on how far to jump for the b instruction