### PR TITLE
YJIT: Implement concatarray in yjit

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3075,3 +3075,13 @@ assert_equal '10', %q{
 
   a.length
 }
+
+assert_equal '[1, 2]', %q{
+  def foo
+    x = [2]
+    [1, *x]
+  end
+
+  foo
+  foo
+}

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4379,6 +4379,12 @@ vm_concat_array(VALUE ary1, VALUE ary2st)
     return rb_ary_concat(tmp1, tmp2);
 }
 
+VALUE
+rb_vm_concat_array(VALUE ary1, VALUE ary2st)
+{
+    return vm_concat_array(ary1, ary2st);
+}
+
 static VALUE
 vm_splat_array(VALUE flag, VALUE ary)
 {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4379,6 +4379,8 @@ vm_concat_array(VALUE ary1, VALUE ary2st)
     return rb_ary_concat(tmp1, tmp2);
 }
 
+// YJIT implementation is using the C function
+// and needs to call a non-static function
 VALUE
 rb_vm_concat_array(VALUE ary1, VALUE ary2st)
 {
@@ -4400,6 +4402,8 @@ vm_splat_array(VALUE flag, VALUE ary)
     }
 }
 
+// YJIT implementation is using the C function
+// and needs to call a non-static function
 VALUE
 rb_vm_splat_array(VALUE flag, VALUE ary)
 {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5862,6 +5862,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
         YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
         YARVINSN_splatarray => Some(gen_splatarray),
+        YARVINSN_concatarray => Some(gen_concatarray),
         YARVINSN_newrange => Some(gen_newrange),
         YARVINSN_putstring => Some(gen_putstring),
         YARVINSN_expandarray => Some(gen_expandarray),

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1256,6 +1256,32 @@ fn gen_splatarray(
     KeepCompiling
 }
 
+// concat two arrays
+fn gen_concatarray(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    cb: &mut CodeBlock,
+    _ocb: &mut OutlinedCb,
+) -> CodegenStatus {
+    // Save the PC and SP because the callee may allocate
+    // Note that this modifies REG_SP, which is why we do it first
+    jit_prepare_routine_call(jit, ctx, cb, REG0);
+
+    // Get the operands from the stack
+    let ary2st_opnd = ctx.stack_pop(1);
+    let ary1_opnd = ctx.stack_pop(1);
+
+    // Call rb_vm_concat_array(ary1, ary2st)
+    mov(cb, C_ARG_REGS[0], ary1_opnd);
+    mov(cb, C_ARG_REGS[1], ary2st_opnd);
+    call_ptr(cb, REG1, rb_vm_concat_array as *const u8);
+
+    let stack_ret = ctx.stack_push(Type::Array);
+    mov(cb, stack_ret, RAX);
+
+    KeepCompiling
+}
+
 // new range initialized from top 2 values
 fn gen_newrange(
     jit: &mut JITState,

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1260,24 +1260,22 @@ fn gen_splatarray(
 fn gen_concatarray(
     jit: &mut JITState,
     ctx: &mut Context,
-    cb: &mut CodeBlock,
+    asm: &mut Assembler,
     _ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Save the PC and SP because the callee may allocate
     // Note that this modifies REG_SP, which is why we do it first
-    jit_prepare_routine_call(jit, ctx, cb, REG0);
+    jit_prepare_routine_call(jit, ctx, asm);
 
     // Get the operands from the stack
     let ary2st_opnd = ctx.stack_pop(1);
     let ary1_opnd = ctx.stack_pop(1);
 
     // Call rb_vm_concat_array(ary1, ary2st)
-    mov(cb, C_ARG_REGS[0], ary1_opnd);
-    mov(cb, C_ARG_REGS[1], ary2st_opnd);
-    call_ptr(cb, REG1, rb_vm_concat_array as *const u8);
+    let ary = asm.ccall(rb_vm_concat_array as *const u8, vec![ary1_opnd, ary2st_opnd]);
 
     let stack_ret = ctx.stack_push(Type::Array);
-    mov(cb, stack_ret, RAX);
+    asm.mov(stack_ret, ary);
 
     KeepCompiling
 }

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -262,6 +262,7 @@ extern "C" {
     // Ruby only defines these in vm_insnhelper.c, not in any header.
     // Parsing it would result in a lot of duplicate definitions.
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
+    pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;
     pub fn rb_vm_defined(
         ec: EcPtr,
         reg_cfp: CfpPtr,


### PR DESCRIPTION
Copy of original PR: https://github.com/ruby/ruby/pull/6236 with new backend. The [CI failure](https://github.com/Shopify/ruby/runs/7827277702?check_suite_focus=true) seems to be unrelated to this change 

Paired with @jhawthorn on this 🎉 

# Changes 
Implement `concatarray` in YJIT so it doesn't cause any side exits. 

It's currently just calling the C function `vm_concat_array` but there's potential to use `guard_object_is_array` in the future to save on the `is_a` check. 

