### PR TITLE
Ensure an out operand is allocated

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -50,7 +50,7 @@ impl From<Opnd> for A64Opnd {
                 panic!("attempted to lower an Opnd::Mem with a MemBase::InsnOut base")
             },
             Opnd::InsnOut { .. } => panic!("attempted to lower an Opnd::InsnOut"),
-            Opnd::None => panic!("attempted to lower an Opnd::None"),
+            Opnd::None => panic!("Attempted to lower an Opnd::None. This often happens when an out operand was not allocated for an instruction because the output of the instruction was not used. Please ensure you are using the output."),
             Opnd::Value(_) => panic!("attempted to lower an Opnd::Value"),
         }
     }


### PR DESCRIPTION
This has come up enough that it seems worth it to do so the error message is less confusing.