### PR TITLE
gc: prevent LTO from eliminating rb_gc_before_fork

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5435,6 +5435,7 @@ rb_obj_info_dump_loc(VALUE obj, const char *file, int line, const char *func)
     fprintf(stderr, "<OBJ_INFO:%s@%s:%d> %s\n", func, file, line, rb_raw_obj_info(buff, 0x100, obj));
 }
 
+RBIMPL_ATTR_NOINLINE()
 void
 rb_gc_before_fork(void)
 {

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -9407,6 +9407,8 @@ rb_gc_impl_before_fork(void *objspace_ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
+    gc_rest(objspace);
+
     objspace->fork_vm_lock_lev = RB_GC_VM_LOCK();
     rb_gc_vm_barrier();
 }


### PR DESCRIPTION
GCC LTO (`-flto=auto`) eliminates `rb_gc_before_fork()` via constprop cloning. The call is completely absent from the binary, meaning fork children can inherit an uncoordinated GC heap.

### the problem

`objdump -d` of `rb_fork_ruby.constprop.0` shows no GC barrier before `fork@plt`:

```asm
bl  rb_io_flush_raw       ; before_exec()
bl  rb_io_flush_raw
bl  pthread_rwlock_wrlock  ; rb_thread_acquire_fork_lock()
bl  sigfillset             ; disable_child_handler_before_fork()
bl  pthread_sigmask
bl  fork@plt               ; ← no rb_gc_before_fork
```

### after this patch

```asm
bl  rb_io_flush_raw
bl  rb_io_flush_raw
bl  rb_gc_before_fork      ; ← restored
bl  pthread_rwlock_wrlock
bl  sigfillset
bl  pthread_sigmask
bl  fork@plt
```

`RBIMPL_ATTR_NOINLINE()` prevents GCC from inlining `rb_gc_before_fork` into the constprop clone. `gc_rest()` completes any in-progress incremental GC cycle before forking.