### PR TITLE
Use VALUE for callinfos that are on the heap

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4033,8 +4033,11 @@ fn gen_send_cfunc(
     if !kw_arg.is_null() {
         // Build a hash from all kwargs passed
         asm.comment("build_kwhash");
+        let imemo_ci = VALUE(ci as usize);
+        assert_ne!(0, unsafe { rb_IMEMO_TYPE_P(imemo_ci, imemo_callinfo) },
+            "we assume all callinfos with kwargs are on the GC heap");
         let sp = asm.lea(ctx.sp_opnd(0));
-        let kwargs = asm.ccall(build_kwhash as *const u8, vec![Opnd::UImm(ci as u64), sp]);
+        let kwargs = asm.ccall(build_kwhash as *const u8, vec![imemo_ci.into(), sp]);
 
         // Replace the stack location at the start of kwargs with the new hash
         let stack_opnd = ctx.stack_opnd(argc - passed_argc);


### PR DESCRIPTION
Yet another case of `jit_mov_gc_ptr()` being yanked out during the
transition to the new backend, causing a crash after object movement.
The intresting wrinkle with this one is that not all callinfos are GC'ed
objects, so the old code had an implicit assumption.

https://github.com/ruby/ruby/blob/b0b9f7201acab05c2a3ad92c3043a1f01df3e17f/yjit/src/codegen.rs#L4087-L4095

---

cherry-picked into [d7d0e0ce2b86850e5664a079a2239521eda60fcf](https://github.com/Shopify/ruby/pull/416) since this should fix a crash in test-all