### PR TITLE
[Experimental] Implement RubyVM::YJIT.pause

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1127,6 +1127,7 @@ VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_simulate_oom_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_exit_locations(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_resume(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_pause(rb_execution_context_t *ec, VALUE self);
 
 // Preprocessed yjit.rb generated during build
 #include "yjit.rbinc"

--- a/yjit.rb
+++ b/yjit.rb
@@ -29,9 +29,14 @@ module RubyVM::YJIT
     Primitive.rb_yjit_reset_stats_bang
   end
 
-  # Resume YJIT compilation after paused on startup with --yjit-pause
+  # Resume YJIT compilation after paused on startup with --yjit-pause or with RubyVM::YJIT.pause
   def self.resume
     Primitive.rb_yjit_resume
+  end
+
+  # Pause YJIT compilation
+  def self.pause
+    Primitive.rb_yjit_pause
   end
 
   # If --yjit-trace-exits is enabled parse the hashes from

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -160,6 +160,15 @@ pub extern "C" fn rb_yjit_resume(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
     Qnil
 }
 
+#[no_mangle]
+pub extern "C" fn rb_yjit_pause(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    if yjit_enabled_p() {
+        COMPILE_NEW_ISEQS.store(false, Ordering::Release);
+    }
+
+    Qnil
+}
+
 /// Simulate a situation where we are out of executable memory
 #[no_mangle]
 pub extern "C" fn rb_yjit_simulate_oom_bang(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {


### PR DESCRIPTION
This allows to pause and resume YJIT compilation at any point.

Note that it won't prevent YJIT from compiling when it hits a stub.

But this is flexible enough to allow to prevent compilation on a per code section basis (for single threaded apps). e.g. per controller in a Rails app.

cc @k0kubun @maximecb @XrXr @tenderworks 