### PR TITLE
Fix a bus error on regenerate_branch

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -440,39 +440,46 @@ impl Assembler
         /// Emit the required instructions to load the given value into the
         /// given register. Our goal here is to use as few instructions as
         /// possible to get this value into the register.
-        fn emit_load_value(cb: &mut CodeBlock, rd: A64Opnd, value: u64) {
+        fn emit_load_value(cb: &mut CodeBlock, rd: A64Opnd, value: u64) -> i32 {
             let mut current = value;
 
             if current <= 0xffff {
                 // If the value fits into a single movz
                 // instruction, then we'll use that.
                 movz(cb, rd, A64Opnd::new_uimm(current), 0);
+                return 1;
             } else if BitmaskImmediate::try_from(current).is_ok() {
                 // Otherwise, if the immediate can be encoded
                 // with the special bitmask immediate encoding,
                 // we'll use that.
                 mov(cb, rd, A64Opnd::new_uimm(current));
+                return 1;
             } else {
                 // Finally we'll fall back to encoding the value
                 // using movz for the first 16 bits and movk for
                 // each subsequent set of 16 bits as long we
                 // they are necessary.
                 movz(cb, rd, A64Opnd::new_uimm(current & 0xffff), 0);
+                let mut num_insns = 1;
 
                 // (We're sure this is necessary since we
                 // checked if it only fit into movz above).
                 current >>= 16;
                 movk(cb, rd, A64Opnd::new_uimm(current & 0xffff), 16);
+                num_insns += 1;
 
                 if current > 0xffff {
                     current >>= 16;
                     movk(cb, rd, A64Opnd::new_uimm(current & 0xffff), 32);
+                    num_insns += 1;
                 }
 
                 if current > 0xffff {
                     current >>= 16;
                     movk(cb, rd, A64Opnd::new_uimm(current & 0xffff), 48);
+                    num_insns += 1;
                 }
+                return num_insns;
             }
         }
 
@@ -495,8 +502,11 @@ impl Assembler
                     // next instruction that perform the direct jump.
 
                     b(cb, A64Opnd::new_imm(2i64 + emit_load_size(dst_addr) as i64));
-                    emit_load_value(cb, Assembler::SCRATCH0, dst_addr);
+                    let num_insns = emit_load_value(cb, Assembler::SCRATCH0, dst_addr);
                     br(cb, Assembler::SCRATCH0);
+                    for _ in num_insns..4 {
+                        nop(cb);
+                    }
 
                     /*
                     // If the jump offset fits into the conditional jump as an
@@ -568,6 +578,7 @@ impl Assembler
         let mut gc_offsets: Vec<u32> = Vec::new();
 
         // For each instruction
+        let start_write_pos = cb.get_write_pos();
         for insn in &self.insns {
             match insn.op {
                 Op::Comment => {
@@ -800,11 +811,10 @@ impl Assembler
                             // branch instruction. Otherwise, we'll move the
                             // destination into a register and use the branch
                             // register instruction.
-                            if b_offset_fits_bits(offset) {
-                                b(cb, A64Opnd::new_imm(offset));
-                            } else {
-                                emit_load_value(cb, Self::SCRATCH0, dst_addr as u64);
-                                br(cb, Self::SCRATCH0);
+                            let num_insns = emit_load_value(cb, Self::SCRATCH0, dst_addr as u64);
+                            br(cb, Self::SCRATCH0);
+                            for _ in num_insns..4 {
+                                nop(cb);
                             }
                         },
                         Target::Label(label_idx) => {
@@ -866,6 +876,12 @@ impl Assembler
                     csel(cb, insn.out.into(), insn.opnds[0].into(), insn.opnds[1].into(), Condition::GE);
                 }
                 Op::LiveReg => (), // just a reg alloc signal, no code
+                Op::PadEntryExit => {
+                    let jmp_len = 5 * 4; // Op::Jmp may emit 5 instructions
+                    while (cb.get_write_pos() - start_write_pos) < jmp_len {
+                        nop(cb);
+                    }
+                }
             };
         }
 

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -168,6 +168,9 @@ pub enum Op
 
     /// Take a specific register. Signal the register allocator to not use it.
     LiveReg,
+
+    /// Pad nop instructions to accomodate Op::Jmp in case the block is invalidated.
+    PadEntryExit,
 }
 
 // Memory operand base
@@ -1127,5 +1130,9 @@ impl Assembler {
         let out = self.next_opnd_out(&[left, right]);
         self.push_insn(Insn { op: Op::Xor, opnds: vec![left, right], out, text: None, target: None, pos_marker: None });
         out
+    }
+
+    pub fn pad_entry_exit(&mut self) {
+        self.push_insn(Insn { op: Op::PadEntryExit, opnds: vec![], out: Opnd::None, text: None, target: None, pos_marker: None });
     }
 }

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -279,6 +279,7 @@ impl Assembler
         let mut gc_offsets: Vec<u32> = Vec::new();
 
         // For each instruction
+        let start_write_pos = cb.get_write_pos();
         for insn in &self.insns {
             match insn.op {
                 Op::Comment => {
@@ -548,6 +549,10 @@ impl Assembler
                     cmovl(cb, insn.out.into(), insn.opnds[1].into());
                 }
                 Op::LiveReg => (), // just a reg alloc signal, no code
+                Op::PadEntryExit => {
+                    let jmp_len = 5; // We assume that our Op::Jmp usage that gets invalidated is <= 5
+                    nop(cb, jmp_len);
+                }
 
                 // We want to keep the panic here because some instructions that
                 // we feed to the backend could get lowered into other

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -550,8 +550,11 @@ impl Assembler
                 }
                 Op::LiveReg => (), // just a reg alloc signal, no code
                 Op::PadEntryExit => {
-                    let jmp_len = 5; // We assume that our Op::Jmp usage that gets invalidated is <= 5
-                    nop(cb, jmp_len);
+                    // We assume that our Op::Jmp usage that gets invalidated is <= 5
+                    let code_size: u32 = (cb.get_write_pos() - start_write_pos).try_into().unwrap();
+                    if code_size < 5 {
+                        nop(cb, 5 - code_size);
+                    }
                 }
 
                 // We want to keep the panic here because some instructions that

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -843,10 +843,13 @@ pub fn gen_single_block(
 
     // Finish filling out the block
     {
+        let mut block = jit.block.borrow_mut();
+        if block.entry_exit.is_some() {
+            asm.pad_entry_exit();
+        }
+
         // Compile code into the code block
         let gc_offsets = asm.compile(cb);
-
-        let mut block = jit.block.borrow_mut();
 
         // Add the GC offsets to the block
         for offset in gc_offsets {


### PR DESCRIPTION
## Problem
The assertion added by this PR is hit by:

```rb
# frozen_string_literal: true
class GemRequirement
  PATTERN_RAW = "(>|>=) ([0-9]+(\.[0-9a-z])?)"
  Nil = nil

  def self.create(input)
    case input
    when nil
    else
      new(input)
    end
  end

  def self.parse(obj)
    if Object === obj
    end

    if /\A#{PATTERN_RAW}\z/ =~ obj.to_s
    end

    if $1 == ">=" && $2 == "0"
    elsif $1 == ">=" && $2 == "0.a"
      Nil
    else
      [($1 || "=").to_s, $2, Object.new]
    end
  end

  def initialize(requirement)
    [requirement].each {|r| self.class.parse(r) }
  end
end

2.times { GemRequirement.new(">= 1") }
7.times { GemRequirement.create(">= 1") }
GemRequirement.create("> 0")
GemRequirement.create(">= 1") # JIT GemRequirement.parse (opt_getinlinecache not compiled, stub)
GemRequirement.create(">= 1") # JIT GemRequirement.create
GemRequirement.create(">= 1")
GemRequirement.new(">= 0.a") # JIT opt_getinlinecache stub -> invalidate -> rewrite stub (overwrite)
GemRequirement.create(">= 0.a") # Crash after entering the JIT code of GemRequirement.create
```

We could add the same thing as a test, but I'd like to work on making this smaller before doing that, which actually seems not trivial. Adding an assertion that could be easily triggered on gem_prelude feels enough as a first step.

## Solution
Pad `nop` instructions to let `Op::Jmp` always generate the same size of instructions.

Once we do that, however, we cannot invalidate a block when its size is smaller than the increased size of `Op::Jmp`. To always accommodate `Op::Jmp` on invalidation, `Op::PadEntryExit` is introduced to pad blocks with `entry_exit` as well.