### PR TITLE
YJIT: Stack temp register allocation

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -78,6 +78,10 @@ jobs:
             configure: "--enable-yjit=dev"
             yjit_opts: "--yjit-call-threshold=1 --yjit-verify-ctx"
 
+          - test_task: "check"
+            configure: "--enable-yjit=dev"
+            yjit_opts: "--yjit-call-threshold=1 --yjit-temp-regs=6"
+
           - test_task: "test-all TESTS=--repeat-count=2"
             configure: "--enable-yjit=dev"
 

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -80,7 +80,7 @@ jobs:
 
           - test_task: "check"
             configure: "--enable-yjit=dev"
-            yjit_opts: "--yjit-call-threshold=1 --yjit-temp-regs=6"
+            yjit_opts: "--yjit-call-threshold=1 --yjit-temp-regs=5"
 
           - test_task: "test-all TESTS=--repeat-count=2"
             configure: "--enable-yjit=dev"

--- a/yjit.rb
+++ b/yjit.rb
@@ -268,6 +268,10 @@ module RubyVM::YJIT
 
       $stderr.puts "iseq_stack_too_large:  " + format_number(13, stats[:iseq_stack_too_large])
       $stderr.puts "iseq_too_long:         " + format_number(13, stats[:iseq_too_long])
+      $stderr.puts "temp_reg_opnd:         " + format_number(13, stats[:temp_reg_opnd])
+      $stderr.puts "temp_mem_opnd:         " + format_number(13, stats[:temp_mem_opnd])
+      $stderr.puts "temp_spill:            " + format_number(13, stats[:temp_spill])
+      $stderr.puts "temp_reload:           " + format_number(13, stats[:temp_reload])
       $stderr.puts "bindings_allocations:  " + format_number(13, stats[:binding_allocations])
       $stderr.puts "bindings_set:          " + format_number(13, stats[:binding_set])
       $stderr.puts "compilation_failure:   " + format_number(13, compilation_failure) if compilation_failure != 0

--- a/yjit.rb
+++ b/yjit.rb
@@ -271,7 +271,6 @@ module RubyVM::YJIT
       $stderr.puts "temp_reg_opnd:         " + format_number(13, stats[:temp_reg_opnd])
       $stderr.puts "temp_mem_opnd:         " + format_number(13, stats[:temp_mem_opnd])
       $stderr.puts "temp_spill:            " + format_number(13, stats[:temp_spill])
-      $stderr.puts "temp_reload:           " + format_number(13, stats[:temp_reload])
       $stderr.puts "bindings_allocations:  " + format_number(13, stats[:binding_allocations])
       $stderr.puts "bindings_set:          " + format_number(13, stats[:binding_set])
       $stderr.puts "compilation_failure:   " + format_number(13, compilation_failure) if compilation_failure != 0

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1053,15 +1053,14 @@ impl Assembler
                 Insn::CSelGE { truthy, falsy, out } => {
                     csel(cb, out.into(), truthy.into(), falsy.into(), Condition::GE);
                 }
-                Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
+                Insn::LiveReg { .. } |
+                Insn::LiveTemps(_) |
+                Insn::SpillTemp(_) => (), // just a reg alloc signal, no code
                 Insn::PadInvalPatch => {
                     while (cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()))) < JMP_PTR_BYTES && !cb.has_dropped_bytes() {
                         nop(cb);
                     }
                 }
-                Insn::LiveTemps(_) |
-                Insn::SpillTemp(_) |
-                Insn::ReloadTemp(_) => unreachable!("lower_stack should remove {:?}", insn),
             };
 
             // On failure, jump to the next page and retry the current insn

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1059,6 +1059,9 @@ impl Assembler
                         nop(cb);
                     }
                 }
+                Insn::LiveTemps(_) |
+                Insn::SpillTemp(_) |
+                Insn::ReloadTemp(_) => unreachable!("lower_stack should remove {:?}", insn),
             };
 
             // On failure, jump to the next page and retry the current insn

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -175,6 +175,13 @@ impl Assembler
         vec![X11_REG, X12_REG, X13_REG]
     }
 
+    /// Get the list of registers that can be used for stack temps.
+    pub fn get_temp_regs() -> Vec<Reg> {
+        // FIXME: arm64 is not supported yet. Insn::Store doesn't support registers
+        // in its dest operand. Currently crashing at split_memory_address.
+        vec![]
+    }
+
     /// Get a list of all of the caller-saved registers
     pub fn get_caller_save_regs() -> Vec<Reg> {
         vec![X9_REG, X10_REG, X11_REG, X12_REG, X13_REG, X14_REG, X15_REG]

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -941,7 +941,7 @@ impl Assembler
         }
 
         // Update live stack temps for this instruction
-        let mut live_temps = *self.live_temps.last().unwrap_or(&LiveTemps::default());
+        let mut live_temps = self.get_live_temps();
         match insn {
             Insn::LiveTemps(next_temps) => {
                 live_temps = next_temps;
@@ -960,6 +960,11 @@ impl Assembler
         self.insns.push(insn);
         self.live_ranges.push(insn_idx);
         self.live_temps.push(live_temps);
+    }
+
+    /// Get stack temps that are currently in a register
+    fn get_live_temps(&self) -> LiveTemps {
+        *self.live_temps.last().unwrap_or(&LiveTemps::default())
     }
 
     /// Create a new label instance that we can jump to
@@ -1380,6 +1385,7 @@ impl Assembler {
     }
 
     pub fn ccall(&mut self, fptr: *const u8, opnds: Vec<Opnd>) -> Opnd {
+        assert_eq!(self.get_live_temps(), LiveTemps::default(), "temps must be spilled before ccall");
         let out = self.next_opnd_out(Opnd::match_num_bits(&opnds));
         self.push_insn(Insn::CCall { fptr, opnds, out });
         out

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -718,15 +718,15 @@ impl Assembler
                     emit_csel(cb, *truthy, *falsy, *out, cmovl);
                 }
                 Insn::LiveReg { .. } |
-                Insn::LiveTemps(_) => (), // just a reg alloc signal, no code
+                Insn::LiveTemps(_) |
+                Insn::SpillTemp(_) |
+                Insn::ReloadTemp(_) => (), // just a reg alloc signal, no code
                 Insn::PadInvalPatch => {
                     let code_size = cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()));
                     if code_size < JMP_PTR_BYTES {
                         nop(cb, (JMP_PTR_BYTES - code_size) as u32);
                     }
                 }
-                Insn::SpillTemp(_) |
-                Insn::ReloadTemp(_) => unreachable!("lower_stack should lower {:?}", insn),
 
                 // We want to keep the panic here because some instructions that
                 // we feed to the backend could get lowered into other

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -101,7 +101,7 @@ impl Assembler
     /// Get the list of registers that can be used for stack temps.
     pub fn get_temp_regs() -> Vec<Reg> {
         let num_regs = get_option!(temp_regs);
-        let mut regs = vec![RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG, R11_REG];
+        let mut regs = vec![RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG];
         regs.drain(0..num_regs).collect()
     }
 
@@ -724,6 +724,9 @@ impl Assembler
                         nop(cb, (JMP_PTR_BYTES - code_size) as u32);
                     }
                 }
+                Insn::LiveTemps(_) |
+                Insn::SpillTemp(_) |
+                Insn::ReloadTemp(_) => unreachable!("lower_stack should remove {:?}", insn),
 
                 // We want to keep the panic here because some instructions that
                 // we feed to the backend could get lowered into other

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -717,16 +717,16 @@ impl Assembler
                 Insn::CSelGE { truthy, falsy, out } => {
                     emit_csel(cb, *truthy, *falsy, *out, cmovl);
                 }
-                Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
+                Insn::LiveReg { .. } |
+                Insn::LiveTemps(_) => (), // just a reg alloc signal, no code
                 Insn::PadInvalPatch => {
                     let code_size = cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()));
                     if code_size < JMP_PTR_BYTES {
                         nop(cb, (JMP_PTR_BYTES - code_size) as u32);
                     }
                 }
-                Insn::LiveTemps(_) |
                 Insn::SpillTemp(_) |
-                Insn::ReloadTemp(_) => unreachable!("lower_stack should remove {:?}", insn),
+                Insn::ReloadTemp(_) => unreachable!("lower_stack should lower {:?}", insn),
 
                 // We want to keep the panic here because some instructions that
                 // we feed to the backend could get lowered into other

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -719,8 +719,7 @@ impl Assembler
                 }
                 Insn::LiveReg { .. } |
                 Insn::LiveTemps(_) |
-                Insn::SpillTemp(_) |
-                Insn::ReloadTemp(_) => (), // just a reg alloc signal, no code
+                Insn::SpillTemp(_) => (), // just a reg alloc signal, no code
                 Insn::PadInvalPatch => {
                     let code_size = cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()));
                     if code_size < JMP_PTR_BYTES {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -10,6 +10,7 @@ use crate::codegen::{JITState};
 use crate::cruby::*;
 use crate::backend::ir::*;
 use crate::codegen::CodegenGlobals;
+use crate::options::*;
 
 // Use the x86 register type for this platform
 pub type Reg = X86Reg;
@@ -95,6 +96,13 @@ impl Assembler
             RCX_REG,
             RDX_REG,
         ]
+    }
+
+    /// Get the list of registers that can be used for stack temps.
+    pub fn get_temp_regs() -> Vec<Reg> {
+        let num_regs = get_option!(temp_regs);
+        let mut regs = vec![RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG, R11_REG];
+        regs.drain(0..num_regs).collect()
     }
 
     /// Get a list of all of the caller-save registers

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -289,6 +289,7 @@ macro_rules! gen_counter_incr {
         }
     };
 }
+pub(crate) use gen_counter_incr;
 
 macro_rules! counted_exit {
     ($jit:tt, $ctx:tt, $ocb:tt, $counter_name:ident) => {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -851,6 +851,7 @@ pub fn gen_single_block(
 
     // Create a backend assembler instance
     let mut asm = Assembler::new();
+    asm.set_live_temps(ctx.get_live_temps());
 
     #[cfg(feature = "disasm")]
     if get_option_ref!(dump_disasm).is_some() {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -289,7 +289,6 @@ macro_rules! gen_counter_incr {
         }
     };
 }
-pub(crate) use gen_counter_incr;
 
 macro_rules! counted_exit {
     ($jit:tt, $ctx:tt, $ocb:tt, $counter_name:ident) => {
@@ -315,6 +314,7 @@ fn jit_save_pc(jit: &JITState, asm: &mut Assembler) {
 /// Note: this will change the current value of REG_SP,
 ///       which could invalidate memory operands
 fn gen_save_sp(asm: &mut Assembler, ctx: &mut Context) {
+    asm.spill_temps(ctx);
     if ctx.get_sp_offset() != 0 {
         asm.comment("save SP to CFP");
         let stack_pointer = ctx.sp_opnd(0);
@@ -906,7 +906,7 @@ pub fn gen_single_block(
             gen_counter_incr!(asm, exec_instruction);
 
             // Add a comment for the name of the YARV instruction
-            asm.comment(&format!("Insn: {}", insn_name(opcode)));
+            asm.comment(&format!("Insn: {} (stack_size: {})", insn_name(opcode), ctx.get_stack_size()));
 
             // If requested, dump instructions for debugging
             if get_option!(dump_insns) {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1582,10 +1582,10 @@ impl Context {
 
     /// Push one new value on the temp stack with an explicit mapping
     /// Return a pointer to the new stack top
-    pub fn stack_push_mapping(&mut self, (mapping, temp_type): (TempMapping, Type)) -> Opnd {
+    pub fn stack_push_mapping(&mut self, asm: &mut Assembler, (mapping, temp_type): (TempMapping, Type)) -> Opnd {
         // If type propagation is disabled, store no types
         if get_option!(no_type_prop) {
-            return self.stack_push_mapping((mapping, Type::Unknown));
+            return self.stack_push_mapping(asm, (mapping, Type::Unknown));
         }
 
         let stack_size: usize = self.stack_size.into();
@@ -1608,22 +1608,22 @@ impl Context {
 
     /// Push one new value on the temp stack
     /// Return a pointer to the new stack top
-    pub fn stack_push(&mut self, val_type: Type) -> Opnd {
-        return self.stack_push_mapping((MapToStack, val_type));
+    pub fn stack_push(&mut self, asm: &mut Assembler, val_type: Type) -> Opnd {
+        return self.stack_push_mapping(asm, (MapToStack, val_type));
     }
 
     /// Push the self value on the stack
-    pub fn stack_push_self(&mut self) -> Opnd {
-        return self.stack_push_mapping((MapToSelf, Type::Unknown));
+    pub fn stack_push_self(&mut self, asm: &mut Assembler) -> Opnd {
+        return self.stack_push_mapping(asm, (MapToSelf, Type::Unknown));
     }
 
     /// Push a local variable on the stack
-    pub fn stack_push_local(&mut self, local_idx: usize) -> Opnd {
+    pub fn stack_push_local(&mut self, asm: &mut Assembler, local_idx: usize) -> Opnd {
         if local_idx >= MAX_LOCAL_TYPES {
-            return self.stack_push(Type::Unknown);
+            return self.stack_push(asm, Type::Unknown);
         }
 
-        return self.stack_push_mapping((MapToLocal((local_idx as u8).into()), Type::Unknown));
+        return self.stack_push_mapping(asm, (MapToLocal((local_idx as u8).into()), Type::Unknown));
     }
 
     // Pop N values off the stack
@@ -3096,7 +3096,7 @@ mod tests {
 
         // Try pushing an operand and getting its type
         let mut ctx = Context::default();
-        ctx.stack_push(Type::Fixnum);
+        ctx.stack_push(&mut Assembler::new(), Type::Fixnum);
         let top_type = ctx.get_opnd_type(StackOpnd(0));
         assert!(top_type == Type::Fixnum);
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1614,7 +1614,9 @@ impl Context {
 
         // Allocate a register to the stack operand
         assert_eq!(self.live_temps, asm.get_live_temps());
-        self.live_temps = asm.alloc_temp(self.stack_size);
+        if self.stack_size < MAX_LIVE_TEMPS {
+            self.live_temps = asm.alloc_temp(self.stack_size);
+        }
 
         self.stack_size += 1;
         self.sp_offset += 1;

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1569,6 +1569,10 @@ impl Context {
         self.live_temps
     }
 
+    pub fn set_live_temps(&mut self, live_temps: LiveTemps) {
+        self.live_temps = live_temps;
+    }
+
     pub fn get_chain_depth(&self) -> u8 {
         self.chain_depth
     }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -375,7 +375,7 @@ impl From<Opnd> for YARVOpnd {
 pub const MAX_LIVE_TEMPS: u8 = 8;
 
 /// Bitmap of which stack temps are in a register
-#[derive(Copy, Clone, Default, PartialEq, Debug)]
+#[derive(Copy, Clone, Default, Eq, Hash, PartialEq, Debug)]
 pub struct LiveTemps(u8);
 
 impl LiveTemps {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -372,19 +372,19 @@ impl From<Opnd> for YARVOpnd {
 }
 
 /// Maximum index of stack temps that could be in a register
-pub const MAX_LIVE_TEMPS: usize = 8;
+pub const MAX_LIVE_TEMPS: u8 = 8;
 
 /// Bitmap of which stack temps are in a register
 #[derive(Copy, Clone, Default, PartialEq, Debug)]
 pub struct LiveTemps(u8);
 
 impl LiveTemps {
-    fn get(&mut self, index: usize) -> bool {
+    pub fn get(&mut self, index: u8) -> bool {
         assert!(index < MAX_LIVE_TEMPS);
         (self.0 >> index) & 1 == 1
     }
 
-    fn set(&mut self, index: usize, value: bool) {
+    pub fn set(&mut self, index: u8, value: bool) {
         assert!(index < MAX_LIVE_TEMPS);
         if value {
             self.0 = self.0 | (1 << index);
@@ -1666,7 +1666,7 @@ impl Context {
 
     /// Get an operand pointing to a slot on the temp stack
     pub fn stack_opnd(&self, idx: i32) -> Opnd {
-        Opnd::Stack { idx, sp_offset: self.sp_offset, num_bits: 64 }
+        Opnd::Stack { idx, stack_size: self.stack_size, sp_offset: self.sp_offset, num_bits: 64 }
     }
 
     /// Get the type of an instruction operand

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -379,7 +379,7 @@ pub const MAX_LIVE_TEMPS: u8 = 8;
 pub struct LiveTemps(u8);
 
 impl LiveTemps {
-    pub fn get(&mut self, index: u8) -> bool {
+    pub fn get(&self, index: u8) -> bool {
         assert!(index < MAX_LIVE_TEMPS);
         (self.0 >> index) & 1 == 1
     }
@@ -391,6 +391,10 @@ impl LiveTemps {
         } else {
             self.0 = self.0 & !(1 << index);
         }
+    }
+
+    pub fn as_u8(&self) -> u8 {
+        self.0
     }
 }
 
@@ -1561,6 +1565,10 @@ impl Context {
         self.sp_offset = offset;
     }
 
+    pub fn get_live_temps(&self) -> LiveTemps {
+        self.live_temps
+    }
+
     pub fn get_chain_depth(&self) -> u8 {
         self.chain_depth
     }
@@ -1599,6 +1607,10 @@ impl Context {
                 assert!((idx as usize) < MAX_LOCAL_TYPES);
             }
         }
+
+        // Allocate a register to the stack operand
+        assert_eq!(self.live_temps, asm.get_live_temps());
+        self.live_temps = asm.alloc_temp(self.stack_size);
 
         self.stack_size += 1;
         self.sp_offset += 1;

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -22,6 +22,9 @@ pub struct Options {
     // 1 means always create generic versions
     pub max_versions: usize,
 
+    // The number of registers allocated for stack temps
+    pub temp_regs: usize,
+
     // Capture and print out stats
     pub gen_stats: bool,
 
@@ -52,6 +55,7 @@ pub static mut OPTIONS: Options = Options {
     greedy_versioning: false,
     no_type_prop: false,
     max_versions: 4,
+    temp_regs: 0,
     gen_stats: false,
     gen_trace_exits: false,
     pause: false,
@@ -139,6 +143,13 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("pause", "") => unsafe {
             OPTIONS.pause = true;
+        },
+
+        ("temp-regs", _) => match opt_val.parse() {
+            Ok(n) => unsafe { OPTIONS.temp_regs = n },
+            Err(_) => {
+                return None;
+            }
         },
 
         ("dump-disasm", _) => match opt_val.to_string().as_str() {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -352,6 +352,11 @@ make_counters! {
 
     iseq_stack_too_large,
     iseq_too_long,
+
+    temp_reg_opnd,
+    temp_mem_opnd,
+    temp_spill,
+    temp_reload,
 }
 
 //===========================================================================

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -92,7 +92,7 @@ yjit-smoke-test:
 ifneq ($(strip $(CARGO)),)
 	$(CARGO) test --all-features -q --manifest-path='$(top_srcdir)/yjit/Cargo.toml'
 endif
-	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1 --yjit-temp-regs=6' BTESTS=-j
+	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1 --yjit-temp-regs=5' BTESTS=-j
 
 # Generate Rust bindings. See source for details.
 # Needs `./configure --enable-yjit=dev` and Clang.

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -92,8 +92,7 @@ yjit-smoke-test:
 ifneq ($(strip $(CARGO)),)
 	$(CARGO) test --all-features -q --manifest-path='$(top_srcdir)/yjit/Cargo.toml'
 endif
-	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1' BTESTS=-j
-	$(MAKE) test-all TESTS='$(top_srcdir)/test/ruby/test_yjit.rb'
+	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1 --yjit-temp-regs=6' BTESTS=-j
 
 # Generate Rust bindings. See source for details.
 # Needs `./configure --enable-yjit=dev` and Clang.


### PR DESCRIPTION
rebasing (WIP)

```
regs=0: ruby 3.3.0dev (2023-03-31T23:04:04Z yjit-temp-regs 1e1b6b94ac) +YJIT [x86_64-linux]
regs=5: ruby 3.3.0dev (2023-03-31T23:04:04Z yjit-temp-regs 1e1b6b94ac) +YJIT [x86_64-linux]

--------------------  -----------  ----------  -----------  ----------  -------------  --------------
bench                 regs=0 (ms)  stddev (%)  regs=5 (ms)  stddev (%)  regs=0/regs=5  regs=5 1st itr
30k_ifelse            252.2        0.1         226.7        0.1         1.11           0.80
30k_methods           499.6        0.1         496.9        0.1         1.01           0.90
cfunc_itself          22.8         1.2         20.9         3.0         1.09           1.03
fib                   50.4         0.3         30.5         0.9         1.65           1.66
getivar               70.8         14.7        22.9         121.4       3.09           0.90
keyword_args          39.4         1.1         43.7         0.5         0.90           0.91
respond_to            20.5         3.8         13.5         2.8         1.52           1.58
setivar               13.9         83.6        11.7         92.8        1.19           1.14
setivar_object        46.0         31.9        40.8         27.0        1.13           1.00
setivar_young_object  42.2         24.7        42.7         30.8        0.99           0.95
str_concat            25.9         1.6         24.2         1.5         1.07           1.04
throw                 15.2         0.3         14.9         0.3         1.02           0.99
--------------------  -----------  ----------  -----------  ----------  -------------  --------------
```

```
regs=0: ruby 3.3.0dev (2023-03-31T23:04:04Z yjit-temp-regs 1e1b6b94ac) +YJIT [x86_64-linux]
regs=5: ruby 3.3.0dev (2023-03-31T23:04:04Z yjit-temp-regs 1e1b6b94ac) +YJIT [x86_64-linux]

-----------  -----------  ----------  -----------  ----------  -------------  --------------
bench        regs=0 (ms)  stddev (%)  regs=5 (ms)  stddev (%)  regs=0/regs=5  regs=5 1st itr
binarytrees  150.0        0.3         135.4        0.4         1.11           1.10
chunky_png   413.5        0.3         368.2        0.2         1.12           1.09
erubi        159.6        1.5         154.0        1.4         1.04           1.03
erubi_rails  11.0         2.0         10.9         1.9         1.01           0.75
etanni       251.9        0.6         252.6        0.6         1.00           1.00
lee          550.3        1.5         517.1        1.6         1.06           1.06
nbody        45.2         0.3         42.9         0.5         1.05           1.02
optcarrot    1770.3       0.5         1554.8       0.5         1.14           1.11
ruby-json    2462.0       0.0         2461.0       0.0         1.00           1.00
rubykon      4797.5       0.4         4407.7       0.4         1.09           1.09
-----------  -----------  ----------  -----------  ----------  -------------  --------------
```