### PR TITLE
Avoid marking op_type on gen_defined

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -170,6 +170,6 @@ yjit_task:
   make_rdoc_script: source $HOME/.cargo/env && make -j rdoc
 
   # Run John's YJIT instruction tests, and make sure we can load the test-all runner
-  test_yjit_script: source $HOME/.cargo/env && make test-all TESTS='test/ruby/test_yjit.rb' RUN_OPTS="--yjit-call-threshold=1"
+  test_yjit_script: source $HOME/.cargo/env && make -j test-all TESTS='test/ruby/test_method.rb test/ruby/test_yjit.rb' RUN_OPTS="--yjit-call-threshold=1"
 
   # TODO: check that we can we run all of test-all successfully

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2186,7 +2186,7 @@ fn gen_defined(
     asm: &mut Assembler,
     _ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    let op_type = jit_get_arg(jit, 0);
+    let op_type = jit_get_arg(jit, 0).as_u64();
     let obj = jit_get_arg(jit, 1);
     let pushval = jit_get_arg(jit, 2);
 


### PR DESCRIPTION
This patch fixes `test_method` with `--yjit-call-threshold=1`. The first argument of `defined` is `rb_num_t op_type`, not a `VALUE`. So it shouldn't be passed to IR as a `VALUE`.