### PR TITLE
Minor cleanups

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -796,9 +796,9 @@ impl Assembler
     }
 
     //pub fn pos_marker<F: FnMut(CodePtr)>(&mut self, marker_fn: F)
-    pub fn pos_marker(&mut self, marker_fn: PosMarkerFn)
+    pub fn pos_marker(&mut self, marker_fn: impl Fn(CodePtr) + 'static)
     {
-        self.push_insn(Op::PosMarker, vec![], None, None, Some(marker_fn));
+        self.push_insn(Op::PosMarker, vec![], None, None, Some(Box::new(marker_fn)));
     }
 }
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -288,9 +288,9 @@ fn jit_prepare_routine_call(
 /// Record the current codeblock write position for rewriting into a jump into
 /// the outlined block later. Used to implement global code invalidation.
 fn record_global_inval_patch(asm: &mut Assembler, outline_block_target_pos: CodePtr) {
-    asm.pos_marker(Box::new(move |code_ptr| {
+    asm.pos_marker(move |code_ptr| {
         CodegenGlobals::push_global_inval_patch(code_ptr, outline_block_target_pos);
-    }));
+    });
 }
 
 /// Verify the ctx's types and mappings against the compile-time stack, self,

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1744,10 +1744,10 @@ impl Assembler
         // so that we can move the closure below
         let branchref = branchref.clone();
 
-        self.pos_marker(Box::new(move |code_ptr| {
+        self.pos_marker(move |code_ptr| {
             let mut branch = branchref.borrow_mut();
             branch.start_addr = Some(code_ptr);
-        }));
+        });
     }
 
     // Mark the end position of a patchable branch in the machine code
@@ -1757,10 +1757,10 @@ impl Assembler
         // so that we can move the closure below
         let branchref = branchref.clone();
 
-        self.pos_marker(Box::new(move |code_ptr| {
+        self.pos_marker(move |code_ptr| {
             let mut branch = branchref.borrow_mut();
             branch.end_addr = Some(code_ptr);
-        }));
+        });
     }
 }
 

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -87,7 +87,7 @@ yjit_print_iseq(const rb_iseq_t *iseq)
 
 #[cfg(target_arch = "aarch64")]
 macro_rules! c_callable {
-    (fn $f:ident $args:tt $(-> $ret:ty)? $body:block) => { fn $f $args $(-> $ret)? $body };
+    (fn $f:ident $args:tt $(-> $ret:ty)? $body:block) => { extern "C" fn $f $args $(-> $ret)? $body };
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -87,14 +87,12 @@ yjit_print_iseq(const rb_iseq_t *iseq)
 
 #[cfg(target_arch = "aarch64")]
 macro_rules! c_callable {
-    (fn $f:ident $args:tt -> $ret:ty $body:block) => { fn $f $args -> $ret $body };
-    (fn $f:ident $args:tt $body:block) => { fn $f $args $body };
+    (fn $f:ident $args:tt $(-> $ret:ty)? $body:block) => { fn $f $args $(-> $ret)? $body };
 }
 
 #[cfg(target_arch = "x86_64")]
 macro_rules! c_callable {
-    (fn $f:ident $args:tt -> $ret:ty $body:block) => { extern "sysv64" fn $f $args -> $ret $body };
-    (fn $f:ident $args:tt $body:block) => { extern "sysv64" fn $f $args $body };
+    (fn $f:ident $args:tt $(-> $ret:ty)? $body:block) => { extern "sysv64" fn $f $args $(-> $ret)? $body };
 }
 pub(crate) use c_callable;
 


### PR DESCRIPTION
See commit log for details
- Move allocation into Assembler::pos_marker
- Use optional token syntax for calling convention macro
