### PR TITLE
YJIT, ZJIT: enhance clippy settings and fix lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,34 @@ overflow-checks = true
 debug = true
 # Use ThinLTO. Much smaller output for a small amount of build time increase.
 lto = "thin"
+
+[workspace.lints.clippy]
+correctness = { level = "forbid", priority = 1 }
+suspicious = { level = "forbid", priority = 1 }
+perf = { level = "forbid", priority = 1 }
+
+complexity = { level = "deny", priority = -1 }
+
+style = { level = "allow", priority = -1 }
+pedantic = { level = "allow", priority = -1 }
+restriction = { level = "allow", priority = -1 }
+
+too_many_arguments = "allow"
+identity_op = "allow"
+
+ptr_arg = "forbid"
+ref_option = "forbid"
+inefficient_to_string = "forbid"
+from_over_into = "forbid"
+unwrap_or_default = "forbid"
+redundant_static_lifetimes = "forbid"
+match_like_matches_macro = "forbid"
+field_reassign_with_default = "forbid"
+inherent_to_string = "forbid"
+owned_cow = "forbid"
+redundant_clone = "forbid"
+str_to_string = "forbid"
+single_char_pattern = "forbid"
+single_char_add_str = "forbid"
+unnecessary_owned_empty_strings = "forbid"
+manual_string_new = "forbid"

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -24,3 +24,6 @@ disasm = ["capstone"]
 # from cfg!(debug_assertions) so that we can see disasm of the code
 # that would run in the release mode.
 runtime_checks = []
+
+[lints]
+workspace = true

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -79,10 +79,7 @@ impl A64Opnd {
 
     /// Convenience function to check if this operand is a register.
     pub fn is_reg(&self) -> bool {
-        match self {
-            A64Opnd::Reg(_) => true,
-            _ => false
-        }
+        matches!(self, A64Opnd::Reg(_))
     }
 
     /// Unwrap a register from an operand.

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -224,16 +224,16 @@ impl CodeBlock {
     }
 
     /// Free the memory pages of given code page indexes
-    fn free_pages(&mut self, page_idxs: &Vec<usize>) {
-        let mut page_idxs = page_idxs.clone();
-        page_idxs.reverse(); // to loop with pop()
+    /// In Rust >= 1.77 this could probably be simplified with chunk_by.
+    fn free_pages(&mut self, page_idxs: &[usize]) {
+        let mut page_idxs = page_idxs.iter().rev().collect::<Vec<_>>();
 
         // Group adjacent page indexes and free them in batches to reduce the # of syscalls.
-        while let Some(page_idx) = page_idxs.pop() {
+        while let Some(&page_idx) = page_idxs.pop() {
             // Group first adjacent page indexes
             let mut batch_idxs = vec![page_idx];
-            while page_idxs.last() == Some(&(batch_idxs.last().unwrap() + 1)) {
-                batch_idxs.push(page_idxs.pop().unwrap());
+            while page_idxs.last() == Some(&&(*batch_idxs.last().unwrap() + 1)) {
+                batch_idxs.push(*page_idxs.pop().unwrap());
             }
 
             // Free the grouped pages at once
@@ -378,7 +378,7 @@ impl CodeBlock {
 
         // Unless this comment is the same as the last one at this same line, add it.
         if this_line_comments.last().map(String::as_str) != Some(comment) {
-            this_line_comments.push(comment.to_string());
+            this_line_comments.push(comment.into());
         }
     }
 
@@ -441,12 +441,12 @@ impl CodeBlock {
 
         // Ignore empty code ranges
         if start_addr == end_addr {
-            return (0..0).into_iter();
+            return 0..0;
         }
 
         let start_page = (start_addr.raw_addr(self) - mem_start) / self.page_size;
         let end_page = (end_addr.raw_addr(self) - mem_start - 1) / self.page_size;
-        (start_page..end_page + 1).into_iter()
+        start_page..end_page + 1
     }
 
     /// Get a (possibly dangling) direct pointer to the current write position

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -163,10 +163,7 @@ impl X86Opnd {
     }
 
     pub fn is_some(&self) -> bool {
-        match self {
-            X86Opnd::None => false,
-            _ => true
-        }
+        !matches!(self, X86Opnd::None)
     }
 
 }

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -454,7 +454,7 @@ fn block_comments() {
     let third_write_ptr = cb.get_write_ptr().raw_addr(&cb);
     cb.add_comment("Ten bytes in");
 
-    assert_eq!(&vec!( "Beginning".to_string() ), cb.comments_at(first_write_ptr).unwrap());
-    assert_eq!(&vec!( "Two bytes in".to_string(), "Still two bytes in".to_string() ), cb.comments_at(second_write_ptr).unwrap());
-    assert_eq!(&vec!( "Ten bytes in".to_string() ), cb.comments_at(third_write_ptr).unwrap());
+    assert_eq!(&vec!( "Beginning".to_owned() ), cb.comments_at(first_write_ptr).unwrap());
+    assert_eq!(&vec!( "Two bytes in".to_owned(), "Still two bytes in".to_owned() ), cb.comments_at(second_write_ptr).unwrap());
+    assert_eq!(&vec!( "Ten bytes in".to_owned() ), cb.comments_at(third_write_ptr).unwrap());
 }

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1243,7 +1243,7 @@ impl Assembler
                     emit_cmp_zero_jump(cb, opnd.into(), false, compile_side_exit(*target, self, ocb)?);
                 },
                 Insn::IncrCounter { mem, value } => {
-                    let label = cb.new_label("incr_counter_loop".to_string());
+                    let label = cb.new_label("incr_counter_loop".into());
                     cb.write_label(label);
 
                     ldaxr(cb, Self::SCRATCH0, mem.into());

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -186,7 +186,7 @@ impl Opnd
 
     /// Maps the indices from a previous list of instructions to a new list of
     /// instructions.
-    pub fn map_index(self, indices: &Vec<usize>) -> Opnd {
+    pub fn map_index(self, indices: &[usize]) -> Opnd {
         match self {
             Opnd::InsnOut { idx, num_bits } => {
                 Opnd::InsnOut { idx: indices[idx], num_bits }
@@ -1186,7 +1186,7 @@ impl Assembler
         assert!(!name.contains(' '), "use underscores in label names, not spaces");
 
         let label_idx = self.label_names.len();
-        self.label_names.push(name.to_string());
+        self.label_names.push(name.into());
         Target::Label(label_idx)
     }
 
@@ -1266,11 +1266,11 @@ impl Assembler
 
     /// Spill all live registers to the stack
     pub fn spill_regs(&mut self) {
-        self.spill_regs_except(&vec![]);
+        self.spill_regs_except(&[]);
     }
 
     /// Spill all live registers except `ignored_temps` to the stack
-    pub fn spill_regs_except(&mut self, ignored_temps: &Vec<RegOpnd>) {
+    pub fn spill_regs_except(&mut self, ignored_temps: &[RegOpnd]) {
         // Forget registers above the stack top
         let mut reg_mapping = self.ctx.get_reg_mapping();
         for stack_idx in self.ctx.get_stack_size()..MAX_CTX_TEMPS as u8 {
@@ -1348,17 +1348,17 @@ impl Assembler
 
     // Shuffle register moves, sometimes adding extra moves using SCRATCH_REG,
     // so that they will not rewrite each other before they are used.
-    pub fn reorder_reg_moves(old_moves: &Vec<(Reg, Opnd)>) -> Vec<(Reg, Opnd)> {
+    pub fn reorder_reg_moves(old_moves: &[(Reg, Opnd)]) -> Vec<(Reg, Opnd)> {
         // Return the index of a move whose destination is not used as a source if any.
-        fn find_safe_move(moves: &Vec<(Reg, Opnd)>) -> Option<usize> {
+        fn find_safe_move(moves: &[(Reg, Opnd)]) -> Option<usize> {
             moves.iter().enumerate().find(|(_, &(dest_reg, _))| {
                 moves.iter().all(|&(_, src_opnd)| src_opnd != Opnd::Reg(dest_reg))
             }).map(|(index, _)| index)
         }
 
         // Remove moves whose source and destination are the same
-        let mut old_moves: Vec<(Reg, Opnd)> = old_moves.clone().into_iter()
-            .filter(|&(reg, opnd)| Opnd::Reg(reg) != opnd).collect();
+        let mut old_moves: Vec<(Reg, Opnd)> = old_moves.into_iter()
+            .filter(|&&(reg, opnd)| Opnd::Reg(reg) != opnd).copied().collect();
 
         let mut new_moves = vec![];
         while old_moves.len() > 0 {
@@ -1385,6 +1385,7 @@ impl Assembler
     /// Sets the out field on the various instructions that require allocated
     /// registers because their output is used as the operand on a subsequent
     /// instruction. This is our implementation of the linear scan algorithm.
+    #[allow(clippy::useless_conversion)]
     pub(super) fn alloc_regs(mut self, regs: Vec<Reg>) -> Assembler
     {
         //dbg!(&self);
@@ -1394,7 +1395,7 @@ impl Assembler
 
         // Mutate the pool bitmap to indicate that the register at that index
         // has been allocated and is live.
-        fn alloc_reg(pool: &mut u32, regs: &Vec<Reg>) -> Option<Reg> {
+        fn alloc_reg(pool: &mut u32, regs: &[Reg]) -> Option<Reg> {
             for (index, reg) in regs.iter().enumerate() {
                 if (*pool & (1 << index)) == 0 {
                     *pool |= 1 << index;
@@ -1405,7 +1406,7 @@ impl Assembler
         }
 
         // Allocate a specific register
-        fn take_reg(pool: &mut u32, regs: &Vec<Reg>, reg: &Reg) -> Reg {
+        fn take_reg(pool: &mut u32, regs: &[Reg], reg: &Reg) -> Reg {
             let reg_index = regs.iter().position(|elem| elem.reg_no == reg.reg_no);
 
             if let Some(reg_index) = reg_index {
@@ -1419,7 +1420,7 @@ impl Assembler
         // Mutate the pool bitmap to indicate that the given register is being
         // returned as it is no longer used by the instruction that previously
         // held it.
-        fn dealloc_reg(pool: &mut u32, regs: &Vec<Reg>, reg: &Reg) {
+        fn dealloc_reg(pool: &mut u32, regs: &[Reg], reg: &Reg) {
             let reg_index = regs.iter().position(|elem| elem.reg_no == reg.reg_no);
 
             if let Some(reg_index) = reg_index {
@@ -1602,7 +1603,7 @@ impl Assembler
                 if c_args.len() > 0 {
                     // Resolve C argument dependencies
                     let c_args_len = c_args.len() as isize;
-                    let moves = Self::reorder_reg_moves(&c_args.drain(..).into_iter().collect());
+                    let moves = Self::reorder_reg_moves(&c_args.drain(..).into_iter().collect::<Vec<_>>());
                     shift_live_ranges(&mut shifted_live_ranges, asm.insns.len(), moves.len() as isize - c_args_len);
 
                     // Push batched C arguments
@@ -1751,7 +1752,7 @@ impl Assembler {
     }
 
     pub fn bake_string(&mut self, text: &str) {
-        self.push_insn(Insn::BakeString(text.to_string()));
+        self.push_insn(Insn::BakeString(text.into()));
     }
 
     #[allow(dead_code)]
@@ -1791,7 +1792,7 @@ impl Assembler {
     }
 
     /// Let vm_check_canary() assert the leafness of this ccall if leaf_ccall is set
-    fn set_stack_canary(&mut self, opnds: &Vec<Opnd>) -> Option<Opnd> {
+    fn set_stack_canary(&mut self, opnds: &[Opnd]) -> Option<Opnd> {
         // Use the slot right above the stack top for verifying leafness.
         let canary_opnd = self.stack_opnd(-1);
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -97,7 +97,7 @@ pub type size_t = u64;
 pub type RedefinitionFlag = u32;
 
 #[allow(dead_code)]
-#[allow(clippy::all)]
+#[allow(clippy::complexity)]
 mod autogened {
     use super::*;
     // Textually include output from rust-bindgen as suggested by its user guide.
@@ -223,7 +223,7 @@ pub fn insn_name(opcode: usize) -> String {
         let op_name = CStr::from_ptr(op_name).to_str().unwrap();
 
         // Convert into an owned string
-        op_name.to_string()
+        op_name.into()
     }
 }
 
@@ -619,7 +619,7 @@ pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> Option<String> {
     let c_str: &CStr = unsafe { CStr::from_ptr(c_char_ptr) };
 
     match c_str.to_str() {
-        Ok(rust_str) => Some(rust_str.to_string()),
+        Ok(rust_str) => Some(rust_str.into()),
         Err(_) => None
     }
 }

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -69,7 +69,7 @@ pub extern "C" fn rb_yjit_disasm_iseq(_ec: EcPtr, _ruby_self: VALUE, iseqw: VALU
 /// Only call while holding the VM lock.
 #[cfg(feature = "disasm")]
 pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u16, end_idx: u16) -> String {
-    let mut out = String::from("");
+    let mut out = String::new();
 
     // Get a list of block versions generated for this iseq
     let block_list = get_or_create_iseq_block_list(iseq);
@@ -161,7 +161,7 @@ pub fn dump_disasm_addr_range(cb: &CodeBlock, start_addr: CodePtr, end_addr: Cod
 
 #[cfg(feature = "disasm")]
 pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> String {
-    let mut out = String::from("");
+    let mut out = String::new();
 
     // Initialize capstone
     use capstone::prelude::*;

--- a/yjit/src/lib.rs
+++ b/yjit/src/lib.rs
@@ -1,8 +1,3 @@
-// Clippy disagreements
-#![allow(clippy::style)] // We are laid back about style
-#![allow(clippy::too_many_arguments)] // :shrug:
-#![allow(clippy::identity_op)] // Sometimes we do it for style
-
 // TODO(alan): This lint is right -- the way we use `static mut` is UB happy. We have many globals
 // and take `&mut` frequently, sometimes with a method that easily allows calling it twice.
 //

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -115,7 +115,7 @@ pub static mut OPTIONS: Options = Options {
 
 /// YJIT option descriptions for `ruby --help`.
 /// Note that --help allows only 80 characters per line, including indentation.   80-character limit --> |
-pub const YJIT_OPTIONS: &'static [(&str, &str)] = &[
+pub const YJIT_OPTIONS: &[(&str, &str)] = &[
     ("--yjit-mem-size=num",                "Soft limit on YJIT memory usage in MiB (default: 128)."),
     ("--yjit-exec-mem-size=num",           "Hard limit on executable memory block in MiB."),
     ("--yjit-call-threshold=num",          "Number of calls to trigger JIT."),
@@ -319,7 +319,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                 eprintln!("WARNING: the {} option is only available when YJIT is built in dev mode, i.e. ./configure --enable-yjit=dev", opt_name);
             }
 
-            OPTIONS.dump_iseq_disasm = Some(opt_val.to_string());
+            OPTIONS.dump_iseq_disasm = Some(opt_val.into());
         },
 
         ("no-type-prop", "") => unsafe { OPTIONS.no_type_prop = true },
@@ -346,7 +346,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                 let log_file_path = if std::path::Path::new(arg_value).is_dir() {
                     format!("{arg_value}/yjit_{}.log", std::process::id())
                 } else {
-                    arg_value.to_string()
+                    arg_value.into()
                 };
 
                 match File::options().create(true).write(true).truncate(true).open(&log_file_path) {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -95,7 +95,7 @@ fn get_method_idx(
         Some(idx) => *idx,
         None => {
             let idx = name_to_idx.len();
-            name_to_idx.insert(name.to_string(), idx);
+            name_to_idx.insert(name.into(), idx);
 
             // Resize the call count vector
             if idx >= call_count.len() {
@@ -269,7 +269,7 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: &'static [Counter] = &[
+pub const DEFAULT_COUNTERS: &[Counter] = &[
     Counter::code_gc_count,
     Counter::compiled_iseq_entry,
     Counter::cold_iseq_entry,

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -92,10 +92,7 @@ pub fn ruby_str_to_rust(v: VALUE) -> String {
     let str_ptr = unsafe { rb_RSTRING_PTR(v) } as *mut u8;
     let str_len: usize = unsafe { rb_RSTRING_LEN(v) }.try_into().unwrap();
     let str_slice: &[u8] = unsafe { slice::from_raw_parts(str_ptr, str_len) };
-    match String::from_utf8(str_slice.to_vec()) {
-        Ok(utf8) => utf8,
-        Err(_) => String::new(),
-    }
+    String::from_utf8(str_slice.to_vec()).unwrap_or_default()
 }
 
 // Location is the file defining the method, colon, method name.
@@ -107,17 +104,17 @@ pub fn iseq_get_location(iseq: IseqPtr, pos: u16) -> String {
     let iseq_lineno = unsafe { rb_iseq_line_no(iseq, pos as usize) };
 
     let mut s = if iseq_label == Qnil {
-        "None".to_string()
+        "None".into()
     } else {
         ruby_str_to_rust(iseq_label)
     };
-    s.push_str("@");
+    s.push('@');
     if iseq_path == Qnil {
         s.push_str("None");
     } else {
         s.push_str(&ruby_str_to_rust(iseq_path));
     }
-    s.push_str(":");
+    s.push(':');
     s.push_str(&iseq_lineno.to_string());
     s
 }

--- a/zjit/Cargo.toml
+++ b/zjit/Cargo.toml
@@ -19,3 +19,6 @@ expect-test = "1.5.1"
 # Support --yjit-dump-disasm and RubyVM::YJIT.disasm using libcapstone.
 disasm = ["capstone"]
 runtime_checks = []
+
+[lints]
+workspace = true

--- a/zjit/build.rs
+++ b/zjit/build.rs
@@ -13,7 +13,7 @@ fn main() {
         // ordered after -lminiruby above.
         let link_flags = env::var("RUBY_LD_FLAGS").unwrap();
 
-        let mut split_iter = link_flags.split(" ");
+        let mut split_iter = link_flags.split(' ');
         while let Some(token) = split_iter.next() {
             if token == "-framework" {
                 if let Some(framework) = split_iter.next() {

--- a/zjit/src/asm/arm64/opnd.rs
+++ b/zjit/src/asm/arm64/opnd.rs
@@ -79,10 +79,7 @@ impl A64Opnd {
 
     /// Convenience function to check if this operand is a register.
     pub fn is_reg(&self) -> bool {
-        match self {
-            A64Opnd::Reg(_) => true,
-            _ => false
-        }
+        matches!(self, A64Opnd::Reg(_))
     }
 
     /// Unwrap a register from an operand.

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -97,7 +97,7 @@ impl CodeBlock {
 
         // Unless this comment is the same as the last one at this same line, add it.
         if this_line_comments.last().map(String::as_str) != Some(comment) {
-            this_line_comments.push(comment.to_string());
+            this_line_comments.push(comment.into());
         }
     }
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -16,7 +16,7 @@ pub use crate::backend::current::{
     C_ARG_OPNDS, C_RET_REG, C_RET_OPND,
 };
 
-pub static JIT_PRESERVED_REGS: &'static [Opnd] = &[CFP, SP, EC];
+pub static JIT_PRESERVED_REGS: &[Opnd] = &[CFP, SP, EC];
 
 // Memory operand base
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -97,8 +97,8 @@ impl Opnd
                 assert!(base_reg.num_bits == 64);
                 Opnd::Mem(Mem {
                     base: MemBase::Reg(base_reg.reg_no),
-                    disp: disp,
-                    num_bits: num_bits,
+                    disp,
+                    num_bits,
                 })
             },
 
@@ -106,8 +106,8 @@ impl Opnd
                 assert!(num_bits <= out_num_bits);
                 Opnd::Mem(Mem {
                     base: MemBase::VReg(idx),
-                    disp: disp,
-                    num_bits: num_bits,
+                    disp,
+                    num_bits,
                 })
             },
 
@@ -1354,7 +1354,7 @@ impl Assembler
         assert!(!name.contains(' '), "use underscores in label names, not spaces");
 
         let label = Label(self.label_names.len());
-        self.label_names.push(name.to_string());
+        self.label_names.push(name.into());
         Target::Label(label)
     }
 
@@ -1518,17 +1518,17 @@ impl Assembler
 
     // Shuffle register moves, sometimes adding extra moves using SCRATCH_REG,
     // so that they will not rewrite each other before they are used.
-    pub fn resolve_parallel_moves(old_moves: &Vec<(Reg, Opnd)>) -> Vec<(Reg, Opnd)> {
+    pub fn resolve_parallel_moves(old_moves: &[(Reg, Opnd)]) -> Vec<(Reg, Opnd)> {
         // Return the index of a move whose destination is not used as a source if any.
-        fn find_safe_move(moves: &Vec<(Reg, Opnd)>) -> Option<usize> {
+        fn find_safe_move(moves: &[(Reg, Opnd)]) -> Option<usize> {
             moves.iter().enumerate().find(|&(_, &(dest_reg, _))| {
                 moves.iter().all(|&(_, src_opnd)| src_opnd != Opnd::Reg(dest_reg))
             }).map(|(index, _)| index)
         }
 
         // Remove moves whose source and destination are the same
-        let mut old_moves: Vec<(Reg, Opnd)> = old_moves.clone().into_iter()
-            .filter(|&(reg, opnd)| Opnd::Reg(reg) != opnd).collect();
+        let mut old_moves: Vec<(Reg, Opnd)> = old_moves.iter()
+            .filter(|&(reg, opnd)| Opnd::Reg(*reg) != *opnd).copied().collect();
 
         let mut new_moves = vec![];
         while !old_moves.is_empty() {
@@ -1696,21 +1696,19 @@ impl Assembler
                 // Allocate a new register for this instruction if one is not
                 // already allocated.
                 if out_reg.is_none() {
-                    out_reg = match &insn {
-                        _ => match pool.alloc_reg(vreg_idx.unwrap()) {
-                            Some(reg) => Some(reg),
-                            None => {
-                                if get_option!(debug) {
-                                    let mut insns = asm.insns;
+                    out_reg = match pool.alloc_reg(vreg_idx.unwrap()) {
+                        Some(reg) => Some(reg),
+                        None => {
+                            if get_option!(debug) {
+                                let mut insns = asm.insns;
+                                insns.push(insn);
+                                for (_, insn) in iterator.by_ref() {
                                     insns.push(insn);
-                                    while let Some((_, insn)) = iterator.next() {
-                                        insns.push(insn);
-                                    }
-                                    dump_live_regs(insns, live_ranges, regs.len(), index);
                                 }
-                                debug!("Register spill not supported");
-                                return None;
+                                dump_live_regs(insns, live_ranges, regs.len(), index);
                             }
+                            debug!("Register spill not supported");
+                            return None;
                         }
                     };
                 }
@@ -1771,7 +1769,7 @@ impl Assembler
             if is_ccall {
                 // On x86_64, maintain 16-byte stack alignment
                 if cfg!(target_arch = "x86_64") && saved_regs.len() % 2 == 1 {
-                    asm.cpop_into(Opnd::Reg(saved_regs.last().unwrap().0.clone()));
+                    asm.cpop_into(Opnd::Reg(saved_regs.last().unwrap().0));
                 }
                 // Restore saved registers
                 for &(reg, vreg_idx) in saved_regs.iter().rev() {
@@ -1830,7 +1828,7 @@ impl Assembler
                 let side_exit_label = if let Some(label) = label {
                     Target::Label(label)
                 } else {
-                    self.new_label("side_exit".into())
+                    self.new_label("side_exit")
                 };
                 self.write_label(side_exit_label.clone());
 
@@ -1902,7 +1900,7 @@ impl Assembler {
     }
 
     pub fn bake_string(&mut self, text: &str) {
-        self.push_insn(Insn::BakeString(text.to_string()));
+        self.push_insn(Insn::BakeString(text.into()));
     }
 
     #[allow(dead_code)]

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -113,7 +113,7 @@ fn annotate_builtin_method(props_map: &mut HashMap<*mut c_void, FnProperties>, c
                opcode == YARVINSN_opt_invokebuiltin_delegate_leave as i32 {
                 // The first operand is the builtin function pointer
                 let bf_value = *pc.add(1);
-                let bf_ptr = bf_value.as_ptr() as *const rb_builtin_function;
+                let bf_ptr = bf_value.as_ptr::<rb_builtin_function>();
 
                 if func_ptr.is_null() {
                     func_ptr = (*bf_ptr).func_ptr as *mut c_void;

--- a/zjit/src/disasm.rs
+++ b/zjit/src/disasm.rs
@@ -6,7 +6,7 @@ pub const BOLD_END: &str = "\x1b[22m";
 pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> String {
     use std::fmt::Write;
 
-    let mut out = String::from("");
+    let mut out = String::new();
 
     // Initialize capstone
     use capstone::prelude::*;

--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -105,7 +105,7 @@ impl<T: Copy + PartialEq + Default + std::fmt::Debug, const N: usize> Distributi
                 DistributionKind::Megamorphic
             }
         };
-        Self { kind, buckets: dist.buckets.clone() }
+        Self { kind, buckets: dist.buckets }
     }
 
     pub fn is_monomorphic(&self) -> bool {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -19,9 +19,9 @@ use crate::profile::{TypeDistributionSummary, ProfiledType};
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct InsnId(pub usize);
 
-impl Into<usize> for InsnId {
-    fn into(self) -> usize {
-        self.0
+impl From<InsnId> for usize {
+    fn from(val: InsnId) -> Self {
+        val.0
     }
 }
 
@@ -35,9 +35,9 @@ impl std::fmt::Display for InsnId {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct BlockId(pub usize);
 
-impl Into<usize> for BlockId {
-    fn into(self) -> usize {
-        self.0
+impl From<BlockId> for usize {
+    fn from(val: BlockId) -> Self {
+        val.0
     }
 }
 
@@ -573,22 +573,16 @@ pub enum Insn {
 impl Insn {
     /// Not every instruction returns a value. Return true if the instruction does and false otherwise.
     pub fn has_output(&self) -> bool {
-        match self {
-            Insn::Jump(_)
+        !matches!(self, Insn::Jump(_)
             | Insn::IfTrue { .. } | Insn::IfFalse { .. } | Insn::Return { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetGlobal { .. }
-            | Insn::SetLocal { .. } | Insn::Throw { .. } | Insn::IncrCounter(_) => false,
-            _ => true,
-        }
+            | Insn::SetLocal { .. } | Insn::Throw { .. } | Insn::IncrCounter(_))
     }
 
     /// Return true if the instruction ends a basic block and false otherwise.
     pub fn is_terminator(&self) -> bool {
-        match self {
-            Insn::Jump(_) | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => true,
-            _ => false,
-        }
+        matches!(self, Insn::Jump(_) | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. })
     }
 
     pub fn print<'a>(&self, ptr_map: &'a PtrPrintMap) -> InsnPrinter<'a> {
@@ -898,7 +892,7 @@ impl<T: Copy + Into<usize> + PartialEq> UnionFind<T> {
 
     /// Private. Return the internal representation of the forwarding pointer for a given element.
     fn at(&self, idx: T) -> Option<T> {
-        self.forwarded.get(idx.into()).map(|x| *x).flatten()
+        self.forwarded.get(idx.into()).and_then(|x| *x)
     }
 
     /// Private. Set the internal representation of the forwarding pointer for the given element
@@ -963,6 +957,7 @@ pub enum ValidationError {
     DuplicateInstruction(BlockId, InsnId),
 }
 
+#[allow(clippy::needless_bool)]
 fn can_direct_send(iseq: *const rb_iseq_t) -> bool {
     if unsafe { rb_get_iseq_flags_has_rest(iseq) } { false }
     else if unsafe { rb_get_iseq_flags_has_opt(iseq) } { false }
@@ -1051,8 +1046,7 @@ impl Function {
 
     fn new_block(&mut self, insn_idx: u32) -> BlockId {
         let id = BlockId(self.blocks.len());
-        let mut block = Block::default();
-        block.insn_idx = insn_idx;
+        let block = Block { insn_idx, ..Default::default() };
         self.blocks.push(block);
         id
     }
@@ -1137,11 +1131,11 @@ impl Function {
             &StringIntern { val } => StringIntern { val: find!(val) },
             &Test { val } => Test { val: find!(val) },
             &IsNil { val } => IsNil { val: find!(val) },
-            &Jump(ref target) => Jump(find_branch_edge!(target)),
+            Jump(target) => Jump(find_branch_edge!(target)),
             &IfTrue { val, ref target } => IfTrue { val: find!(val), target: find_branch_edge!(target) },
             &IfFalse { val, ref target } => IfFalse { val: find!(val), target: find_branch_edge!(target) },
-            &GuardType { val, guard_type, state } => GuardType { val: find!(val), guard_type: guard_type, state },
-            &GuardBitEquals { val, expected, state } => GuardBitEquals { val: find!(val), expected: expected, state },
+            &GuardType { val, guard_type, state } => GuardType { val: find!(val), guard_type, state },
+            &GuardBitEquals { val, expected, state } => GuardBitEquals { val: find!(val), expected, state },
             &FixnumAdd { left, right, state } => FixnumAdd { left: find!(left), right: find!(right), state },
             &FixnumSub { left, right, state } => FixnumSub { left: find!(left), right: find!(right), state },
             &FixnumMult { left, right, state } => FixnumMult { left: find!(left), right: find!(right), state },
@@ -1157,7 +1151,7 @@ impl Function {
             &FixnumOr { left, right } => FixnumOr { left: find!(left), right: find!(right) },
             &ObjToString { val, cd, state } => ObjToString {
                 val: find!(val),
-                cd: cd,
+                cd,
                 state,
             },
             &AnyToString { val, str, state } => AnyToString {
@@ -1167,22 +1161,22 @@ impl Function {
             },
             &SendWithoutBlock { self_val, cd, ref args, state } => SendWithoutBlock {
                 self_val: find!(self_val),
-                cd: cd,
+                cd,
                 args: find_vec!(args),
                 state,
             },
             &SendWithoutBlockDirect { self_val, cd, cme, iseq, ref args, state } => SendWithoutBlockDirect {
                 self_val: find!(self_val),
-                cd: cd,
-                cme: cme,
-                iseq: iseq,
+                cd,
+                cme,
+                iseq,
                 args: find_vec!(args),
                 state,
             },
             &Send { self_val, cd, blockiseq, ref args, state } => Send {
                 self_val: find!(self_val),
-                cd: cd,
-                blockiseq: blockiseq,
+                cd,
+                blockiseq,
                 args: find_vec!(args),
                 state,
             },
@@ -1391,19 +1385,19 @@ impl Function {
     }
 
     fn likely_is_fixnum(&self, val: InsnId, profiled_type: ProfiledType) -> bool {
-        return self.is_a(val, types::Fixnum) || profiled_type.is_fixnum();
+        self.is_a(val, types::Fixnum) || profiled_type.is_fixnum()
     }
 
     fn coerce_to_fixnum(&mut self, block: BlockId, val: InsnId, state: InsnId) -> InsnId {
         if self.is_a(val, types::Fixnum) { return val; }
-        return self.push_insn(block, Insn::GuardType { val, guard_type: types::Fixnum, state });
+        self.push_insn(block, Insn::GuardType { val, guard_type: types::Fixnum, state })
     }
 
     fn arguments_likely_fixnums(&mut self, left: InsnId, right: InsnId, state: InsnId) -> bool {
         let frame_state = self.frame_state(state);
-        let iseq_insn_idx = frame_state.insn_idx as usize;
-        let left_profiled_type = self.profiled_type_of_at(left, iseq_insn_idx).unwrap_or(ProfiledType::empty());
-        let right_profiled_type = self.profiled_type_of_at(right, iseq_insn_idx).unwrap_or(ProfiledType::empty());
+        let iseq_insn_idx = frame_state.insn_idx;
+        let left_profiled_type = self.profiled_type_of_at(left, iseq_insn_idx).unwrap_or_default();
+        let right_profiled_type = self.profiled_type_of_at(right, iseq_insn_idx).unwrap_or_default();
         self.likely_is_fixnum(left, left_profiled_type) && self.likely_is_fixnum(right, right_profiled_type)
     }
 
@@ -1524,9 +1518,9 @@ impl Function {
                         self.try_rewrite_fixnum_op(block, insn_id, &|left, right| Insn::FixnumAnd { left, right }, BOP_AND, self_val, args[0], state),
                     Insn::SendWithoutBlock { self_val, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(or) && args.len() == 1 =>
                         self.try_rewrite_fixnum_op(block, insn_id, &|left, right| Insn::FixnumOr { left, right }, BOP_OR, self_val, args[0], state),
-                    Insn::SendWithoutBlock { self_val, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(freeze) && args.len() == 0 =>
+                    Insn::SendWithoutBlock { self_val, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(freeze) && args.is_empty() =>
                         self.try_rewrite_freeze(block, insn_id, self_val, state),
-                    Insn::SendWithoutBlock { self_val, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.len() == 0 =>
+                    Insn::SendWithoutBlock { self_val, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
                         self.try_rewrite_uminus(block, insn_id, self_val, state),
                     Insn::SendWithoutBlock { self_val, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(aref) && args.len() == 1 =>
                         self.try_rewrite_aref(block, insn_id, self_val, args[0], state),
@@ -1904,7 +1898,7 @@ impl Function {
                 worklist.push_back(val);
                 worklist.push_back(state);
             }
-            &Insn::Snapshot { ref state } => {
+            Insn::Snapshot { state } => {
                 worklist.extend(&state.stack);
                 worklist.extend(&state.locals);
             }
@@ -1951,7 +1945,7 @@ impl Function {
                 worklist.extend(args);
                 worklist.push_back(state)
             }
-            &Insn::CCall { ref args, .. } => worklist.extend(args),
+            Insn::CCall { args, .. } => worklist.extend(args),
             &Insn::GetIvar { self_val, state, .. } | &Insn::DefinedIvar { self_val, state, .. } => {
                 worklist.push_back(self_val);
                 worklist.push_back(state);
@@ -2008,7 +2002,7 @@ impl Function {
         }
     }
 
-    fn absorb_dst_block(&mut self, num_in_edges: &Vec<u32>, block: BlockId) -> bool {
+    fn absorb_dst_block(&mut self, num_in_edges: &[u32], block: BlockId) -> bool {
         let Some(terminator_id) = self.blocks[block.0].insns.last()
             else { return false };
         let Insn::Jump(BranchEdge { target, args }) = self.find(*terminator_id)
@@ -2127,8 +2121,8 @@ impl Function {
 
         // Dump HIR after optimization
         match get_option!(dump_hir_opt) {
-            Some(DumpHIR::WithoutSnapshot) => println!("Optimized HIR:\n{}", FunctionPrinter::without_snapshot(&self)),
-            Some(DumpHIR::All) => println!("Optimized HIR:\n{}", FunctionPrinter::with_snapshot(&self)),
+            Some(DumpHIR::WithoutSnapshot) => println!("Optimized HIR:\n{}", FunctionPrinter::without_snapshot(self)),
+            Some(DumpHIR::All) => println!("Optimized HIR:\n{}", FunctionPrinter::with_snapshot(self)),
             Some(DumpHIR::Debug) => println!("Optimized HIR:\n{:#?}", &self),
             None => {},
         }
@@ -2504,7 +2498,7 @@ impl FrameState {
         // TODO: Modify the register allocator to allow reusing an argument
         // of another basic block.
         let mut args = vec![self_param];
-        args.extend(self.locals.iter().chain(self.stack.iter()).map(|op| *op));
+        args.extend(self.locals.iter().chain(self.stack.iter()).copied());
         args
     }
 }
@@ -2639,7 +2633,7 @@ impl ProfileOracle {
     fn profile_stack(&mut self, state: &FrameState) {
         let iseq_insn_idx = state.insn_idx;
         let Some(operand_types) = self.payload.profile.get_operand_types(iseq_insn_idx) else { return };
-        let entry = self.types.entry(iseq_insn_idx).or_insert_with(|| vec![]);
+        let entry = self.types.entry(iseq_insn_idx).or_default();
         // operand_types is always going to be <= stack size (otherwise it would have an underflow
         // at run-time) so use that to drive iteration.
         for (idx, insn_type_distribution) in operand_types.iter().rev().enumerate() {

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -66,7 +66,7 @@ mod bits {
   pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
   pub const TrueClass: u64 = 1u64 << 40;
   pub const Undef: u64 = 1u64 << 41;
-  pub const AllBitPatterns: [(&'static str, u64); 66] = [
+  pub const AllBitPatterns: [(&str, u64); 66] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn integer_has_exact_ruby_class() {
-        assert_eq!(Type::fixnum(3).exact_ruby_class(), Some(unsafe { rb_cInteger }.into()));
+        assert_eq!(Type::fixnum(3).exact_ruby_class(), Some(unsafe { rb_cInteger }));
         assert_eq!(types::Fixnum.exact_ruby_class(), None);
         assert_eq!(types::Integer.exact_ruby_class(), None);
     }
@@ -665,7 +665,7 @@ mod tests {
 
     #[test]
     fn integer_has_ruby_class() {
-        assert_eq!(Type::fixnum(3).inexact_ruby_class(), Some(unsafe { rb_cInteger }.into()));
+        assert_eq!(Type::fixnum(3).inexact_ruby_class(), Some(unsafe { rb_cInteger }));
         assert_eq!(types::Fixnum.inexact_ruby_class(), None);
         assert_eq!(types::Integer.inexact_ruby_class(), None);
     }

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -75,7 +75,7 @@ impl Default for Options {
 
 /// `ruby --help` descriptions for user-facing options. Do not add options for ZJIT developers.
 /// Note that --help allows only 80 chars per line, including indentation.    80-char limit --> |
-pub const ZJIT_OPTIONS: &'static [(&str, &str)] = &[
+pub const ZJIT_OPTIONS: &[(&str, &str)] = &[
     ("--zjit-call-threshold=num", "Number of calls to trigger JIT (default: 2)."),
     ("--zjit-num-profiles=num",   "Number of profiled calls before JIT (default: 1, max: 255)."),
     ("--zjit-stats",              "Enable collecting ZJIT statistics."),
@@ -128,7 +128,7 @@ fn parse_jit_list(path_like: &str) -> HashSet<String> {
         for line in lines.lines() {
             let trimmed = line.trim();
             if !trimmed.is_empty() {
-                result.insert(trimmed.to_string());
+                result.insert(trimmed.into());
             }
         }
     } else {

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -78,7 +78,7 @@ impl ZJITState {
             );
             let mem_block = Rc::new(RefCell::new(mem_block));
 
-            CodeBlock::new(mem_block.clone(), get_option!(dump_disasm))
+            CodeBlock::new(mem_block, get_option!(dump_disasm))
         };
         #[cfg(test)]
         let mut cb = CodeBlock::new_dummy();


### PR DESCRIPTION
Move clippy lint configuration (which is declarative) from lib.rs into Cargo.toml.

## Lint Groups

Forbid: correctness, suspicious, perf
Deny: complexity
Allow: pedantic, style, restricted

Can be overridden with allow in code or with specific lint?
- Deny = Yes
- Forbid = No

## Individual Lints

### Allow from complexity

```
too_many_arguments = "allow"
identity_op = "allow"
```

### Deny from allowed groups

```
ptr_arg = "forbid"
ref_option = "forbid"
inefficient_to_string = "forbid"
from_over_into = "forbid"
unwrap_or_default = "forbid"
redundant_static_lifetimes = "forbid"
match_like_matches_macro = "forbid"
field_reassign_with_default = "forbid"
inherent_to_string = "forbid"
owned_cow = "forbid"
redundant_clone = "forbid"
str_to_string = "forbid"
single_char_pattern = "forbid"
single_char_add_str = "forbid"
unnecessary_owned_empty_strings = "forbid"
manual_string_new = "forbid"
```

## Resources

- https://doc.rust-lang.org/clippy/lints.html
- https://rust-lang.github.io/rust-clippy/master/index.html