### PR TITLE
Port opt_getinlinecache to the new backend

### DIFF
--- a/bootstraptest/test_yjit_new_backend.rb
+++ b/bootstraptest/test_yjit_new_backend.rb
@@ -738,6 +738,15 @@ assert_equal 'netscape', %q{
     foo()
 }
 
+# opt_getinlinecache
+assert_equal 'navigator', %q{
+    NETSCAPE = "navigator"
+    def foo()
+      NETSCAPE
+    end
+    foo()
+}
+
 # BOP redefinition works on Integer#<
 assert_equal 'false', %q{
   def less_than x


### PR DESCRIPTION
```
irb(main):001:0' code = %q{
irb(main):002:0'     NETSCAPE = "navigator"
irb(main):003:0'     def foo()
irb(main):004:0'       NETSCAPE
irb(main):005:0'     end
irb(main):006:0'     foo()
irb(main):007:0> }
=> "\n    NETSCAPE = \"navigator\"\n    def foo()\n      NETSCAPE\n    end\n    foo()\n"
irb(main):008:0> puts RubyVM::InstructionSequence.compile(code).disassemble
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(6,9)> (catch: FALSE)
0000 putstring                              "navigator"               (   2)[Li]
0002 putspecialobject                       3
0004 setconstant                            :NETSCAPE
0006 definemethod                           :foo, foo                 (   3)[Li]
0009 putself                                                          (   6)[Li]
0010 opt_send_without_block                 <calldata!mid:foo, argc:0, FCALL|ARGS_SIMPLE>
0012 leave

== disasm: #<ISeq:foo@<compiled>:3 (3,4)-(5,7)> (catch: FALSE)
0000 opt_getinlinecache                     9, <is:0>                 (   4)[LiCa]
0003 putobject                              true
0005 getconstant                            :NETSCAPE
0007 opt_setinlinecache                     <is:0>
0009 leave                                                            (   5)[Re]
```

```
➜   make -j miniruby && RUST_BACKTRACE=1 ruby --disable=gems bootstraptest/runner.rb --ruby="./miniruby -I./lib -I. -I.ext/common --disable-gems --yjit-call-threshold=1 --yjit-verify-ctx" bootstraptest/test_yjit_new_backend.rb

[...]

2022-08-11 12:20:48 -0400
Driver is ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin21]
Target is ruby 3.2.0dev (2022-08-11T16:16:49Z zack_getinlinecache b2c6fff0d8) +YJIT [x86_64-darwin21]

test_yjit_new_backend.rb  PASS 115

Finished in 4.03 sec

PASS all 115 tests

```