### PR TITLE
Fix dupn

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -7,7 +7,6 @@ use std::convert::From;
 use crate::cruby::{VALUE};
 use crate::virtualmem::{CodePtr};
 use crate::asm::{CodeBlock, uimm_num_bits, imm_num_bits};
-use crate::asm::x86_64::{X86Opnd, X86Imm, X86UImm, X86Reg, X86Mem, RegType};
 use crate::core::{Context, Type, TempMapping};
 use crate::codegen::{JITState};
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6313,7 +6313,6 @@ mod tests {
         assert!(ocb.unwrap().get_write_pos() > 0);
     }
 
-    /*
     #[test]
     fn test_gen_exit() {
         let (_, ctx, mut asm, mut cb, _) = setup_codegen();
@@ -6328,7 +6327,6 @@ mod tests {
          get_side_exit(&mut jit, &mut ocb, &ctx);
         assert!(ocb.unwrap().get_write_pos() > 0);
     }
-    */
 
     #[test]
     fn test_gen_check_ints() {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -931,8 +931,6 @@ fn gen_dupn(
     _ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
 
-    let mut asm = Assembler::new();
-
     let nval: VALUE = jit_get_arg(jit, 0);
     let VALUE(n) = nval;
 
@@ -6376,7 +6374,6 @@ mod tests {
         assert!(cb.get_write_pos() > 0); // Write some movs
     }
 
-    /*
     #[test]
     fn test_gen_dupn() {
         let (mut jit, mut context, mut asm, mut cb, mut ocb) = setup_codegen();
@@ -6400,7 +6397,6 @@ mod tests {
         asm.compile(&mut cb);
         assert!(cb.get_write_pos() > 0); // Write some movs
     }
-    */
 
     #[test]
     fn test_gen_swap() {


### PR DESCRIPTION
Dupn was creating an internal asm object, using it, and throwing it away. Thus, no instructions written.

There was an x86-specific line in the shared backend IR file that no longer seems needed. Removed it.

Uncommented all the tests. Looks like get_side_exit and gen_exit work now too, probably because of the recent fixes other folks pushed.