### PR TITLE
Port gen_concatstring to new backend IR

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -231,7 +231,6 @@ assert_equal 'foo', %q{
     $foo
 }
 
-<<<<<<< HEAD
 # anytostring, intern
 assert_equal 'true', %q{
     def foo()

--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -231,6 +231,7 @@ assert_equal 'foo', %q{
     $foo
 }
 
+<<<<<<< HEAD
 # anytostring, intern
 assert_equal 'true', %q{
     def foo()
@@ -247,6 +248,13 @@ assert_equal '/true/', %q{
     foo().inspect
 }
 
+# concatstrings
+assert_equal '9001', %q{
+    def foo()
+      "#{9001}"
+    end
+    foo()
+}
 
 
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2265,8 +2265,10 @@ fn gen_concatstrings(
     let values_ptr = ctx.sp_opnd(-((SIZEOF_VALUE as isize) * n.as_isize()));
 
     // call rb_str_concat_literals(long n, const VALUE *strings);
-    let args: Vec<Opnd> = vec![Opnd::UImm(n.into()), values_ptr];
-    let return_value = asm.ccall(rb_str_concat_literals as *const u8, args);
+    let return_value = asm.ccall(
+        rb_str_concat_literals as *const u8,
+        vec![Opnd::UImm(n.into()), values_ptr]
+    );
 
     ctx.stack_pop(n.as_usize());
     let stack_ret = ctx.stack_push(Type::CString);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2250,32 +2250,31 @@ fn gen_checktype(
     }
 }
 
-/*
+
 fn gen_concatstrings(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     _ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     let n = jit_get_arg(jit, 0);
 
     // Save the PC and SP because we are allocating
-    jit_prepare_routine_call(jit, ctx, cb, REG0);
+    jit_prepare_routine_call(jit, ctx, asm);
 
     let values_ptr = ctx.sp_opnd(-((SIZEOF_VALUE as isize) * n.as_isize()));
 
     // call rb_str_concat_literals(long n, const VALUE *strings);
-    mov(cb, C_ARG_REGS[0], imm_opnd(n.into()));
-    lea(cb, C_ARG_REGS[1], values_ptr);
-    call_ptr(cb, REG0, rb_str_concat_literals as *const u8);
+    let args: Vec<Opnd> = vec![Opnd::UImm(n.into()), values_ptr];
+    let return_value = asm.ccall(rb_str_concat_literals as *const u8, args);
 
     ctx.stack_pop(n.as_usize());
     let stack_ret = ctx.stack_push(Type::CString);
-    mov(cb, stack_ret, RAX);
+    asm.mov(stack_ret, return_value);
 
     KeepCompiling
 }
-*/
+
 
 fn guard_two_fixnums(ctx: &mut Context, asm: &mut Assembler, side_exit: CodePtr) {
     // Get the stack operand types
@@ -5951,8 +5950,8 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         //YARVINSN_expandarray => Some(gen_expandarray),
         YARVINSN_defined => Some(gen_defined),
         YARVINSN_checkkeyword => Some(gen_checkkeyword),
-        /*
         YARVINSN_concatstrings => Some(gen_concatstrings),
+        /*
         YARVINSN_getinstancevariable => Some(gen_getinstancevariable),
         YARVINSN_setinstancevariable => Some(gen_setinstancevariable),
 


### PR DESCRIPTION
Ports `gen_concastring` to the new IR.

I added a test that includes a `concatstring` but it won't fully run until we get `opt_send_without_block` ported.

```
irb(main):026:0> puts RubyVM::InstructionSequence.compile(%q{"#{9001}"}).disassemble
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,9)> (catch: FALSE)
0000 putobject                              ""                        (   1)[Li]
0002 putobject                              9001
0004 dup
0005 opt_send_without_block                 <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
0007 tostring
0008 concatstrings                          2
0010 leave
```

```
➜  ruby git:(zack_backend_ir_port) make -j miniruby && RUST_BACKTRACE=1 ruby --disable=gems bootstraptest/runner.rb --ruby="./miniruby -I./lib -I. -I.ext/common --disable-gems --yjit-call-threshold=1 --yjit-verify-ctx" bootstraptest/test_yjit_new_backend.rb
[...]
2022-08-01 17:04:26 -0400
Driver is ruby 3.2.0dev (2022-07-22T22:02:24Z yjit_backend_ir 639815ef68) [x86_64-darwin21]
Target is ruby 3.2.0dev (2022-08-01T17:38:44Z zack_backend_ir_port 338880128a) +YJIT [x86_64-darwin21]
last_commit=Merge pull request #347 from Shopify/yjit-backend-setglobal

test_yjit_new_backend.rb  PASS 26

Finished in 1.64 sec

PASS all 26 tests
```