### PR TITLE
Update disasm to work on ARM

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -758,4 +758,28 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
     }
+
+    #[test]
+    #[cfg(feature = "disasm")]
+    fn test_simple_disasm() -> std::result::Result<(), capstone::Error> {
+        // Test drive Capstone with simple input
+        use capstone::prelude::*;
+
+        let cs = Capstone::new()
+            .arm64()
+            .mode(arch::arm64::ArchMode::Arm)
+            .build()?;
+
+        let insns = cs.disasm_all(&[0x60, 0x0f, 0x80, 0xF2], 0x1000)?;
+
+        match insns.as_ref() {
+            [insn] => {
+                assert_eq!(Some("movk"), insn.mnemonic());
+                Ok(())
+            }
+            _ => Err(capstone::Error::CustomError(
+                "expected to disassemble to movk",
+            )),
+        }
+    }
 }

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -67,10 +67,19 @@ fn disasm_iseq(iseq: IseqPtr) -> String {
 
     // Initialize capstone
     use capstone::prelude::*;
+
+    #[cfg(target_arch = "x86_64")]
     let cs = Capstone::new()
         .x86()
         .mode(arch::x86::ArchMode::Mode64)
         .syntax(arch::x86::ArchSyntax::Intel)
+        .build()
+        .unwrap();
+
+    #[cfg(target_arch = "aarch64")]
+    let cs = Capstone::new()
+        .arm64()
+        .mode(arch::arm64::ArchMode::Arm)
         .build()
         .unwrap();
 


### PR DESCRIPTION
Here's a trivial disassembly test that shows ARM assembly with this PR if run with "./miniruby --yjit-call-threshold=1" on an appropriately-configured Ruby:

~~~
def test_for_disasm
  7
end

./test_for_disasm

puts "DISASM: #{RubyVM::YJIT.disasm(method(:test_for_disasm))}"
puts "======"
~~~

Here's the disassembly I get on my M1:

~~~
noah@Noahs-MBP rust-yjit % ./miniruby --yjit-call-threshold=1 ./disasm_test.rb
DISASM: == disasm: #<ISeq:test_for_disasm@./disasm_test.rb:1 (1,0)-(3,3)> (catch: FALSE)
0000 putobject                              7                         (   2)[LiCa]
0002 leave                                                            (   3)[Re]

NUM BLOCK VERSIONS: 1
TOTAL INLINE CODE SIZE: 48 bytes
== BLOCK 1/1, ISEQ RANGE [0,3), 48 bytes ======================
  # putobject
  0x1039c0934: mov x11, #0xf
  0x1039c0938: stur x11, [x21]
  # leave
  # pop stack frame
  0x1039c093c: add x11, x19, #0x40
  0x1039c0940: mov x19, x11
  0x1039c0944: stur x11, [x20, #0x10]
  0x1039c0948: ldur x11, [x21]
  0x1039c094c: mov x0, x11
  0x1039c0950: ldur x11, [x19, #8]
  0x1039c0954: mov x21, x11
  0x1039c0958: stur x0, [x21]
  0x1039c095c: ldur x11, [x19, #-8]
  0x1039c0960: br x11
======
~~~
