### PR TITLE
Add LiveReg IR instruction to fix stats leave exit code

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -791,6 +791,7 @@ impl Assembler
                 Op::CSelGE => {
                     csel(cb, insn.out.into(), insn.opnds[0].into(), insn.opnds[1].into(), Condition::GE);
                 }
+                Op::LiveReg => (), // just a reg alloc signal, no code
             };
         }
 

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -448,7 +448,8 @@ impl Assembler
                 Op::CSelGE => {
                     mov(cb, insn.out.into(), insn.opnds[0].into());
                     cmovl(cb, insn.out.into(), insn.opnds[1].into());
-                },
+                }
+                Op::LiveReg => (), // just a reg alloc signal, no code
 
                 // We want to keep the panic here because some instructions that
                 // we feed to the backend could get lowered into other

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -204,7 +204,7 @@ macro_rules! gen_counter_incr {
             let counter_opnd = Opnd::mem(64, ptr_reg, 0);
 
             // Increment and store the updated value
-            $asm.incr_counter(counter_opnd, 1.into() );
+            $asm.incr_counter(counter_opnd, 1.into());
         }
     };
 }
@@ -543,8 +543,9 @@ fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr {
     let code_ptr = ocb.get_write_ptr();
     let mut asm = Assembler::new();
 
-    // NOTE: gen_leave() fully reconstructs interpreter state and leaves the
+    // gen_leave() fully reconstructs interpreter state and leaves the
     // return value in C_RET_OPND before coming here.
+    let ret_opnd = asm.live_reg_opnd(C_RET_OPND);
 
     // Every exit to the interpreter should be counted
     gen_counter_incr!(asm, leave_interp_return);
@@ -555,7 +556,7 @@ fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr {
 
     asm.frame_teardown();
 
-    asm.cret(C_RET_OPND);
+    asm.cret(ret_opnd);
 
     asm.compile(ocb);
 


### PR DESCRIPTION
It allows for reserving a specific register and prevents the register
allocator from clobbering it. Without this
`./miniruby --yjit-stats --yjit-callthreshold=1 -e0` was crashing because
the counter incrementing code was clobbering RAX incorrectly.