### PR TITLE
Fix code invalidation while OOM and OOM simulation

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2901,10 +2901,19 @@ assert_equal 'new', %q{
     foo
   end
 
+  def bar
+    :bar
+  end
+
+
   test
   test
 
   RubyVM::YJIT.simulate_oom! if defined?(RubyVM::YJIT)
+
+  # Old simulat_omm! leaves one byte of space and this fills it up
+  bar
+  bar
 
   def foo
     :new

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -121,10 +121,10 @@ impl CodeBlock {
 
     // Set the current write position
     pub fn set_pos(&mut self, pos: usize) {
-        // Assert here since while CodeBlock functions do bounds checking, there is
-        // nothing stopping users from taking out an out-of-bounds pointer and
-        // doing bad accesses with it.
-        assert!(pos < self.mem_size);
+        // No bounds check here since we can be out of bounds
+        // when the code block fills up. We want to be able to
+        // restore to the filled up state after patching something
+        // in the middle.
         self.write_pos = pos;
     }
 
@@ -152,12 +152,12 @@ impl CodeBlock {
         self.set_pos(pos);
     }
 
-    // Get a direct pointer into the executable memory block
+    /// Get a (possibly dangling) direct pointer into the executable memory block
     pub fn get_ptr(&self, offset: usize) -> CodePtr {
         self.mem_block.start_ptr().add_bytes(offset)
     }
 
-    // Get a direct pointer to the current write position
+    /// Get a (possibly dangling) direct pointer to the current write position
     pub fn get_write_ptr(&mut self) -> CodePtr {
         self.get_ptr(self.write_pos)
     }

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -91,8 +91,8 @@ pub extern "C" fn rb_yjit_simulate_oom_bang(_ec: EcPtr, _ruby_self: VALUE) -> VA
     if cfg!(debug_assertions) {
         let cb = CodegenGlobals::get_inline_cb();
         let ocb = CodegenGlobals::get_outlined_cb().unwrap();
-        cb.set_pos(cb.get_mem_size() - 1);
-        ocb.set_pos(ocb.get_mem_size() - 1);
+        cb.set_pos(cb.get_mem_size());
+        ocb.set_pos(ocb.get_mem_size());
     }
 
     return Qnil;


### PR DESCRIPTION
`YJIT.simulate_oom!` used to leave one byte of space in the code block,
so our test didn't expose a problem with asserting that the write
position is in bounds in `CodeBlock::set_pos`. We do the following when
patching code:
  1. save current write position
  2. seek to middle of the code block and patch
  3. restore old write position
The bounds check fails on (3) when the code block is already filled up.

Leaving one byte of space also meant that when we write that byte, we
need to fill the entire code region with trapping instruction in
`VirtualMem`, which made the OOM tests unnecessarily slow.

Remove the incorrect bounds check and stop leaving space in the code
block when simulating OOM.
