### PR TITLE
Respect RUBY_TESTOPTS on test-all

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,6 +91,7 @@ yjit_task:
     matrix:
       CC: clang-12
       CC: gcc-11
+  timeout_in: 90m
   id_script: id
   set_env_script:
     # Set `GNUMAKEFLAGS`, because the flags are GNU make specific. Note using

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,7 +136,7 @@ yjit_task:
   make_btest_script: source $HOME/.cargo/env && make -j btest RUN_OPTS="--yjit-call-threshold=1 --yjit-verify-ctx"
 
   # Check that we can run test-all successfully (running TestGCCompact separately until we fix its performance)
-  make_test_all_script: source $HOME/.cargo/env && make -j test-all RUN_OPTS="--yjit-call-threshold=1" TESTOPTS='--name=!/TestGCCompact/'
+  make_test_all_script: source $HOME/.cargo/env && make -j test-all RUN_OPTS="--yjit-call-threshold=1" TESTOPTS="$RUBY_TESTOPTS"' --name=!/TestGCCompact/'
   test_gc_compact_script: source $HOME/.cargo/env && make -j test-all RUN_OPTS="--yjit-call-threshold=1" TESTS="test/ruby/test_gc_compact.rb"
 
   # Check that we can run test-spec successfully

--- a/test/csv/parse/test_general.rb
+++ b/test/csv/parse/test_general.rb
@@ -247,6 +247,9 @@ line,5,jkl
   def assert_parse_errors_out(data, **options)
     assert_raise(CSV::MalformedCSVError) do
       timeout = 0.2
+      if defined?(RubyVM::YJIT.enabled?) and RubyVM::YJIT.enabled?
+        timeout = 1  # for --yjit-call-threshold=1
+      end
       if defined?(RubyVM::MJIT.enabled?) and RubyVM::MJIT.enabled?
         timeout = 5  # for --jit-wait
       end


### PR DESCRIPTION
Since I specified `TESTOPTS` in https://github.com/Shopify/ruby/pull/426, `RUBY_TESTOPTS` set by the workflow has been ignored by mistake. `-q --color=always --tty=no` seems useful for debugging a timeout when it happens, so I'd like to resurrect it.
