### PR TITLE
Reimplement RData on top of RTypedData

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3071,7 +3071,7 @@ memsize_deprecated_rdata_object(const void *ptr)
 
 #define DEPRECATED_DATA_FREE RBIMPL_DATA_FUNC(-3)
 
-const rb_data_type_t deprecated_rdata_type = {
+const rb_data_type_t ruby_deprecated_rdata_type = {
     .wrap_struct_name = "RDATA(deprecated)",
     .function = {
         .dmark = mark_deprecated_rdata_object,
@@ -3086,7 +3086,7 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
     if (klass) rb_data_object_check(klass);
 
-    VALUE obj = rb_data_typed_object_zalloc(klass, sizeof(struct RData), &deprecated_rdata_type);
+    VALUE obj = rb_data_typed_object_zalloc(klass, sizeof(struct RData), &ruby_deprecated_rdata_type);
 
     struct RData *rdata = (struct RData *)obj;
     rdata->dmark = dmark;
@@ -4363,7 +4363,7 @@ rb_objspace_call_finalizer_i(VALUE obj, void *data)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_DATA:
-        if (!rb_free_at_exit && (!DATA_PTR(obj) || !RDATA(obj)->dfree)) break;
+        if (!rb_free_at_exit && (!RTYPEDDATA_GET_DATA(obj) || !RANY(obj)->as.typeddata.type->function.dfree)) break;
         if (rb_obj_is_thread(obj)) break;
         if (rb_obj_is_mutex(obj)) break;
         if (rb_obj_is_fiber(obj)) break;

--- a/include/ruby/internal/core/rdata.h
+++ b/include/ruby/internal/core/rdata.h
@@ -30,6 +30,7 @@
 #include "ruby/internal/attr/warning.h"
 #include "ruby/internal/cast.h"
 #include "ruby/internal/core/rbasic.h"
+#include "ruby/internal/core/rtypeddata.h"
 #include "ruby/internal/dllexport.h"
 #include "ruby/internal/fl_type.h"
 #include "ruby/internal/value.h"
@@ -77,6 +78,7 @@
  */
 #define RUBY_DEFAULT_FREE         RBIMPL_DATA_FUNC(-1)
 
+
 /**
  * This is a value you can set  to ::RData::dfree.  Setting this means the data
  * is managed by  someone else, like, statically allocated.  Of  course you are
@@ -93,16 +95,6 @@
  */
 #define RUBY_UNTYPED_DATA_FUNC(f) f RBIMPL_ATTRSET_UNTYPED_DATA_FUNC()
 
-/*
-#define RUBY_DATA_FUNC(func) ((void (*)(void*))(func))
-*/
-
-/**
- * This is  the type of callbacks  registered to ::RData.  The  argument is the
- * `data` field.
- */
-typedef void (*RUBY_DATA_FUNC)(void*);
-
 /**
  * @deprecated
  *
@@ -117,10 +109,25 @@ typedef void (*RUBY_DATA_FUNC)(void*);
  * too many warnings  in the core.  Maybe  we want to retry  later...  Just add
  * deprecated document for now.
  */
+struct RDataHeader {
+    /** Basic part, including flags and class. */
+    struct RBasic basic;
+
+    const rb_data_type_t *const type;
+
+    /** Pointer to the actual C level struct that you want to wrap. */
+    void *data;
+};
+
 struct RData {
 
     /** Basic part, including flags and class. */
     struct RBasic basic;
+
+    const rb_data_type_t *const type;
+
+    /** Pointer to the actual C level struct that you want to wrap. */
+    void *data;
 
     /**
      * This function is called when the object is experiencing GC marks.  If it
@@ -141,9 +148,6 @@ struct RData {
      *           impossible at that moment (that is why GC runs).
      */
     RUBY_DATA_FUNC dfree;
-
-    /** Pointer to the actual C level struct that you want to wrap. */
-    void *data;
 };
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -33,7 +33,6 @@
 #include "ruby/internal/attr/pure.h"
 #include "ruby/internal/cast.h"
 #include "ruby/internal/core/rbasic.h"
-#include "ruby/internal/core/rdata.h"
 #include "ruby/internal/dllexport.h"
 #include "ruby/internal/error.h"
 #include "ruby/internal/fl_type.h"
@@ -101,6 +100,16 @@
  */
 #define RTYPEDDATA_DATA(v)           (RTYPEDDATA(v)->data)
 
+/*
+#define RUBY_DATA_FUNC(func) ((void (*)(void*))(func))
+*/
+
+/**
+ * This is  the type of callbacks  registered to ::RData.  The  argument is the
+ * `data` field.
+ */
+typedef void (*RUBY_DATA_FUNC)(void*);
+
 /** @old{rb_check_typeddata} */
 #define Check_TypedStruct(v, t)      \
     rb_check_typeddata(RBIMPL_CAST((VALUE)(v)), (t))
@@ -112,9 +121,8 @@
 #define RUBY_TYPED_FROZEN_SHAREABLE  RUBY_TYPED_FROZEN_SHAREABLE
 #define RUBY_TYPED_WB_PROTECTED      RUBY_TYPED_WB_PROTECTED
 #define RUBY_TYPED_PROMOTED1         RUBY_TYPED_PROMOTED1
+#define TYPED_DATA_FL_EMBEDDED       RUBY_FL_USER0
 /** @endcond */
-
-#define TYPED_DATA_EMBEDDED 2
 
 /**
  * @private
@@ -364,7 +372,7 @@ struct RTypedData {
      *
      * @internal
      */
-    const VALUE typed_flag;
+    // const VALUE typed_flag;
 
     /** Pointer to the actual C level struct that you want to wrap. */
     void *data;
@@ -515,35 +523,7 @@ RBIMPL_SYMBOL_EXPORT_END()
 #define TypedData_Get_Struct(obj,type,data_type,sval) \
     ((sval) = RBIMPL_CAST((type *)rb_check_typeddata((obj), (data_type))))
 
-static inline bool
-RTYPEDDATA_EMBEDDED_P(VALUE obj)
-{
-#if RUBY_DEBUG
-    if (RB_UNLIKELY(!RB_TYPE_P(obj, RUBY_T_DATA))) {
-        Check_Type(obj, RUBY_T_DATA);
-        RBIMPL_UNREACHABLE_RETURN(false);
-    }
-#endif
-
-    return RTYPEDDATA(obj)->typed_flag & TYPED_DATA_EMBEDDED;
-}
-
-static inline void *
-RTYPEDDATA_GET_DATA(VALUE obj)
-{
-#if RUBY_DEBUG
-    if (RB_UNLIKELY(!RB_TYPE_P(obj, RUBY_T_DATA))) {
-        Check_Type(obj, RUBY_T_DATA);
-        RBIMPL_UNREACHABLE_RETURN(false);
-    }
-#endif
-
-    /* We reuse the data pointer in embedded TypedData. We can't use offsetof
-     * since RTypedData a non-POD type in C++. */
-    const size_t embedded_typed_data_size = sizeof(struct RTypedData) - sizeof(void *);
-
-    return RTYPEDDATA_EMBEDDED_P(obj) ? (char *)obj + embedded_typed_data_size : RTYPEDDATA(obj)->data;
-}
+extern const rb_data_type_t deprecated_rdata_type;
 
 RBIMPL_ATTR_PURE()
 RBIMPL_ATTR_ARTIFICIAL()
@@ -561,8 +541,7 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline bool
 rbimpl_rtypeddata_p(VALUE obj)
 {
-    VALUE typed_flag = RTYPEDDATA(obj)->typed_flag;
-    return typed_flag != 0 && typed_flag <= 3;
+    return RTYPEDDATA(obj)->type != &deprecated_rdata_type;
 }
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
@@ -586,6 +565,37 @@ RTYPEDDATA_P(VALUE obj)
 #endif
 
     return rbimpl_rtypeddata_p(obj);
+}
+
+static inline bool
+rbimpl_rtypeddata_embedded_p(VALUE obj)
+{
+#if RUBY_DEBUG
+    if (RB_UNLIKELY(!RB_TYPE_P(obj, RUBY_T_DATA))) {
+        Check_Type(obj, RUBY_T_DATA);
+        RBIMPL_UNREACHABLE_RETURN(false);
+    }
+#endif
+
+    return RTYPEDDATA_P(obj) && RTYPEDDATA(obj)->type->flags & RUBY_TYPED_EMBEDDABLE && FL_TEST_RAW(obj, TYPED_DATA_FL_EMBEDDED);
+}
+
+
+static inline void *
+RTYPEDDATA_GET_DATA(VALUE obj)
+{
+#if RUBY_DEBUG
+    if (RB_UNLIKELY(!RB_TYPE_P(obj, RUBY_T_DATA))) {
+        Check_Type(obj, RUBY_T_DATA);
+        RBIMPL_UNREACHABLE_RETURN(false);
+    }
+#endif
+
+    /* We reuse the data pointer in embedded TypedData. We can't use offsetof
+     * since RTypedData a non-POD type in C++. */
+    const size_t embedded_typed_data_size = sizeof(struct RTypedData) - sizeof(void *);
+
+    return rbimpl_rtypeddata_embedded_p(obj) ? (char *)obj + embedded_typed_data_size : RTYPEDDATA(obj)->data;
 }
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -523,7 +523,6 @@ RBIMPL_SYMBOL_EXPORT_END()
 #define TypedData_Get_Struct(obj,type,data_type,sval) \
     ((sval) = RBIMPL_CAST((type *)rb_check_typeddata((obj), (data_type))))
 
-extern const rb_data_type_t deprecated_rdata_type;
 
 RBIMPL_ATTR_PURE()
 RBIMPL_ATTR_ARTIFICIAL()
@@ -541,7 +540,8 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline bool
 rbimpl_rtypeddata_p(VALUE obj)
 {
-    return RTYPEDDATA(obj)->type != &deprecated_rdata_type;
+    extern const rb_data_type_t ruby_deprecated_rdata_type;
+    return RTYPEDDATA(obj)->type != &ruby_deprecated_rdata_type;
 }
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()

--- a/include/ruby/internal/gc.h
+++ b/include/ruby/internal/gc.h
@@ -825,5 +825,4 @@ rb_obj_write(
 
 RBIMPL_ATTR_DEPRECATED(("Will be removed soon"))
 static inline void rb_gc_force_recycle(VALUE obj){}
-
 #endif /* RBIMPL_GC_H */


### PR DESCRIPTION
The goal is to eliminate `RTypedData.typed_flag` which waste 8B, allowing `TypedData` to fit in a potential `32B` slot.

This however makes `RData` 48B long, but given it's a deprecated construct it seems acceptable to degrade it to improve its replacement.

Paired with @etiennebarrie on it, it's mostly a proof of concept at this stage, needs ton of cleanup and does have some bugs.

FYI: @peterzhu2118 @eightbitraptor 