### PR TITLE
Port send-only insns and write tests

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -40,6 +40,12 @@ assert_equal '[8]', %q{
     end
     foo(7)
 }
+assert_equal 'ab', %q{
+    def foo
+      "a" + "b"
+    end
+    foo
+}
 
 # setlocal, getlocal, opt_plus
 assert_equal '10', %q{
@@ -98,6 +104,120 @@ assert_equal '{:a=>777}', %q{
         { a: n }
     end
     foo(777)
+}
+
+# opt_lt
+assert_equal 'true', %q{1 < 2}
+assert_equal 'false', %q{1 < 1}
+assert_equal 'true', %q{"1" < "2"}
+assert_equal 'false', %q{"1" < "1"}
+
+# opt_le
+assert_equal 'true', %q{1 <= 1}
+assert_equal 'false', %q{1 <= 0}
+assert_equal 'true', %q{"1" <= "1"}
+assert_equal 'false', %q{"1" <= "0"}
+
+# opt_ge
+assert_equal 'true', %q{1 >= 1}
+assert_equal 'false', %q{0 >= 1}
+assert_equal 'true', %q{"1" >= "1"}
+assert_equal 'false', %q{"0" >= "1"}
+
+# opt_gt
+assert_equal 'true', %q{2 > 1}
+assert_equal 'false', %q{1 > 1}
+assert_equal 'true', %q{"2" > "1"}
+assert_equal 'false', %q{"1" > "1"}
+
+# opt_mult
+assert_equal '6', %q{
+    def foo
+      2 * 3
+    end
+    foo
+}
+
+# opt_div
+assert_equal '3', %q{
+    def foo
+      6 / 2
+    end
+    foo
+}
+
+# opt_ltlt
+assert_equal 'ab', %q{
+    def foo
+      "a" << "b"
+    end
+    foo
+}
+
+# opt_nil_p
+assert_equal 'true', %q{
+    def foo
+      nil.nil?
+    end
+    foo
+}
+
+# opt_empty_p
+assert_equal 'true', %q{
+    def foo
+      "".empty?
+    end
+    foo
+}
+
+# opt_succ
+assert_equal '2', %q{
+    def foo
+      1.succ
+    end
+    foo
+}
+
+# opt_not
+assert_equal 'false', %q{
+    def foo
+      !true
+    end
+    foo
+}
+
+# opt_size
+assert_equal '2', %q{
+    def foo
+      [1, nil].size
+    end
+    foo
+}
+
+# opt_length
+assert_equal '2', %q{
+    def foo
+      [1, nil].length
+    end
+    foo
+}
+
+# opt_regexpmatch2
+assert_equal '0', %q{
+    def foo
+      /a/ =~ 'a'
+    end
+    foo
+}
+
+# opt_case_dispatch
+assert_equal 'true', %q{
+    case 2
+    when 1
+      false
+    when 2
+      true
+    end
 }
 
 # branchunless

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1147,8 +1147,7 @@ fn gen_opt_plus(
 
         KeepCompiling
     } else {
-        todo!("opt_plus send path");
-        //gen_opt_send_without_block(jit, ctx, cb, ocb)
+        gen_opt_send_without_block(jit, ctx, asm, ocb)
     }
 }
 
@@ -2385,8 +2384,7 @@ fn gen_fixnum_cmp(
 
         KeepCompiling
     } else {
-        todo!("compare send path not yet implemented");
-        //gen_opt_send_without_block(jit, ctx, cb, ocb)
+        gen_opt_send_without_block(jit, ctx, asm, ocb)
     }
 }
 
@@ -2399,34 +2397,34 @@ fn gen_opt_lt(
     gen_fixnum_cmp(jit, ctx, asm, ocb, Assembler::csel_l)
 }
 
-/*
 fn gen_opt_le(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    gen_fixnum_cmp(jit, ctx, cb, ocb, cmovle)
+    gen_fixnum_cmp(jit, ctx, asm, ocb, Assembler::csel_le)
 }
 
 fn gen_opt_ge(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    gen_fixnum_cmp(jit, ctx, cb, ocb, cmovge)
+    gen_fixnum_cmp(jit, ctx, asm, ocb, Assembler::csel_ge)
 }
 
 fn gen_opt_gt(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    gen_fixnum_cmp(jit, ctx, cb, ocb, cmovg)
+    gen_fixnum_cmp(jit, ctx, asm, ocb, Assembler::csel_g)
 }
 
+/*
 // Implements specialized equality for either two fixnum or two strings
 // Returns true if code was generated, otherwise false
 fn gen_equality_specialized(
@@ -2950,27 +2948,29 @@ fn gen_opt_minus(
         gen_opt_send_without_block(jit, ctx, cb, ocb)
     }
 }
+*/
 
 fn gen_opt_mult(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Delegate to send, call the method on the recv
-    gen_opt_send_without_block(jit, ctx, cb, ocb)
+    gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
 fn gen_opt_div(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Delegate to send, call the method on the recv
-    gen_opt_send_without_block(jit, ctx, cb, ocb)
+    gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
+/*
 fn gen_opt_mod(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -3022,47 +3022,49 @@ fn gen_opt_mod(
         gen_opt_send_without_block(jit, ctx, cb, ocb)
     }
 }
+*/
 
 fn gen_opt_ltlt(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Delegate to send, call the method on the recv
-    gen_opt_send_without_block(jit, ctx, cb, ocb)
+    gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
 fn gen_opt_nil_p(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Delegate to send, call the method on the recv
-    gen_opt_send_without_block(jit, ctx, cb, ocb)
+    gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
 fn gen_opt_empty_p(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Delegate to send, call the method on the recv
-    gen_opt_send_without_block(jit, ctx, cb, ocb)
+    gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
 fn gen_opt_succ(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Delegate to send, call the method on the recv
-    gen_opt_send_without_block(jit, ctx, cb, ocb)
+    gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
+/*
 fn gen_opt_str_freeze(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -3102,47 +3104,48 @@ fn gen_opt_str_uminus(
 
     KeepCompiling
 }
+*/
 
 fn gen_opt_not(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    return gen_opt_send_without_block(jit, ctx, cb, ocb);
+    return gen_opt_send_without_block(jit, ctx, asm, ocb);
 }
 
 fn gen_opt_size(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    return gen_opt_send_without_block(jit, ctx, cb, ocb);
+    return gen_opt_send_without_block(jit, ctx, asm, ocb);
 }
 
 fn gen_opt_length(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    return gen_opt_send_without_block(jit, ctx, cb, ocb);
+    return gen_opt_send_without_block(jit, ctx, asm, ocb);
 }
 
 fn gen_opt_regexpmatch2(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    return gen_opt_send_without_block(jit, ctx, cb, ocb);
+    return gen_opt_send_without_block(jit, ctx, asm, ocb);
 }
 
 fn gen_opt_case_dispatch(
     _jit: &mut JITState,
     ctx: &mut Context,
-    _cb: &mut CodeBlock,
+    _asm: &mut Assembler,
     _ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Normally this instruction would lookup the key in a hash and jump to an
@@ -3157,7 +3160,6 @@ fn gen_opt_case_dispatch(
 
     KeepCompiling // continue with the next instruction
 }
-*/
 
 fn gen_branchif_branch(
     asm: &mut Assembler,
@@ -5062,7 +5064,6 @@ fn gen_opt_send_without_block(
     gen_send_general(jit, ctx, asm, ocb, cd, None)
 }
 
-/*
 fn gen_send(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -5074,6 +5075,7 @@ fn gen_send(
     return gen_send_general(jit, ctx, asm, ocb, cd, block);
 }
 
+/*
 fn gen_invokesuper(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -5977,10 +5979,10 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_duparray => Some(gen_duparray),
         YARVINSN_checktype => Some(gen_checktype),
         YARVINSN_opt_lt => Some(gen_opt_lt),
-        /*
         YARVINSN_opt_le => Some(gen_opt_le),
         YARVINSN_opt_gt => Some(gen_opt_gt),
         YARVINSN_opt_ge => Some(gen_opt_ge),
+        /*
         YARVINSN_opt_mod => Some(gen_opt_mod),
         YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
         YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
@@ -6000,6 +6002,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_neq => Some(gen_opt_neq),
         YARVINSN_opt_aref => Some(gen_opt_aref),
         YARVINSN_opt_aset => Some(gen_opt_aset),
+        */
         YARVINSN_opt_mult => Some(gen_opt_mult),
         YARVINSN_opt_div => Some(gen_opt_div),
         YARVINSN_opt_ltlt => Some(gen_opt_ltlt),
@@ -6010,12 +6013,13 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_size => Some(gen_opt_size),
         YARVINSN_opt_length => Some(gen_opt_length),
         YARVINSN_opt_regexpmatch2 => Some(gen_opt_regexpmatch2),
+        /*
         YARVINSN_opt_getinlinecache => Some(gen_opt_getinlinecache),
         YARVINSN_invokebuiltin => Some(gen_invokebuiltin),
         YARVINSN_opt_invokebuiltin_delegate => Some(gen_opt_invokebuiltin_delegate),
         YARVINSN_opt_invokebuiltin_delegate_leave => Some(gen_opt_invokebuiltin_delegate),
-        YARVINSN_opt_case_dispatch => Some(gen_opt_case_dispatch),
         */
+        YARVINSN_opt_case_dispatch => Some(gen_opt_case_dispatch),
         YARVINSN_branchif => Some(gen_branchif),
         YARVINSN_branchunless => Some(gen_branchunless),
         YARVINSN_branchnil => Some(gen_branchnil),


### PR DESCRIPTION
Ported instructions that require trivial effort now: send-only opt insns, insns with `todo!` on send, and opt_case_dispatch. Also added tests for them.