### PR TITLE
Enable skipdata on Capstone to allow embedded data in disassembly

### DIFF
--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -71,7 +71,7 @@ pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u32, end_idx: u32) -> St
     use capstone::prelude::*;
 
     #[cfg(target_arch = "x86_64")]
-    let cs = Capstone::new()
+    let mut cs = Capstone::new()
         .x86()
         .mode(arch::x86::ArchMode::Mode64)
         .syntax(arch::x86::ArchSyntax::Intel)
@@ -79,11 +79,13 @@ pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u32, end_idx: u32) -> St
         .unwrap();
 
     #[cfg(target_arch = "aarch64")]
-    let cs = Capstone::new()
+    let mut cs = Capstone::new()
         .arm64()
         .mode(arch::arm64::ArchMode::Arm)
+        .detail(true)
         .build()
         .unwrap();
+    cs.set_skipdata(true);
 
     out.push_str(&format!("NUM BLOCK VERSIONS: {}\n", block_list.len()));
     out.push_str(&format!(


### PR DESCRIPTION
We embed data regularly on ARM64. Capstone has a mode to skip it. It's not in the CapstoneBuilder (https://docs.rs/capstone/latest/capstone/arch/arm64/struct.ArchCapstoneBuilder.html), but it *can* be set later on the instance, so we'll do that.

Prior to this, instructions that embedded data (e.g. putobject_int2fix) would have disassemblies that incorrectly stopped at the embedded data rather than showing later instructions.