### PR TITLE
Run test-all with --yjit-call-threshold=1 on arm64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,43 +125,6 @@ yjit_task:
   boot_miniruby_script: RUST_BACKTRACE=1 ./miniruby --yjit-call-threshold=1 -e0
   test_dump_insns_script: RUST_BACKTRACE=1 ./miniruby --yjit-call-threshold=1 --yjit-dump-insns -e0
   output_stats_script: RUST_BACKTRACE=1 ./miniruby --yjit-call-threshold=1 --yjit-stats -e0
-  bootstrap_tests_script: |
-    RUST_BACKTRACE=1 ruby --disable=gems bootstraptest/runner.rb --ruby="./miniruby -I./lib -I. -I.ext/common --disable-gems --yjit-call-threshold=1 --yjit-verify-ctx" \
-    bootstraptest/test_attr.rb \
-    bootstraptest/test_autoload.rb \
-    bootstraptest/test_block.rb \
-    bootstraptest/test_class.rb \
-    bootstraptest/test_constant_cache.rb \
-    bootstraptest/test_env.rb \
-    bootstraptest/test_eval.rb \
-    bootstraptest/test_exception.rb \
-    bootstraptest/test_fiber.rb \
-    bootstraptest/test_finalizer.rb \
-    bootstraptest/test_flip.rb \
-    bootstraptest/test_flow.rb \
-    bootstraptest/test_fork.rb \
-    bootstraptest/test_gc.rb \
-    bootstraptest/test_insns.rb \
-    bootstraptest/test_io.rb \
-    bootstraptest/test_jump.rb \
-    bootstraptest/test_literal.rb \
-    bootstraptest/test_literal_suffix.rb \
-    bootstraptest/test_load.rb \
-    bootstraptest/test_marshal.rb \
-    bootstraptest/test_massign.rb \
-    bootstraptest/test_method.rb \
-    bootstraptest/test_objectspace.rb \
-    bootstraptest/test_ractor.rb \
-    bootstraptest/test_proc.rb \
-    bootstraptest/test_string.rb \
-    bootstraptest/test_struct.rb \
-    bootstraptest/test_syntax.rb \
-    bootstraptest/test_thread.rb \
-    bootstraptest/test_yjit_30k_ifelse.rb \
-    bootstraptest/test_yjit_30k_methods.rb \
-    bootstraptest/test_yjit_new_backend.rb \
-    bootstraptest/test_yjit_rust_port.rb \
-    bootstraptest/test_yjit.rb
 
   # Check that we can do a full ruby build
   full_build_script: source $HOME/.cargo/env && make -j
@@ -169,8 +132,12 @@ yjit_task:
   # Check that we can build rdoc successfully
   make_rdoc_script: source $HOME/.cargo/env && make -j rdoc
 
-  # Run John's YJIT instruction tests, and make sure we can load the test-all runner
-  test_yjit_script: source $HOME/.cargo/env && make -j test-all TESTS='test/ruby/test_method.rb test/ruby/test_yjit.rb' RUN_OPTS="--yjit-call-threshold=1"
+  # Check that we can run btest successfully
+  make_btest_script: source $HOME/.cargo/env && make -j btest RUN_OPTS="--yjit-call-threshold=1 --yjit-verify-ctx"
 
-  # Run test-all with the default call threshold
-  test_yjit_script: source $HOME/.cargo/env && RUBY_YJIT_ENABLE=1 make -j test-all
+  # Check that we can run test-all successfully (running TestGCCompact separately until we fix its performance)
+  make_test_all_script: source $HOME/.cargo/env && make -j test-all RUN_OPTS="--yjit-call-threshold=1" TESTOPTS='--name=!/TestGCCompact/'
+  test_gc_compact_script: source $HOME/.cargo/env && make -j test-all RUN_OPTS="--yjit-call-threshold=1" TESTS="test/ruby/test_gc_compact.rb"
+
+  # Check that we can run test-spec successfully
+  make_test_spec_script: source $HOME/.cargo/env && make -j test-spec RUN_OPTS="--yjit-call-threshold=1"


### PR DESCRIPTION
I assume, if `--yjit-call-threshold=1` works, it's pretty likely that `--yjit` works as well. So I left only `--yjit-call-threshold=1` to save some CI time in temp checks.