### PR TITLE
Port `opt_str_uminus` to new backend IR

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -470,6 +470,14 @@ assert_equal 'netscape', %q{
     foo()
 }
 
+# opt_str_uminus
+assert_equal 'mosaic', %q{
+    def foo()
+      -"mosaic"
+    end
+    foo()
+}
+
 # BOP redefinition works on Integer#<
 assert_equal 'false', %q{
   def less_than x

--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -462,6 +462,14 @@ assert_equal '[nil, 1]', %q{
     [Foo.new.foo, bar]
 }
 
+# opt_str_freeze
+assert_equal 'netscape', %q{
+    def foo()
+      "netscape".freeze
+    end
+    foo()
+}
+
 # BOP redefinition works on Integer#<
 assert_equal 'false', %q{
   def less_than x

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3061,7 +3061,6 @@ fn gen_opt_succ(
     gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
-
 fn gen_opt_str_freeze(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -3081,11 +3080,10 @@ fn gen_opt_str_freeze(
     KeepCompiling
 }
 
-/*
 fn gen_opt_str_uminus(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     if !assume_bop_not_redefined(jit, ocb, STRING_REDEFINED_OP_FLAG, BOP_UMINUS) {
@@ -3093,15 +3091,13 @@ fn gen_opt_str_uminus(
     }
 
     let str = jit_get_arg(jit, 0);
-    jit_mov_gc_ptr(jit, cb, REG0, str);
 
     // Push the return value onto the stack
     let stack_ret = ctx.stack_push(Type::CString);
-    mov(cb, stack_ret, REG0);
+    asm.mov(stack_ret, str.into());
 
     KeepCompiling
 }
-*/
 
 fn gen_opt_not(
     jit: &mut JITState,
@@ -5982,6 +5978,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_mod => Some(gen_opt_mod),
         YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
         YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
+
         YARVINSN_splatarray => Some(gen_splatarray),
         YARVINSN_newrange => Some(gen_newrange),
         YARVINSN_putstring => Some(gen_putstring),

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3061,11 +3061,11 @@ fn gen_opt_succ(
     gen_opt_send_without_block(jit, ctx, asm, ocb)
 }
 
-/*
+
 fn gen_opt_str_freeze(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     if !assume_bop_not_redefined(jit, ocb, STRING_REDEFINED_OP_FLAG, BOP_FREEZE) {
@@ -3073,15 +3073,15 @@ fn gen_opt_str_freeze(
     }
 
     let str = jit_get_arg(jit, 0);
-    jit_mov_gc_ptr(jit, cb, REG0, str);
 
     // Push the return value onto the stack
     let stack_ret = ctx.stack_push(Type::CString);
-    mov(cb, stack_ret, REG0);
+    asm.mov(stack_ret, str.into());
 
     KeepCompiling
 }
 
+/*
 fn gen_opt_str_uminus(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -5980,8 +5980,8 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_gt => Some(gen_opt_gt),
         YARVINSN_opt_ge => Some(gen_opt_ge),
         YARVINSN_opt_mod => Some(gen_opt_mod),
-        //YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
-        //YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
+        YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
+        YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
         YARVINSN_splatarray => Some(gen_splatarray),
         YARVINSN_newrange => Some(gen_newrange),
         YARVINSN_putstring => Some(gen_putstring),


### PR DESCRIPTION
```
irb(main):009:0' code = %q{
irb(main):010:0'     def foo()
irb(main):011:0'       -"mosaic"
irb(main):012:0'     end
irb(main):013:0'     foo()
irb(main):014:0> }
=> "\n    def foo()\n      -\"mosaic\"\n    end\n    foo()\n"
irb(main):015:0> puts RubyVM::InstructionSequence.compile(code).disassemble
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(5,9)> (catch: FALSE)
0000 definemethod                           :foo, foo                 (   2)[Li]
0003 putself                                                          (   5)[Li]
0004 opt_send_without_block                 <calldata!mid:foo, argc:0, FCALL|ARGS_SIMPLE>
0006 leave

== disasm: #<ISeq:foo@<compiled>:2 (2,4)-(4,7)> (catch: FALSE)
0000 opt_str_uminus                         "mosaic", <calldata!mid:-@, argc:0, ARGS_SIMPLE>(   3)[LiCa]
0003 leave                                                            (   4)[Re]
```

```
make -j miniruby && RUST_BACKTRACE=1 ruby --disable=gems bootstraptest/runner.rb --ruby="./miniruby -I./lib -I. -I.ext/common --disable-gems --yjit-call-threshold=1 --yjit-verify-ctx" bootstraptest/test_yjit_new_backend.rb

[...]

Driver is ruby 3.2.0dev (2022-07-22T22:02:24Z yjit_backend_ir 639815ef68) [x86_64-darwin21]
Target is ruby 3.2.0dev (2022-08-05T15:11:26Z zack_backend_ir 27775ac394) +YJIT [x86_64-darwin21]

test_yjit_new_backend.rb  PASS 70

Finished in 3.13 sec

PASS all 70 tests
```