### PR TITLE
Port objtostring to the new backend

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -472,7 +472,7 @@ assert_equal 'true', %q{
     foo()
 }
 
-# toregexp
+# toregexp, objtostring
 assert_equal '/true/', %q{
     def foo()
       /#{true}/
@@ -480,7 +480,7 @@ assert_equal '/true/', %q{
     foo().inspect
 }
 
-# concatstrings
+# concatstrings, objtostring
 assert_equal '9001', %q{
     def foo()
       "#{9001}"

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2274,7 +2274,7 @@ fn gen_concatstrings(
     // Save the PC and SP because we are allocating
     jit_prepare_routine_call(jit, ctx, asm);
 
-    let values_ptr = ctx.sp_opnd(-((SIZEOF_VALUE as isize) * n.as_isize()));
+    let values_ptr = asm.lea(ctx.sp_opnd(-((SIZEOF_VALUE as isize) * n.as_isize())));
 
     // call rb_str_concat_literals(long n, const VALUE *strings);
     let return_value = asm.ccall(
@@ -5328,15 +5328,14 @@ fn gen_anytostring(
     KeepCompiling
 }
 
-/*
 fn gen_objtostring(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, cb, ocb);
+        defer_compilation(jit, ctx, asm, ocb);
         return EndBlock;
     }
 
@@ -5349,7 +5348,7 @@ fn gen_objtostring(
         jit_guard_known_klass(
             jit,
             ctx,
-            cb,
+            asm,
             ocb,
             comptime_recv.class_of(),
             recv,
@@ -5362,10 +5361,9 @@ fn gen_objtostring(
         KeepCompiling
     } else {
         let cd = jit_get_arg(jit, 0).as_ptr();
-        gen_send_general(jit, ctx, cb, ocb, cd, None)
+        gen_send_general(jit, ctx, asm, ocb, cd, None)
     }
 }
-*/
 
 fn gen_intern(
     jit: &mut JITState,
@@ -5399,7 +5397,7 @@ fn gen_toregexp(
     // raise an exception.
     jit_prepare_routine_call(jit, ctx, asm);
 
-    let values_ptr = ctx.sp_opnd(-((SIZEOF_VALUE as isize) * (cnt as isize)));
+    let values_ptr = asm.lea(ctx.sp_opnd(-((SIZEOF_VALUE as isize) * (cnt as isize))));
     ctx.stack_pop(cnt);
 
     let ary = asm.ccall(
@@ -6022,7 +6020,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_getglobal => Some(gen_getglobal),
         YARVINSN_setglobal => Some(gen_setglobal),
         YARVINSN_anytostring => Some(gen_anytostring),
-        //YARVINSN_objtostring => Some(gen_objtostring),
+        YARVINSN_objtostring => Some(gen_objtostring),
         YARVINSN_intern => Some(gen_intern),
         YARVINSN_toregexp => Some(gen_toregexp),
         YARVINSN_getspecial => Some(gen_getspecial),


### PR DESCRIPTION
Ported objtostring to the new backend IR, and added missing lea instructions to fix concatstrings and toregexp.