### PR TITLE
Port `gen_checktype` to the new IR assembler backend

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -169,6 +169,14 @@ assert_equal '[nil, "method"]', %q{
     foo()
 }
 
+# checktype
+assert_equal 'false', %q{
+    def function()
+        [1, 2] in [Integer, String]
+    end
+    function()
+}
+
 
 
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2183,11 +2183,10 @@ fn gen_defined(
     KeepCompiling
 }
 
-/*
 fn gen_checktype(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     _ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     let type_val = jit_get_arg(jit, 0).as_u32();
@@ -2205,44 +2204,39 @@ fn gen_checktype(
             | (RUBY_T_HASH, Type::Hash) => {
                 // guaranteed type match
                 let stack_ret = ctx.stack_push(Type::True);
-                mov(cb, stack_ret, uimm_opnd(Qtrue.as_u64()));
+                asm.mov(stack_ret, Opnd::UImm(Qtrue.into()));
                 return KeepCompiling;
             }
             _ if val_type.is_imm() || val_type.is_specific() => {
                 // guaranteed not to match T_STRING/T_ARRAY/T_HASH
                 let stack_ret = ctx.stack_push(Type::False);
-                mov(cb, stack_ret, uimm_opnd(Qfalse.as_u64()));
+                asm.mov(stack_ret, Opnd::UImm(Qfalse.into()));
                 return KeepCompiling;
             }
             _ => (),
         }
 
-        mov(cb, REG0, val);
-        mov(cb, REG1, uimm_opnd(Qfalse.as_u64()));
-
-        let ret = cb.new_label("ret".to_string());
+        let ret = asm.new_label("ret");
 
         if !val_type.is_heap() {
             // if (SPECIAL_CONST_P(val)) {
             // Return Qfalse via REG1 if not on heap
-            test(cb, REG0, uimm_opnd(RUBY_IMMEDIATE_MASK as u64));
-            jnz_label(cb, ret);
-            cmp(cb, REG0, uimm_opnd(Qnil.as_u64()));
-            jbe_label(cb, ret);
+            asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
+            asm.jnz(ret);
+            asm.cmp(val, Opnd::UImm(Qnil.into()));
+            asm.jbe(ret);
         }
 
         // Check type on object
-        mov(cb, REG0, mem_opnd(64, REG0, RUBY_OFFSET_RBASIC_FLAGS));
-        and(cb, REG0, uimm_opnd(RUBY_T_MASK as u64));
-        cmp(cb, REG0, uimm_opnd(type_val as u64));
-        mov(cb, REG0, uimm_opnd(Qtrue.as_u64()));
-        // REG1 contains Qfalse from above
-        cmove(cb, REG1, REG0);
+        let object_type = asm.and(
+            Opnd::mem(64, val, RUBY_OFFSET_RBASIC_FLAGS),
+            Opnd::UImm(RUBY_T_MASK.into()));
+        asm.cmp(object_type, Opnd::UImm(type_val.into()));
+        let ret_opnd = asm.csel_e(Opnd::UImm(Qfalse.into()), Opnd::UImm(Qtrue.into()));
 
-        cb.write_label(ret);
+        asm.write_label(ret);
         let stack_ret = ctx.stack_push(Type::UnknownImm);
-        mov(cb, stack_ret, REG1);
-        cb.link_labels();
+        asm.mov(stack_ret, ret_opnd);
 
         KeepCompiling
     } else {
@@ -2250,6 +2244,7 @@ fn gen_checktype(
     }
 }
 
+/*
 fn gen_concatstrings(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -5915,7 +5910,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_duphash => Some(gen_duphash),
         YARVINSN_newarray => Some(gen_newarray),
         YARVINSN_duparray => Some(gen_duparray),
-        //YARVINSN_checktype => Some(gen_checktype),
+        YARVINSN_checktype => Some(gen_checktype),
         YARVINSN_opt_lt => Some(gen_opt_lt),
         /*
         YARVINSN_opt_le => Some(gen_opt_le),


### PR DESCRIPTION
Attempt at porting `checktype` to the new IR backend.


Added a test snippet that includes a `checktype`:

```
irb(main):003:0> puts RubyVM::InstructionSequence.compile(%q{ [1, 2] in [Integer, String]}).disassemble
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,28)> (catch: FALSE)
0000 putnil                                                           (   1)[Li]
0001 duparray                               [1, 2]
0003 dup
0004 topn                                   2
0006 branchnil                              17
0008 topn                                   2
0010 branchunless                           90
0012 pop
0013 topn                                   1
0015 jump                                   35
0017 dup
0018 putobject                              :deconstruct
0020 opt_send_without_block                 <calldata!mid:respond_to?, argc:1, ARGS_SIMPLE>
0022 setn                                   3
0024 branchunless                           90
0026 opt_send_without_block                 <calldata!mid:deconstruct, argc:0, ARGS_SIMPLE>
0028 setn                                   2
0030 dup
0031 checktype                              T_ARRAY
```

```
➜  ruby git:(zack_backend_ir_port) ✗ make -j miniruby && RUST_BACKTRACE=1 ruby --disable=gems bootstraptest/runner.rb --ruby="./miniruby -I./lib -I. -I.ext/common --disable-gems --yjit-call-threshold=1 --yjit-verify-ctx" bootstraptest/test_yjit_new_backend.rb
[...]
Target is ruby 3.2.0dev (2022-07-26T18:52:49Z zack_backend_ir_port fcf1d708f0) +YJIT [x86_64-darwin21]
last_commit=port gen_checktype to the new IR assembler backend

test_yjit_new_backend.rb  PASS 21

Finished in 4.68 sec

PASS all 21 tests
```