### PR TITLE
Add counters to measure `branch_stub_hit` instances on old ISEQs

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -285,6 +285,9 @@ module RubyVM::YJIT
       if stats[:compiled_blockid_count] != 0
         out.puts "versions_per_block:    " + ("%10.3f" % stats[:compiled_block_count].fdiv(stats[:compiled_blockid_count]))
       end
+      out.puts "branch_stub_hit:       " + ("%10d" % stats[:branch_stub_hit])
+      out.puts "branch_stub_hit_old:   " + ("%10d" % stats[:branch_stub_hit_old])
+
       out.puts "compiled_branch_count: " + ("%10d" % stats[:compiled_branch_count])
       out.puts "compile_time_ms:       " + ("%10d" % stats[:compile_time_ns].div(1000 * 1000))
       out.puts "block_next_count:      " + ("%10d" % stats[:block_next_count])

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -143,13 +143,15 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: [&str; 6] = [
+pub const DEFAULT_COUNTERS: [&str; 8] = [
     "code_gc_count",
     "compiled_iseq_entry",
     "compiled_iseq_count",
     "compiled_blockid_count",
     "compiled_block_count",
     "compiled_branch_count",
+    "branch_stub_hit",
+    "branch_stub_hit_old",
 ];
 
 /// Macro to increase a counter by name and count

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -327,6 +327,8 @@ make_counters! {
     defer_count,
     freed_iseq_count,
 
+    branch_stub_hit,
+    branch_stub_hit_old,
     exit_from_branch_stub,
 
     invalidation_count,


### PR DESCRIPTION
Adding some counters so we can measure and graph how often we hit branch stubs from old ISEQs on Core and SFR