### PR TITLE
Fix complex transi compact

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -47,7 +47,8 @@ VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 
 struct gen_ivtbl;
 int rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl);
-void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
+VALUE rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
+void rb_obj_copy_ivs_to_hash_table_complete(VALUE ivar_pinner);
 void rb_obj_convert_to_too_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);
 

--- a/object.c
+++ b/object.c
@@ -326,8 +326,9 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
         shape_to_set_on_dest = rb_shape_rebuild_shape(initial_shape, src_shape);
         if (UNLIKELY(rb_shape_id(shape_to_set_on_dest) == OBJ_TOO_COMPLEX_SHAPE_ID)) {
             st_table * table = rb_st_init_numtable_with_size(src_num_ivs);
-            rb_obj_copy_ivs_to_hash_table(obj, table);
+            VALUE ivar_pinner = rb_obj_copy_ivs_to_hash_table(obj, table);
             rb_obj_convert_to_too_complex(dest, table);
+            rb_obj_copy_ivs_to_hash_table_complete(ivar_pinner);
 
             return;
         }

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -256,9 +256,9 @@ class TestShapes < Test::Unit::TestCase
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       i = 0
+      o = Object.new
       while RubyVM::Shape.shapes_available > 0
-        c = Class.new
-        c.instance_variable_set(:"@i#{i}", 1)
+        o.instance_variable_set(:"@i#{i}", 1)
         i += 1
       end
 
@@ -271,6 +271,103 @@ class TestShapes < Test::Unit::TestCase
 
       assert_raise(NameError) do
         c.remove_instance_variable(:@a)
+      end
+    end;
+  end
+
+  def test_evacuate_class_ivar_and_compaction
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+
+    begin;
+      count = 20
+
+      c = Class.new
+      count.times do |ivar|
+        c.instance_variable_set("@i#{ivar}", "ivar-#{ivar}")
+      end
+
+      i = 0
+      o = Object.new
+      while RubyVM::Shape.shapes_available > 0
+        o.instance_variable_set("@i#{i}", 1)
+        i += 1
+      end
+
+      GC.auto_compact = true
+      GC.stress = true
+      # Cause evacuation
+      c.instance_variable_set(:@a, o = Object.new)
+      assert_equal(o, c.instance_variable_get(:@a))
+      GC.stress = false
+
+      count.times do |ivar|
+        assert_equal "ivar-#{ivar}", c.instance_variable_get("@i#{ivar}")
+      end
+    end;
+  end
+
+  def test_evacuate_generic_ivar_and_compaction
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+
+    begin;
+      count = 20
+
+      c = Hash.new
+      count.times do |ivar|
+        c.instance_variable_set("@i#{ivar}", "ivar-#{ivar}")
+      end
+
+      i = 0
+      o = Object.new
+      while RubyVM::Shape.shapes_available > 0
+        o.instance_variable_set("@i#{i}", 1)
+        i += 1
+      end
+
+      GC.auto_compact = true
+      GC.stress = true
+
+      # Cause evacuation
+      c.instance_variable_set(:@a, o = Object.new)
+      assert_equal(o, c.instance_variable_get(:@a))
+
+      GC.stress = false
+
+      count.times do |ivar|
+        assert_equal "ivar-#{ivar}", c.instance_variable_get("@i#{ivar}")
+      end
+    end;
+  end
+
+  def test_evacuate_object_ivar_and_compaction
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+
+    begin;
+      count = 20
+
+      c = Object.new
+      count.times do |ivar|
+        c.instance_variable_set("@i#{ivar}", "ivar-#{ivar}")
+      end
+
+      i = 0
+      o = Object.new
+      while RubyVM::Shape.shapes_available > 0
+        o.instance_variable_set("@i#{i}", 1)
+        i += 1
+      end
+
+      GC.auto_compact = true
+      GC.stress = true
+
+      # Cause evacuation
+      c.instance_variable_set(:@a, o = Object.new)
+      assert_equal(o, c.instance_variable_get(:@a))
+
+      GC.stress = false
+
+      count.times do |ivar|
+        assert_equal "ivar-#{ivar}", c.instance_variable_get("@i#{ivar}")
       end
     end;
   end

--- a/variable.c
+++ b/variable.c
@@ -1370,12 +1370,21 @@ rb_attr_delete(VALUE obj, ID id)
     return rb_ivar_delete(obj, id, Qnil);
 }
 
+static int
+rb_obj_write_barrier_ivars_i(ID key, VALUE val, st_data_t arg)
+{
+    RB_OBJ_WRITTEN((VALUE)arg, Qundef, val);
+    return ST_CONTINUE;
+}
+
 void
 rb_obj_convert_to_too_complex(VALUE obj, st_table *table)
 {
     RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
 
     VALUE *old_ivptr = NULL;
+
+    rb_ivar_foreach(obj, rb_obj_write_barrier_ivars_i, (st_data_t)obj);
 
     switch (BUILTIN_TYPE(obj)) {
         case T_OBJECT:
@@ -1422,8 +1431,9 @@ rb_evict_ivars_to_hash(VALUE obj)
     st_table *table = st_init_numtable_with_size(rb_ivar_count(obj));
 
     // Evacuate all previous values from shape into id_table
-    rb_obj_copy_ivs_to_hash_table(obj, table);
+    VALUE ivar_pinner = rb_obj_copy_ivs_to_hash_table(obj, table);
     rb_obj_convert_to_too_complex(obj, table);
+    rb_obj_copy_ivs_to_hash_table_complete(ivar_pinner);
 
     RUBY_ASSERT(rb_shape_obj_too_complex(obj));
 }
@@ -1640,17 +1650,44 @@ rb_ensure_iv_list_size(VALUE obj, uint32_t current_capacity, uint32_t new_capaci
     }
 }
 
-int
-rb_obj_copy_ivs_to_hash_table_i(ID key, VALUE val, st_data_t arg)
+struct rb_evacuate_arg {
+    st_table *table;
+    VALUE host;
+};
+
+static int
+copy_ivs_to_hash_table_i(ID key, VALUE val, st_data_t arg)
 {
-    st_insert((st_table *)arg, (st_data_t)key, (st_data_t)val);
+    struct rb_evacuate_arg *evac_arg = (struct rb_evacuate_arg *)arg;
+    st_insert(evac_arg->table, (st_data_t)key, (st_data_t)val);
+    RB_OBJ_WRITTEN(evac_arg->host, Qundef, val);
     return ST_CONTINUE;
 }
 
-void
+VALUE
 rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table)
 {
-    rb_ivar_foreach(obj, rb_obj_copy_ivs_to_hash_table_i, (st_data_t)table);
+    // There can be compaction runs between each ivar we copy out of obj, so we
+    // need an object to mark each ivar to make sure every reference is valid
+    // by the time we're done. Use a special T_OBJECT for marking.
+    VALUE ivar_pinner = rb_wb_protected_newobj_of(GET_EC(), rb_cBasicObject, T_OBJECT | ROBJECT_EMBED, RVALUE_SIZE);
+    rb_shape_set_shape_id(ivar_pinner, OBJ_TOO_COMPLEX_SHAPE_ID);
+    ROBJECT_SET_IV_HASH(ivar_pinner, table);
+
+    // Evacuate all previous values from shape into id_table
+    struct rb_evacuate_arg evac_arg = { .table = table, .host = ivar_pinner };
+    rb_ivar_foreach(obj, copy_ivs_to_hash_table_i, (st_data_t)&evac_arg);
+
+    return ivar_pinner;
+}
+
+void
+rb_obj_copy_ivs_to_hash_table_complete(VALUE ivar_pinner)
+{
+    // done with pinning, now set pinner to 0 ivars
+    ROBJECT_SET_IV_HASH(ivar_pinner, NULL);
+    rb_shape_set_shape(ivar_pinner, rb_shape_get_root_shape());
+    RB_GC_GUARD(ivar_pinner);
 }
 
 static VALUE *


### PR DESCRIPTION
I think this PR fixes the compaction issue, but now I run into the bug I was looking to in the first place:

```
$ make test/ruby/test_shapes.rb
```

```
TestShapes#test_evacuate_class_ivar_and_compaction [/Users/byroot/src/github.com/Shopify/ruby/test/ruby/test_shapes.rb:279]:
pid 83296 killed by SIGABRT (signal 6)
| <OBJ_INFO:gc_mark_ptr@gc.c:6966> 0x0000000107ccfc10 [0 M    ] T_NONE 
| /Users/byroot/src/github.com/Shopify/ruby/tool/lib/core_assertions.rb:524: [BUG] try to mark T_NONE object
| -- C level backtrace information -------------------------------------------
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_vm_bugreport+0xb60) [0x1052bb5f0] vm_dump.c:1143
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_vm_bugreport) (null):0
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_bug_without_die+0xf0) [0x1050daa84] error.c:1042
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_bug+0x1c) [0x1053b495c] error.c:1050
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_gc_mark_weak+0x0) [0x1050fbce4] gc.c:6967
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_mark_ptr) (null):0
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_mark+0x10) [0x105100ad8] gc.c:7003
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(mark_method_entry) gc.c:6635
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_mark_imemo) gc.c:7153
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_mark_children) gc.c:7275
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_mark_stacked_objects+0x78) [0x105108bd8] gc.c:7471
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_mark_stacked_objects_incremental) gc.c:7503
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_marks_rest+0xac) [0x1051089e0] gc.c:8693
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(gc_rest+0x110) [0x1050fa154] gc.c:9528
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(garbage_collect+0x5c) [0x1050fdf74] gc.c:9382
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(objspace_xmalloc0+0x70) [0x10510167c] gc.c:12408
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_ccs_push+0x14c) [0x1052a2cfc] ./vm_insnhelper.c:1997
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(imemo_type_p+0x0) [0x105285d30] ./vm_insnhelper.c:2138
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_cc_cme) ./vm_callinfo.h:394
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_search_cc) ./vm_insnhelper.c:2140
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_vm_search_method_slowpath) ./vm_insnhelper.c:2156
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_search_method_slowpath0+0x24) [0x1052af124] ./vm_insnhelper.c:2177
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_search_method_fastpath+0x10) [0x105287a4c] ./vm_insnhelper.c:2238
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_sendish) ./vm_insnhelper.c:5581
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(vm_exec_core+0x31bc) [0x10528c344] insns.def:822
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_vm_exec+0x1f4) [0x105287e90] vm.c:2467
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(rb_ec_exec_node+0xac) [0x1050e6ab4] eval.c:287
| /Users/byroot/src/github.com/Shopify/ruby/libruby.3.3.dylib(ruby_run_node+0x70) [0x1050e6998] eval.c:328
| /Users/byroot/src/github.com/Shopify/ruby/ruby(rb_main+0x1c) [0x1048bff18] ./main.c:39
```