### PR TITLE
Fixes for AArch64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,6 +140,7 @@ yjit_task:
     bootstraptest/test_flow.rb \
     bootstraptest/test_fork.rb \
     bootstraptest/test_gc.rb \
+    bootstraptest/test_io.rb \
     bootstraptest/test_jump.rb \
     bootstraptest/test_literal_suffix.rb \
     bootstraptest/test_load.rb \
@@ -147,7 +148,9 @@ yjit_task:
     bootstraptest/test_massign.rb \
     bootstraptest/test_method.rb \
     bootstraptest/test_objectspace.rb \
+    bootstraptest/test_proc.rb \
     bootstraptest/test_string.rb \
     bootstraptest/test_struct.rb \
     bootstraptest/test_yjit_new_backend.rb
+    bootstraptest/test_yjit_rust_port.rb
   # full_build_script: make -j

--- a/yjit/src/asm/arm64/arg/mod.rs
+++ b/yjit/src/asm/arm64/arg/mod.rs
@@ -4,9 +4,11 @@
 mod bitmask_imm;
 mod condition;
 mod sf;
+mod shifted_imm;
 mod sys_reg;
 
 pub use bitmask_imm::BitmaskImmediate;
 pub use condition::Condition;
 pub use sf::Sf;
+pub use shifted_imm::ShiftedImmediate;
 pub use sys_reg::SystemRegister;

--- a/yjit/src/asm/arm64/arg/shifted_imm.rs
+++ b/yjit/src/asm/arm64/arg/shifted_imm.rs
@@ -1,0 +1,75 @@
+/// How much to shift the immediate by.
+pub enum Shift {
+    LSL0 = 0b0, // no shift
+    LSL12 = 0b1 // logical shift left by 12 bits
+}
+
+/// Some instructions accept a 12-bit immediate that has an optional shift
+/// attached to it. This allows encoding larger values than just fit into 12
+/// bits. We attempt to encode those here. If the values are too large we have
+/// to bail out.
+pub struct ShiftedImmediate {
+    shift: Shift,
+    value: u16
+}
+
+impl TryFrom<u64> for ShiftedImmediate {
+    type Error = ();
+
+    /// Attempt to convert a u64 into a BitmaskImm.
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let mut current = value;
+        if current < 2_u64.pow(12) {
+            return Ok(ShiftedImmediate { shift: Shift::LSL0, value: current as u16 });
+        }
+
+        if (current & (2_u64.pow(12) - 1) == 0) && ((current >> 12) < 2_u64.pow(12)) {
+            return Ok(ShiftedImmediate { shift: Shift::LSL12, value: (current >> 12) as u16 });
+        }
+
+        Err(())
+    }
+}
+
+impl From<ShiftedImmediate> for u32 {
+    /// Encode a bitmask immediate into a 32-bit value.
+    fn from(imm: ShiftedImmediate) -> Self {
+        0
+        | (((imm.shift as u32) & 1) << 12)
+        | (imm.value as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_shift() {
+        let value = 256;
+        let result = ShiftedImmediate::try_from(value);
+
+        assert!(matches!(result, Ok(ShiftedImmediate { shift: Shift::LSL0, value })));
+    }
+
+    #[test]
+    fn test_maximum_no_shift() {
+        let value = (1 << 12) - 1;
+        let result = ShiftedImmediate::try_from(value);
+
+        assert!(matches!(result, Ok(ShiftedImmediate { shift: Shift::LSL0, value })));
+    }
+
+    #[test]
+    fn test_with_shift() {
+        let result = ShiftedImmediate::try_from(256 << 12);
+
+        assert!(matches!(result, Ok(ShiftedImmediate { shift: Shift::LSL12, value: 256 })));
+    }
+
+    #[test]
+    fn test_unencodable() {
+        let result = ShiftedImmediate::try_from((256 << 12) + 1);
+        assert!(matches!(result, Err(())));
+    }
+}

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -41,18 +41,16 @@ pub fn add(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::UImm(uimm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(uimm_fits_bits(uimm12, 12), "The immediate operand must be 12 bits or less.");
 
-            DataImm::add(rd.reg_no, rn.reg_no, uimm12 as u16, rd.num_bits).into()
+            DataImm::add(rd.reg_no, rn.reg_no, uimm12.try_into().unwrap(), rd.num_bits).into()
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::Imm(imm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(imm_fits_bits(imm12, 12), "The immediate operand must be 12 bits or less.");
 
             if imm12 < 0 {
-                DataImm::sub(rd.reg_no, rn.reg_no, -imm12 as u16, rd.num_bits).into()
+                DataImm::sub(rd.reg_no, rn.reg_no, (-imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             } else {
-                DataImm::add(rd.reg_no, rn.reg_no, imm12 as u16, rd.num_bits).into()
+                DataImm::add(rd.reg_no, rn.reg_no, (imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             }
         },
         _ => panic!("Invalid operand combination to add instruction."),
@@ -74,18 +72,16 @@ pub fn adds(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::UImm(imm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(uimm_fits_bits(imm12, 12), "The immediate operand must be 12 bits or less.");
 
-            DataImm::adds(rd.reg_no, rn.reg_no, imm12 as u16, rd.num_bits).into()
+            DataImm::adds(rd.reg_no, rn.reg_no, imm12.try_into().unwrap(), rd.num_bits).into()
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::Imm(imm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(imm_fits_bits(imm12, 12), "The immediate operand must be 12 bits or less.");
 
             if imm12 < 0 {
-                DataImm::subs(rd.reg_no, rn.reg_no, -imm12 as u16, rd.num_bits).into()
+                DataImm::subs(rd.reg_no, rn.reg_no, (-imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             } else {
-                DataImm::adds(rd.reg_no, rn.reg_no, imm12 as u16, rd.num_bits).into()
+                DataImm::adds(rd.reg_no, rn.reg_no, (imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             }
         },
         _ => panic!("Invalid operand combination to adds instruction."),
@@ -272,9 +268,7 @@ pub fn cmp(cb: &mut CodeBlock, rn: A64Opnd, rm: A64Opnd) {
             DataReg::cmp(rn.reg_no, rm.reg_no, rn.num_bits).into()
         },
         (A64Opnd::Reg(rn), A64Opnd::UImm(imm12)) => {
-            assert!(uimm_fits_bits(imm12, 12), "The immediate operand must be 12 bits or less.");
-
-            DataImm::cmp(rn.reg_no, imm12 as u16, rn.num_bits).into()
+            DataImm::cmp(rn.reg_no, imm12.try_into().unwrap(), rn.num_bits).into()
         },
         _ => panic!("Invalid operand combination to cmp instruction."),
     };
@@ -477,12 +471,12 @@ pub fn mov(cb: &mut CodeBlock, rd: A64Opnd, rm: A64Opnd) {
         (A64Opnd::Reg(A64Reg { reg_no: 31, num_bits: 64 }), A64Opnd::Reg(rm)) => {
             assert!(rm.num_bits == 64, "Expected rm to be 64 bits");
 
-            DataImm::add(31, rm.reg_no, 0, 64).into()
+            DataImm::add(31, rm.reg_no, 0.try_into().unwrap(), 64).into()
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(A64Reg { reg_no: 31, num_bits: 64 })) => {
             assert!(rd.num_bits == 64, "Expected rd to be 64 bits");
 
-            DataImm::add(rd.reg_no, 31, 0, 64).into()
+            DataImm::add(rd.reg_no, 31, 0.try_into().unwrap(), 64).into()
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rm)) => {
             assert!(rd.num_bits == rm.num_bits, "Expected registers to be the same size");
@@ -713,18 +707,16 @@ pub fn sub(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::UImm(uimm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(uimm_fits_bits(uimm12, 12), "The immediate operand must be 12 bits or less.");
 
-            DataImm::sub(rd.reg_no, rn.reg_no, uimm12 as u16, rd.num_bits).into()
+            DataImm::sub(rd.reg_no, rn.reg_no, uimm12.try_into().unwrap(), rd.num_bits).into()
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::Imm(imm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(imm_fits_bits(imm12, 12), "The immediate operand must be 12 bits or less.");
 
             if imm12 < 0 {
-                DataImm::add(rd.reg_no, rn.reg_no, -imm12 as u16, rd.num_bits).into()
+                DataImm::add(rd.reg_no, rn.reg_no, (-imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             } else {
-                DataImm::sub(rd.reg_no, rn.reg_no, imm12 as u16, rd.num_bits).into()
+                DataImm::sub(rd.reg_no, rn.reg_no, (imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             }
         },
         _ => panic!("Invalid operand combination to sub instruction."),
@@ -746,18 +738,16 @@ pub fn subs(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::UImm(uimm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(uimm_fits_bits(uimm12, 12), "The immediate operand must be 12 bits or less.");
 
-            DataImm::subs(rd.reg_no, rn.reg_no, uimm12 as u16, rd.num_bits).into()
+            DataImm::subs(rd.reg_no, rn.reg_no, uimm12.try_into().unwrap(), rd.num_bits).into()
         },
         (A64Opnd::Reg(rd), A64Opnd::Reg(rn), A64Opnd::Imm(imm12)) => {
             assert!(rd.num_bits == rn.num_bits, "rd and rn must be of the same size.");
-            assert!(imm_fits_bits(imm12, 12), "The immediate operand must be 12 bits or less.");
 
             if imm12 < 0 {
-                DataImm::adds(rd.reg_no, rn.reg_no, -imm12 as u16, rd.num_bits).into()
+                DataImm::adds(rd.reg_no, rn.reg_no, (-imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             } else {
-                DataImm::subs(rd.reg_no, rn.reg_no, imm12 as u16, rd.num_bits).into()
+                DataImm::subs(rd.reg_no, rn.reg_no, (imm12 as u64).try_into().unwrap(), rd.num_bits).into()
             }
         },
         _ => panic!("Invalid operand combination to subs instruction."),


### PR DESCRIPTION
* All of the data processing -- immediate instructions accept both an immediate and an optional flag to shift left by 12 bits. Previously we always set that to 0, but this PR adds support for attempting to encode a u64 as this value. That's encapsulated in the `ShiftedImmediate` struct implementing a `TryFrom<u64>`. Now all of those instructions accept an instance of this struct and use that to encode instead of two different arguments (value + shift). This allows us to encode more immediate values. Believe it or not, this actually came up because of a bootstrap test failing, and it passed after this encoding was in place. Because we can now check if this will encode properly ahead of time, we now split on all places that accept a `ShiftedImmediate`. If it can be encoded, we use the value. Otherwise we split it into a load first. This applies to ADD, ADDS, CMP, SUB, and SUBS.
* When we invoke an STUR instruction, the displacement for the memory address must fit into 9 bits. This works in most cases, but one of the bootstrap tests was failing with a large displacement. Now we split when the value is too large to first load the address into a register with `Op::Lea` (lowers to `ADD`) and then replace it with a new memory operand with a 0 displacement. To use this we split on all `Op::Store` instructions and the `Op::Mov` instructions that would lower to a store.
* Previously we were incorrectly splitting the `Op::Sub` instruction as if subtraction were commutative 😔. We now properly maintain ordering of the operands and lower them appropriately.
* We now do smarter splitting of the `Op::Add` instruction by moving around the operands as necessary. For example, if you were to add an immediate with a register (as opposed to a register with an immediate) we swap the order of the operands instead of loading the first into a register.