### PR TITLE
Opnd::Value fixes

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -303,10 +303,27 @@ assert_equal '[nil, 1]', %q{
     [Foo.new.foo, bar]
 }
 
+# Test that object references in generated code get marked and moved
+assert_equal "good", %q{
+  def bar
+    "good"
+  end
 
+  def foo
+    bar
+  end
 
+  foo
+  foo
 
+  begin
+    GC.verify_compaction_references(expand_heap: true, toward: :empty)
+  rescue NotImplementedError
+    # in case compaction isn't supported
+  end
 
+  foo
+}
 
 # Microbenchmark with a loop, opt_lt
 assert_equal '55', %q{

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -313,8 +313,7 @@ impl From<u32> for Opnd {
 
 impl From<VALUE> for Opnd {
     fn from(value: VALUE) -> Self {
-        let VALUE(uimm) = value;
-        Opnd::UImm(uimm as u64)
+        Opnd::Value(value)
     }
 }
 

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -95,7 +95,7 @@ impl Assembler
         let live_ranges: Vec<usize> = std::mem::take(&mut self.live_ranges);
 
         self.forward_pass(|asm, index, op, opnds, target, text, pos_marker, original_opnds| {
-            // Load VALUEs into registers for because
+            // Load VALUEs into registers because
             //  - Most instructions can't be encoded with 64-bit immediates.
             //  - We look for Op::Load specifically when emiting to keep GC'ed
             //    VALUEs alive. This is a sort of canonicalization.

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -98,7 +98,7 @@ impl Assembler
             // Load heap object operands into registers because most
             // instructions can't directly work with 64-bit constants
             let opnds = match op {
-                Op::Load | Op::Mov => opnds,
+                Op::Load => opnds,
                 _ => opnds.into_iter().map(|opnd| {
                     if let Opnd::Value(value) = opnd {
                         if !value.special_const_p() {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -95,20 +95,22 @@ impl Assembler
         let live_ranges: Vec<usize> = std::mem::take(&mut self.live_ranges);
 
         self.forward_pass(|asm, index, op, opnds, target, text, pos_marker, original_opnds| {
-            // Load heap object operands into registers because most
-            // instructions can't directly work with 64-bit constants
+            // Load VALUEs into registers for because
+            //  - Most instructions can't be encoded with 64-bit immediates.
+            //  - We look for Op::Load specifically when emiting to keep GC'ed
+            //    VALUEs alive. This is a sort of canonicalization.
             let opnds = match op {
                 Op::Load => opnds,
                 _ => opnds.into_iter().map(|opnd| {
                     if let Opnd::Value(value) = opnd {
-                        if !value.special_const_p() {
-                            asm.load(opnd)
-                        } else {
-                            opnd
+                        // Since mov(mem64, imm32) sign extends, as_i64() makes sure we split
+                        // when the extended value is different.
+                        if !value.special_const_p() || imm_num_bits(value.as_i64()) > 32 {
+                            return asm.load(opnd);
                         }
-                    } else {
-                        opnd
                     }
+
+                    opnd
                 }).collect()
             };
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -849,7 +849,9 @@ pub fn gen_single_block(
         let mut block = jit.block.borrow_mut();
 
         // Add the GC offsets to the block
-        gc_offsets.iter().map(|offs| { block.add_gc_obj_offset(*offs) });
+        for offset in gc_offsets {
+            block.add_gc_obj_offset(offset)
+        }
 
         // Mark the end position of the block
         block.set_end_addr(cb.get_write_ptr());


### PR DESCRIPTION
- Fix asm.load(VALUE)
- x64: Mov(mem, VALUE) should load the value first

For fixing the added test. I think x64 split might still be wrong and I want to check the large fixnum case tomorrow. 