### PR TITLE
x86 TEST should do a load for mem opnds first

### DIFF
--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -117,7 +117,7 @@ impl Assembler
             };
 
             match op {
-                Op::Add | Op::Sub | Op::And | Op::Cmp | Op::Or => {
+                Op::Add | Op::Sub | Op::And | Op::Cmp | Op::Or | Op::Test => {
                     let (opnd0, opnd1) = match (opnds[0], opnds[1]) {
                         (Opnd::Mem(_), Opnd::Mem(_)) => {
                             (asm.load(opnds[0]), asm.load(opnds[1]))


### PR DESCRIPTION
x86 wasn't properly doing the load. Thanks to @kddnewton who knew right away how to fix this!