### PR TITLE
[DOC] Example usage for --zjit-dump-hir

### DIFF
--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -306,6 +306,14 @@ A file called `zjit_exits_{pid}.dump` will be created in the same directory as `
 stackprof path/to/zjit_exits_{pid}.dump
 ```
 
+### Viewing HIR as text
+
+The compiled zjit HIR can be viewed as text using the `--zjit-dump-hir` option. However, HIR will only be generated if the `zjit-call-threshold` is reached (default 30). By setting the threshold to 1 you can easily view the HIR for code snippets such as `1 + 1`:
+
+```bash
+./miniruby --zjit --zjit-dump-hir --zjit-call-threshold=1 -e "1 + 1"
+```
+
 ### Viewing HIR in Iongraph
 
 Using `--zjit-dump-hir-iongraph` will dump all compiled functions into a directory named `/tmp/zjit-iongraph-{PROCESS_PID}`. Each file will be named `func_{ZJIT_FUNC_NAME}.json`. In order to use them in the Iongraph viewer, you'll need to use `jq` to collate them to a single file. An example invocation of `jq` is shown below for reference.

--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -308,10 +308,17 @@ stackprof path/to/zjit_exits_{pid}.dump
 
 ### Viewing HIR as text
 
-The compiled zjit HIR can be viewed as text using the `--zjit-dump-hir` option. However, HIR will only be generated if the `zjit-call-threshold` is reached (default 30). By setting the threshold to 1 you can easily view the HIR for code snippets such as `1 + 1`:
+The compiled ZJIT HIR can be viewed as text using the `--zjit-dump-hir` option. However, HIR will only be generated if the call threshold is reached (default 30). By setting the threshold to 1 you can easily view the HIR for code snippets such as `1 + 1`:
 
 ```bash
 ./miniruby --zjit --zjit-dump-hir --zjit-call-threshold=1 -e "1 + 1"
+```
+
+Note that this disables profiling. To inject interpreter profiles into ZJIT, consider running your sample code 30 times:
+
+```bash
+./miniruby --zjit --zjit-dump-hir -e "30.times { 1 + 1 }"
+```
 ```
 
 ### Viewing HIR in Iongraph


### PR DESCRIPTION
I found learning about the HIR format difficult because I couldn't get ruby/miniruby to output it using the `--zjit-dump-hir` option. I eventually realised it won't be generated unless the `zjit-call-threshold` is reached (default 30).

I'm a new contributor to ruby. Any guidance is greatly appreciated :pray: 