### PR TITLE
Fix live_ranges idx calculation

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -556,7 +556,7 @@ impl Assembler
 
     /// Transform input instructions, consumes the input assembler
     pub(super) fn forward_pass<F>(mut self, mut map_insn: F) -> Assembler
-        where F: FnMut(&mut Assembler, usize, Op, Vec<Opnd>, Option<Target>, Option<String>, Option<PosMarkerFn>)
+        where F: FnMut(&mut Assembler, usize, Op, Vec<Opnd>, Option<Target>, Option<String>, Option<PosMarkerFn>, Vec<Opnd>)
     {
         let mut asm = Assembler {
             insns: Vec::default(),
@@ -583,6 +583,7 @@ impl Assembler
         }
 
         for (index, insn) in self.insns.drain(..).enumerate() {
+            let original_opnds = insn.opnds.clone();
             let opnds: Vec<Opnd> = insn.opnds.into_iter().map(|opnd| map_opnd(opnd, &mut indices)).collect();
 
             // For each instruction, either handle it here or allow the map_insn
@@ -592,7 +593,7 @@ impl Assembler
                     asm.comment(insn.text.unwrap().as_str());
                 },
                 _ => {
-                    map_insn(&mut asm, index, insn.op, opnds, insn.target, insn.text, insn.pos_marker);
+                    map_insn(&mut asm, index, insn.op, opnds, insn.target, insn.text, insn.pos_marker, original_opnds);
                 }
             };
 
@@ -653,7 +654,7 @@ impl Assembler
 
         let live_ranges: Vec<usize> = std::mem::take(&mut self.live_ranges);
 
-        let asm = self.forward_pass(|asm, index, op, opnds, target, text, pos_marker| {
+        let asm = self.forward_pass(|asm, index, op, opnds, target, text, pos_marker, original_insns| {
             // Check if this is the last instruction that uses an operand that
             // spans more than one instruction. In that case, return the
             // allocated register to the pool.


### PR DESCRIPTION
![](https://i.kym-cdn.com/entries/icons/original/000/008/342/ihave.jpg)

@matthewd and I started digging into the new IR branch, which looks really cool! In doing so we think we stumbled upon a bug.

forward_pass adjusts the indexes of our opnds to reflect the new instructions as they are generated in the forward pass. However, we were using the old live_ranges array, for which the new indexes are incorrect.

This caused us to previously generate an IR which contained unnecessary trivial load instructions (ex. `mov rax, rax`), because it was looking at the wrong lifespans. Presumably this could also cause bugs because the lifespan of the incorrectly considered operand idx could be short.

We've added an assert which would have failed on the previous trivial case (but not necessarily all cases).

We fixed this by passing through the original operands, but that feels a bit gross, we thought about passing in the live_ranges of the operands but that seems awkward too since they are the original indexes but we also can't translate them along with the forward pass if they survive past the current instruction. Perhaps a `is_opnd_consumed: vec<bool>` would do it?

Feel free to ping us in slack if we can elaborate on the issue.

NOTE: Presumably `Op::Not` below `Op::Add` has the same problem.

Co-authored-by: Matthew Draper <matthew@trebex.net>