### PR TITLE
Only check lowest bit for _Bool type

### DIFF
--- a/.github/workflows/yjit-new-backend.yml
+++ b/.github/workflows/yjit-new-backend.yml
@@ -97,6 +97,6 @@ jobs:
       - run: make -j rdoc
 
       # Run John's YJIT instruction tests, and make sure we can load the test-all runner
-      - run: make -j test-all TESTS='test/ruby/test_assignment test/ruby/test_call test/ruby/test_method test/ruby/test_proc test/ruby/test_module test/ruby/test_yjit' RUN_OPTS="--yjit-call-threshold=1"
+      - run: make -j test-all TESTS='test/ruby/test_assignment test/ruby/test_call test/ruby/test_method test/ruby/test_proc test/ruby/test_module test/ruby/test_class test/ruby/test_yjit' RUN_OPTS="--yjit-call-threshold=1"
 
       # TODO: check that we can we run all of test-all successfully

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5526,8 +5526,9 @@ fn gen_opt_getinlinecache(
             vec![inline_cache, Opnd::mem(64, CFP, RUBY_OFFSET_CFP_EP)]
         );
 
-        // Check the result. _Bool is one byte in SysV.
-        asm.test(ret_val, ret_val);
+        // Check the result. SysV only specifies one byte for _Bool return values,
+        // so it's important we only check one bit to ignore the higher bits in the register.
+        asm.test(ret_val, 1.into());
         asm.jz(counted_exit!(ocb, side_exit, opt_getinlinecache_miss).into());
 
         let inline_cache = asm.load(Opnd::const_ptr(ic as *const u8));


### PR DESCRIPTION
The `test AL, AL` got lost during porting and we were
generating `test RAX, RAX` instead. The upper bits of a `_Bool` return
type is unspecified and we were failing
`TestClass#test_singleton_class_should_has_own_namespace`
due to interpreterting the return value incorrectly.
