### PR TITLE
YJIT: Add counter to measure how often we compile "cold" ISEQs

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -429,7 +429,7 @@ jit_compile(rb_execution_context_t *ec)
     if (body->jit_entry == NULL) {
         body->jit_entry_calls++;
         if (yjit_enabled) {
-            if (body->jit_entry_calls == rb_yjit_call_threshold())  {
+            if (rb_yjit_threshold_hit(iseq, body->jit_entry_calls)) {
                 rb_yjit_compile_iseq(iseq, ec, false);
             }
         }

--- a/yjit.h
+++ b/yjit.h
@@ -28,6 +28,7 @@
 bool rb_yjit_enabled_p(void);
 bool rb_yjit_compile_new_iseqs(void);
 unsigned rb_yjit_call_threshold(void);
+bool rb_yjit_threshold_hit(const rb_iseq_t *const iseq, unsigned long total_calls);
 void rb_yjit_invalidate_all_method_lookup_assumptions(void);
 void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme);
 void rb_yjit_collect_binding_alloc(void);
@@ -50,6 +51,7 @@ void rb_yjit_tracing_invalidate_all(void);
 static inline bool rb_yjit_enabled_p(void) { return false; }
 static inline bool rb_yjit_compile_new_iseqs(void) { return false; }
 static inline unsigned rb_yjit_call_threshold(void) { return UINT_MAX; }
+static inline bool rb_yjit_threshold_hit(const rb_iseq_t *const iseq, unsigned long total_calls) { return false; }
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}
 static inline void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme) {}
 static inline void rb_yjit_collect_binding_alloc(void) {}

--- a/yjit.rb
+++ b/yjit.rb
@@ -279,6 +279,7 @@ module RubyVM::YJIT
       out.puts "bindings_set:          " + ("%10d" % stats[:binding_set])
       out.puts "compilation_failure:   " + ("%10d" % compilation_failure) if compilation_failure != 0
       out.puts "compiled_iseq_entry:   " + ("%10d" % stats[:compiled_iseq_entry])
+      out.puts "compiled_entry_cold:   " + ("%10d" % stats[:compiled_entry_cold])
       out.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
       out.puts "compiled_blockid_count:" + ("%10d" % stats[:compiled_blockid_count])
       out.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -539,6 +539,9 @@ pub struct IseqPayload {
     // How many blocks were compiled when we last hit a branch stub
     // for this ISEQ
     pub block_count_last_stub: u64,
+
+    // Number of calls when we hit the threshold for this ISEQs
+    pub call_count_at_threshold: u64,
 }
 
 impl IseqPayload {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -174,9 +174,10 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: [&str; 9] = [
+pub const DEFAULT_COUNTERS: [&str; 10] = [
     "code_gc_count",
     "compiled_iseq_entry",
+    "compiled_iseq_entry_cold",
     "compiled_iseq_count",
     "compiled_blockid_count",
     "compiled_block_count",
@@ -351,6 +352,7 @@ make_counters! {
     binding_set,
 
     compiled_iseq_entry,
+    compiled_entry_cold,
     compiled_iseq_count,
     compiled_blockid_count,
     compiled_block_count,


### PR DESCRIPTION
I'd like to deploy this to Core so we can monitor the percentage of cold ISEQ entries that get compiled over the weekend.

The thresholds chosen are hardcoded, which is slightly hacky and just for this experiment, but they are set such that our largest benchmark (lobsters) has a small percentage ~2.9% of "cold" ISEQs only, with the idea that a much larger app should have a larger percentage of cold entries compiled, just because it has so much more code.

The idea being: maybe we can find heuristics that are set such that our benchmarks see no performance difference, the same amount of code gets compiled, but real production deployments benefit from less cold and rarely executed code being compiled.