### PR TITLE
Fix accidental bundler spec change

### DIFF
--- a/spec/bundler/resolver/basic_spec.rb
+++ b/spec/bundler/resolver/basic_spec.rb
@@ -233,7 +233,7 @@ Bundler could not find compatible versions for gem "a":
     it "resolves foo only to latest patch - changing dependency declared case" do
       # bar is locked AND a declared dependency in the Gemfile, so it will not move, and therefore
       # foo can only move up to 1.4.4.
-      @base << Bundler::LazySpecification.new("bar", "2.0.3", nil)
+      @base << build_spec("bar", "2.0.3").first
       should_conservative_resolve_and_include :patch, ["foo"], %w[foo-1.4.4 bar-2.0.3]
     end
 


### PR DESCRIPTION
This is a cherry-pick of 466a760e1807e629d0ec9f9ebf160d3c3f649d04.

The rebase in 5b51d0f5e24646b7ee5b07597d686b7f7ef91d7d
touched this bundler spec file accidentally. Cherry pick it again
so the file is the same as upstream. This should fix the bundler
spec failures we have been seeing.
