### PR TITLE
Fix issue with expandarray, add missing jl, enable tests

### DIFF
--- a/.github/workflows/yjit-new-backend.yml
+++ b/.github/workflows/yjit-new-backend.yml
@@ -97,6 +97,6 @@ jobs:
       - run: make -j rdoc
 
       # Run John's YJIT instruction tests, and make sure we can load the test-all runner
-      - run: make -j test-all TESTS='test/ruby/test_method test/ruby/test_module test/ruby/test_yjit' RUN_OPTS="--yjit-call-threshold=1"
+      - run: make -j test-all TESTS='test/ruby/test_assignment test/ruby/test_method test/ruby/test_module test/ruby/test_yjit' RUN_OPTS="--yjit-call-threshold=1"
 
       # TODO: check that we can we run all of test-all successfully

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -826,6 +826,9 @@ impl Assembler
                 Op::Jne => {
                     emit_conditional_jump::<{Condition::NE}>(cb, insn.target.unwrap());
                 },
+                Op::Jl => {
+                    emit_conditional_jump::<{Condition::LT}>(cb, insn.target.unwrap());
+                },
                 Op::Jbe => {
                     emit_conditional_jump::<{Condition::LS}>(cb, insn.target.unwrap());
                 },

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -118,6 +118,7 @@ pub enum Op
     JmpOpnd,
 
     // Low-level conditional jump instructions
+    Jl,
     Jbe,
     Je,
     Jne,
@@ -990,6 +991,7 @@ def_push_1_opnd_no_out!(jmp_opnd, Op::JmpOpnd);
 def_push_jcc!(jmp, Op::Jmp);
 def_push_jcc!(je, Op::Je);
 def_push_jcc!(jne, Op::Jne);
+def_push_jcc!(jl, Op::Jl);
 def_push_jcc!(jbe, Op::Jbe);
 def_push_jcc!(jz, Op::Jz);
 def_push_jcc!(jnz, Op::Jnz);

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -465,6 +465,14 @@ impl Assembler
                     }
                 }
 
+                Op::Jl => {
+                    match insn.target.unwrap() {
+                        Target::CodePtr(code_ptr) => jl_ptr(cb, code_ptr),
+                        Target::Label(label_idx) => jl_label(cb, label_idx),
+                        _ => unreachable!()
+                    }
+                },
+
                 Op::Jbe => {
                     match insn.target.unwrap() {
                         Target::CodePtr(code_ptr) => jbe_ptr(cb, code_ptr),

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1445,7 +1445,7 @@ fn gen_expandarray(
     // Only handle the case where the number of values in the array is greater
     // than or equal to the number of values requested.
     asm.cmp(array_len_opnd, num.into());
-    asm.jo(counted_exit!(ocb, side_exit, expandarray_rhs_too_small).into());
+    asm.jl(counted_exit!(ocb, side_exit, expandarray_rhs_too_small).into());
 
     // Load the address of the embedded array into REG1.
     // (struct RArray *)(obj)->as.ary


### PR DESCRIPTION
We were missing the `jl` instruction and `jo` (jump on overflow) was used instead.

Also enabling a little bit more of `test-all` on x86.