### PR TITLE
Add Ractor.check_isolation

### DIFF
--- a/error.c
+++ b/error.c
@@ -89,6 +89,7 @@ static ID id_deprecated;
 static ID id_experimental;
 static ID id_performance;
 static ID id_strict_unused_block;
+static ID id_ractor_isolation;
 static VALUE sym_category;
 static VALUE sym_highlight;
 static struct {
@@ -224,6 +225,10 @@ rb_warning_category_enabled_p(rb_warning_category_t category)
  * +:performance+ ::
  *   performance hints
  *   * Shape variation limit
+ *
+ * +:ractor_isolation+ ::
+ *   Ractor isolation violations reported by Ractor.check_isolation
+ *   (downgraded from Ractor::IsolationError exceptions to warnings).
  */
 
 static VALUE
@@ -3884,6 +3889,7 @@ Init_Exception(void)
     id_experimental = rb_intern_const("experimental");
     id_performance = rb_intern_const("performance");
     id_strict_unused_block = rb_intern_const("strict_unused_block");
+    id_ractor_isolation = rb_intern_const("ractor_isolation");
     id_top = rb_intern_const("top");
     id_bottom = rb_intern_const("bottom");
     id_iseq = rb_make_internal_id();
@@ -3897,6 +3903,7 @@ Init_Exception(void)
     st_add_direct(warning_categories.id2enum, id_experimental, RB_WARN_CATEGORY_EXPERIMENTAL);
     st_add_direct(warning_categories.id2enum, id_performance, RB_WARN_CATEGORY_PERFORMANCE);
     st_add_direct(warning_categories.id2enum, id_strict_unused_block, RB_WARN_CATEGORY_STRICT_UNUSED_BLOCK);
+    st_add_direct(warning_categories.id2enum, id_ractor_isolation, RB_WARN_CATEGORY_RACTOR_ISOLATION);
 
     warning_categories.enum2id = rb_init_identtable();
     st_add_direct(warning_categories.enum2id, RB_WARN_CATEGORY_NONE, 0);
@@ -3904,6 +3911,7 @@ Init_Exception(void)
     st_add_direct(warning_categories.enum2id, RB_WARN_CATEGORY_EXPERIMENTAL, id_experimental);
     st_add_direct(warning_categories.enum2id, RB_WARN_CATEGORY_PERFORMANCE, id_performance);
     st_add_direct(warning_categories.enum2id, RB_WARN_CATEGORY_STRICT_UNUSED_BLOCK, id_strict_unused_block);
+    st_add_direct(warning_categories.enum2id, RB_WARN_CATEGORY_RACTOR_ISOLATION, id_ractor_isolation);
 }
 
 void

--- a/gc.c
+++ b/gc.c
@@ -2097,6 +2097,12 @@ rb_undefine_finalizer(VALUE obj)
 {
     rb_check_frozen(obj);
 
+    if (rb_gc_obj_foreign_p(obj)) {
+        rb_ractor_isolation_violation(
+            "can not undefine a finalizer of an object of another Ractor");
+        return obj;
+    }
+
     rb_gc_impl_undefine_finalizer(rb_gc_get_objspace(), obj);
 
     return obj;
@@ -2217,7 +2223,13 @@ rb_define_finalizer(VALUE obj, VALUE block)
     should_be_finalizable(obj);
     should_be_callable(block);
 
-    block = rb_gc_impl_define_finalizer(rb_gc_get_objspace(), obj, block);
+    if (rb_gc_obj_foreign_p(obj)) {
+        rb_ractor_isolation_violation(
+            "can not define a finalizer for an object of another Ractor");
+    }
+    else {
+        block = rb_gc_impl_define_finalizer(rb_gc_get_objspace(), obj, block);
+    }
 
     block = rb_ary_new3(2, INT2FIX(0), block);
     OBJ_FREEZE(block);

--- a/include/ruby/internal/error.h
+++ b/include/ruby/internal/error.h
@@ -56,9 +56,13 @@ typedef enum {
     /** Warning is for checking unused block strictly */
     RB_WARN_CATEGORY_STRICT_UNUSED_BLOCK,
 
+    /** Warning is for Ractor isolation violations reported by Ractor.check_isolation. */
+    RB_WARN_CATEGORY_RACTOR_ISOLATION,
+
     RB_WARN_CATEGORY_DEFAULT_BITS = (
         (1U << RB_WARN_CATEGORY_DEPRECATED) |
         (1U << RB_WARN_CATEGORY_EXPERIMENTAL) |
+        (1U << RB_WARN_CATEGORY_RACTOR_ISOLATION) |
         0),
 
     RB_WARN_CATEGORY_ALL_BITS = (
@@ -66,6 +70,7 @@ typedef enum {
         (1U << RB_WARN_CATEGORY_EXPERIMENTAL) |
         (1U << RB_WARN_CATEGORY_PERFORMANCE) |
         (1U << RB_WARN_CATEGORY_STRICT_UNUSED_BLOCK) |
+        (1U << RB_WARN_CATEGORY_RACTOR_ISOLATION) |
         0)
 } rb_warning_category_t;
 

--- a/process.c
+++ b/process.c
@@ -4109,7 +4109,7 @@ rb_pid_t
 rb_fork_ruby(int *status)
 {
     if (UNLIKELY(!rb_ractor_main_p())) {
-        rb_raise(rb_eRactorIsolationError, "can not fork from non-main Ractors");
+        rb_ractor_isolation_violation("can not fork from non-main Ractors");
     }
 
     struct rb_process_status child = {.status = 0};

--- a/ractor.c
+++ b/ractor.c
@@ -5,6 +5,7 @@
 #include "ruby/ractor.h"
 #include "ruby/re.h"
 #include "ruby/thread_native.h"
+#include "ruby_atomic.h"
 #include "vm_core.h"
 #include "vm_sync.h"
 #include "ractor_core.h"
@@ -840,11 +841,12 @@ rb_ractor_main_setup(rb_vm_t *vm, rb_ractor_t *r, rb_thread_t *th)
 }
 
 static VALUE
-ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VALUE args, VALUE block)
+ractor_create0(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VALUE args, VALUE block, bool isolation_check)
 {
     VALUE rv = ractor_alloc(self);
     rb_ractor_t *r = RACTOR_PTR(rv);
     ractor_init(r, name, loc);
+    r->isolation_check = isolation_check;
 
     r->pub.id = ractor_next_id();
     RUBY_DEBUG_LOG("r:%u", r->pub.id);
@@ -861,6 +863,12 @@ ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VAL
 
     RB_GC_GUARD(rv);
     return rv;
+}
+
+static VALUE
+ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VALUE args, VALUE block)
+{
+    return ractor_create0(ec, self, loc, name, args, block, false);
 }
 
 #if 0
@@ -1850,6 +1858,12 @@ make_shareable_check_shareable(VALUE obj)
     }
     else if (!allow_frozen_shareable_p(obj)) {
         if (!RB_TYPE_P(obj, T_DATA)) {
+            if (rb_ractor_isolation_check_p()) {
+                rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION,
+                                 "can not make shareable object of class %+"PRIsVALUE,
+                                 rb_class_of(obj));
+                return traverse_stop;
+            }
             rb_raise(rb_eRactorError,
                      "can not make shareable object for %+"PRIsVALUE, obj);
         }
@@ -1859,6 +1873,12 @@ make_shareable_check_shareable(VALUE obj)
                 RB_OBJ_SET_SHAREABLE(obj);
                 return traverse_skip;
             }
+            else if (rb_ractor_isolation_check_p()) {
+                rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION,
+                                 "can not make shareable object of class %+"PRIsVALUE
+                                 " because it refers unshareable objects", rb_class_of(obj));
+                return traverse_stop;
+            }
             else {
                 rb_raise(rb_eRactorError,
                          "can not make shareable object for %+"PRIsVALUE" because it refers unshareable objects", obj);
@@ -1866,7 +1886,13 @@ make_shareable_check_shareable(VALUE obj)
         }
         else if (rb_obj_is_proc(obj)) {
             rb_proc_ractor_make_shareable(obj, Qundef);
-            return traverse_cont;
+            return rb_ractor_shareable_p(obj) ? traverse_cont : traverse_stop;
+        }
+        else if (rb_ractor_isolation_check_p()) {
+            rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION,
+                             "can not make shareable object of class %+"PRIsVALUE,
+                             rb_class_of(obj));
+            return traverse_stop;
         }
         else {
             rb_raise(rb_eRactorError, "can not make shareable object for %+"PRIsVALUE, obj);
@@ -1930,9 +1956,10 @@ VALUE
 rb_ractor_ensure_shareable(VALUE obj, VALUE name)
 {
     if (!rb_ractor_shareable_p(obj)) {
-        VALUE message = rb_sprintf("cannot assign unshareable object to %"PRIsVALUE,
-                                   name);
-        rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, message));
+        rb_ractor_isolation_violation("cannot assign unshareable object to %"PRIsVALUE, name);
+        // In check_isolation mode the violation only warned: return obj as-is
+        // so the caller can keep going. The caller's invariant ("this is now
+        // shareable") will be wrong, which is exactly the bug we want surfaced.
     }
     return obj;
 }
@@ -1941,7 +1968,7 @@ void
 rb_ractor_ensure_main_ractor(const char *msg)
 {
     if (!rb_ractor_main_p()) {
-        rb_raise(rb_eRactorIsolationError, "%s", msg);
+        rb_ractor_isolation_violation("%s", msg);
     }
 }
 
@@ -3783,13 +3810,11 @@ ractor_local_value_store_if_absent(rb_execution_context_t *ec, VALUE self, VALUE
 static VALUE
 ractor_shareable_proc(rb_execution_context_t *ec, VALUE replace_self, bool is_lambda)
 {
-    if (!rb_ractor_shareable_p(replace_self)) {
-        rb_raise(rb_eRactorIsolationError, "self should be shareable: %" PRIsVALUE, replace_self);
+    if (!rb_ractor_shareable_p(replace_self) && !rb_ractor_isolation_check_p()) {
+        rb_ractor_isolation_violation("self should be shareable: %" PRIsVALUE, replace_self);
     }
-    else {
-        VALUE proc = is_lambda ? rb_block_lambda() : rb_block_proc();
-        return rb_proc_ractor_make_shareable(rb_proc_dup(proc), replace_self);
-    }
+    VALUE proc = is_lambda ? rb_block_lambda() : rb_block_proc();
+    return rb_proc_ractor_make_shareable(rb_proc_dup(proc), replace_self);
 }
 
 // Ractor#require
@@ -3999,6 +4024,72 @@ rb_ractor_autoload_load(VALUE module, ID name)
     else {
         return result;
     }
+}
+
+// =============================================================================
+// Ractor.check_isolation { ... }
+//
+// A development/debugging mode: the block runs in a genuine non-main Ractor,
+// without isolating its Proc or copying its arguments. Violations are
+// downgraded from Ractor::IsolationError to :ractor_isolation category warnings
+// so the program can keep running and report more than the first violation.
+//
+// As a side effect (matches Ractor semantics), the VM is switched into
+// multi-ractor mode the first time check_isolation is enabled. Multi-ractor
+// mode cannot be turned off again, so the VM keeps paying that overhead for
+// the rest of the process lifetime.
+// =============================================================================
+
+bool
+rb_ractor_isolation_check_p(void)
+{
+    rb_execution_context_t *ec = rb_current_ec_noinline();
+    if (!ec) return false;
+    rb_ractor_t *r = rb_ec_ractor_ptr(ec);
+    return r && r->isolation_check;
+}
+
+void
+rb_ractor_isolation_violation_str(VALUE message)
+{
+    if (rb_ractor_isolation_check_p()) {
+        rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION, "%s", StringValueCStr(message));
+        return;
+    }
+
+    rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, message));
+}
+
+void
+rb_ractor_isolation_violation(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    VALUE message = rb_vsprintf(fmt, args);
+    va_end(args);
+
+    rb_ractor_isolation_violation_str(message);
+}
+
+/* Set during native-thread scheduler initialization; see thread_sched.c. */
+extern int ruby_ractor_exclusive_enabled;
+
+static rb_atomic_t ractor_check_isolation_advisory_emitted;
+
+/* Return true to exactly one caller when nonexclusive mode needs its advisory.
+ * This state cannot live on Ractor itself: setting a class/module ivar from an
+ * ordinary non-main Ractor is itself an isolation violation. */
+static VALUE
+ractor_check_isolation_warn_p(rb_execution_context_t *ec, VALUE self)
+{
+    if (ruby_ractor_exclusive_enabled) return Qfalse;
+    return RBOOL(ATOMIC_EXCHANGE(ractor_check_isolation_advisory_emitted, 1) == 0);
+}
+
+static VALUE
+ractor_check_isolation_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VALUE args, VALUE block)
+{
+    return ractor_create0(ec, self, loc, name, args, block, true);
 }
 
 #include "ractor.rbinc"

--- a/ractor.rb
+++ b/ractor.rb
@@ -538,6 +538,46 @@ class Ractor
     }
   end
 
+  # call-seq:
+  #   Ractor.check_isolation(*args, name: nil) {|*args| ... } -> result of block
+  #
+  # Runs the block in a genuine non-main \Ractor while downgrading isolation
+  # violations to +:ractor_isolation+ category warnings. Unlike +Ractor.new+,
+  # the block is not isolated and its arguments are passed by reference, so it
+  # can close over and inspect existing non-shareable application state.
+  #
+  # The block therefore observes production worker-Ractor behavior:
+  # +Ractor.main?+ is false and +Ractor.current+ is the newly created \Ractor.
+  # Its return value is delivered through +Ractor#value+, and exceptions are
+  # re-raised there as for an ordinary \Ractor.
+  #
+  # On builds with M:N scheduling, booting with +RUBY_RACTOR_EXCLUSIVE=1+
+  # limits the scheduler to one shared native thread. This prevents simultaneous
+  # Ruby execution on shared native threads, but does not make the block atomic:
+  # blocking operations can hand the run slot to another \Ractor, and dedicated
+  # native threads are not covered. Without that mode, this method emits a
+  # one-time advisory because other \Ractors may run in parallel.
+  #
+  # Calling this method switches the VM into multi-Ractor mode permanently.
+  # Suppress isolation warnings with +Warning[:ractor_isolation] = false+ or
+  # +-W:no-ractor_isolation+.
+  def self.check_isolation(*args, name: nil, &block)
+    b = block # TODO: builtin bug
+    raise ArgumentError, "must be called with a block" unless block
+
+    if Primitive.ractor_check_isolation_warn_p
+      Kernel.warn("Ractor.check_isolation: other Ractors can run in parallel " \
+                  "with the isolation-check Ractor. On builds with M:N scheduling, " \
+                  "RUBY_RACTOR_EXCLUSIVE=1 prevents simultaneous Ruby execution on " \
+                  "shared native threads.", uplevel: 1)
+    end
+
+    loc = caller_locations(1, 1).first
+    loc = "#{loc.path}:#{loc.lineno}"
+    Primitive.ractor_check_isolation_create(loc, name, args, b).value
+  end
+
+
   # internal method
   def self._require feature # :nodoc:
     if main?

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -144,6 +144,7 @@ struct rb_ractor_struct {
 
     bool malloc_gc_disabled;
     bool main_ractor;
+    bool isolation_check;
     void *newobj_cache;
 
     /* This Ractor's objspace.  The main Ractor receives the boot objspace from
@@ -234,6 +235,20 @@ VALUE rb_ractor_autoload_load(VALUE space, ID id);
 
 VALUE rb_ractor_ensure_shareable(VALUE obj, VALUE name);
 st_table *rb_ractor_targeted_hooks(rb_ractor_t *cr);
+
+/* True if the current Ractor was created by Ractor.check_isolation. */
+bool rb_ractor_isolation_check_p(void);
+
+/* Report a Ractor isolation violation:
+ *   - if Ractor.check_isolation is active on the current Ractor, emit a
+ *     :ractor_isolation category warning and return;
+ *   - otherwise, raise Ractor::IsolationError (does not return).
+ *
+ * Use the printf-style overload for ad-hoc messages and the _str overload
+ * when the message is already constructed (e.g. via several rb_str_catf
+ * calls). */
+PRINTF_ARGS(void rb_ractor_isolation_violation(const char *fmt, ...), 1, 2);
+void rb_ractor_isolation_violation_str(VALUE message);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 void rb_ractor_finish_marking(bool full_mark);

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -1068,6 +1068,20 @@ ractor_prepare_payload(rb_execution_context_t *ec, VALUE obj, enum ractor_basket
             *ptype = basket_type_ref;
             return obj;
         }
+        else if (rb_ractor_isolation_check_p()) {
+            // Under Ractor.check_isolation, don't copy non-shareable messages.
+            // Copying can fail outright (e.g. Procs -> "can not copy Proc
+            // object"), which would abort a real-Ractor sweep at the first
+            // Ractor::Dispatch call. Exclusive mode (RUBY_RACTOR_EXCLUSIVE)
+            // guarantees no other Ractor runs concurrently, so passing the
+            // original object by reference is safe; warn and continue.
+            rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION,
+                             "can not copy an unshareable %"PRIsVALUE" across Ractors; "
+                             "passing by reference under Ractor.check_isolation",
+                             rb_class_of(obj));
+            *ptype = basket_type_ref;
+            return obj;
+        }
         else {
             /* Snapshot the object on the sender side without calling the user-visible
              * #clone.  Both forms are off-heap, so an in-flight payload is never a GC

--- a/ruby.c
+++ b/ruby.c
@@ -402,6 +402,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("experimental", "", "Experimental features."),
         M("performance",  "", "Performance issues."),
         M("strict_unused_block", "", "Warning unused block strictly"),
+        M("ractor_isolation", "", "Ractor isolation violations."),
     };
     int i;
     const char *sb = highlight ? esc_standout+1 : esc_none;
@@ -1269,6 +1270,9 @@ proc_W_option(ruby_cmdline_options_t *opt, const char *s, int *warning)
         }
         else if (NAME_MATCH_P("strict_unused_block", s, len)) {
             bits = 1U << RB_WARN_CATEGORY_STRICT_UNUSED_BLOCK;
+        }
+        else if (NAME_MATCH_P("ractor_isolation", s, len)) {
+            bits = 1U << RB_WARN_CATEGORY_RACTOR_ISOLATION;
         }
         else {
             rb_warn("unknown warning category: '%s'", s);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -798,6 +798,380 @@ class TestRactor < Test::Unit::TestCase
     end
   end
 
+  def test_check_isolation_runs_in_a_non_main_ractor
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      result = Ractor.check_isolation(name: "isolation check") do
+        [Ractor.main?, Ractor.current == Ractor.main, Ractor.current.name]
+      end
+      assert_equal [false, false, "isolation check"], result
+    RUBY
+  end
+
+  def test_check_isolation_returns_the_block_value_by_reference
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      obj = Object.new
+      assert_same obj, Ractor.check_isolation { obj }
+    RUBY
+  end
+
+  def test_check_isolation_passes_args_and_closes_over_outer_variables
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      outer = [1, 2, 3]
+      arg = Object.new
+      returned_arg, returned_outer = Ractor.check_isolation(arg) do |a|
+        [a, outer]
+      end
+      assert_same arg, returned_arg
+      assert_same outer, returned_outer
+    RUBY
+  end
+
+  def test_check_isolation_handles_large_argument_lists_without_using_the_native_stack
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      marker = Object.new
+      args = Array.new(200_000, marker)
+      length, first, last = Ractor.check_isolation(*args) do |*values|
+        [values.length, values.first, values.last]
+      end
+      assert_equal 200_000, length
+      assert_same marker, first
+      assert_same marker, last
+    RUBY
+  end
+
+  def test_check_isolation_requires_a_block
+    assert_ractor(<<~'RUBY')
+      assert_raise(ArgumentError) { Ractor.check_isolation }
+    RUBY
+  end
+
+  def test_check_isolation_make_shareable_warns_and_continues_for_files
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      file = File.open(IO::NULL)
+      begin
+        result = Ractor.check_isolation(file) do |f|
+          Ractor.make_shareable(f)
+          :completed
+        end
+        assert_equal :completed, result
+        refute Ractor.shareable?(file)
+      ensure
+        file.close
+      end
+    RUBY
+  end
+
+  def test_check_isolation_warns_instead_of_raising
+    # Warnings originate in the special Ractor, so capture them with a
+    # shareable queue rather than replacing the main Ractor's $stderr.
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      class CheckIsolationFixture
+        @ivar = "ivar"
+        @@cvar = [1, 2, 3]
+        MUTABLE = "mutable"
+      end
+      $check_isolation_global = "global"
+      ISOLATION_WARNINGS = Thread::Queue.new
+      module CaptureIsolationWarnings
+        def warn(message, category: nil)
+          if category == :ractor_isolation && !Thread.current[:capturing_isolation]
+            Thread.current[:capturing_isolation] = true
+            begin
+              ISOLATION_WARNINGS << Ractor.make_shareable(message)
+            ensure
+              Thread.current[:capturing_isolation] = false
+            end
+            return nil
+          end
+          super
+        end
+      end
+      Warning.singleton_class.prepend(CaptureIsolationWarnings)
+      require "etc"
+
+      h = Hash.new(Mutex.new)
+      result = Ractor.check_isolation do
+        CheckIsolationFixture.instance_variable_get(:@ivar)
+        CheckIsolationFixture.class_variable_get(:@@cvar)
+        3.times { CheckIsolationFixture::MUTABLE } # exercise the constant cache
+        $check_isolation_global
+        CheckIsolationFixture.instance_variable_set(:@ivar, "new")
+        Ractor.make_shareable(h)
+        Etc.passwd
+        Thread.new { CheckIsolationFixture::MUTABLE }.join
+        :completed
+      end
+      assert_equal :completed, result
+
+      messages = []
+      messages << ISOLATION_WARNINGS.pop until ISOLATION_WARNINGS.empty?
+      combined = messages.join("\n")
+      assert_match(/instance variables of classes\/modules from non-main Ractors/, combined)
+      assert_match(/non-shareable class variable @@cvar/, combined)
+      assert_match(/non-shareable objects in constant CheckIsolationFixture::MUTABLE/, combined)
+      assert_match(/global variable \$check_isolation_global/, combined)
+      assert_match(/set instance variables of classes\/modules/, combined)
+      assert_match(/can not make shareable object/, combined)
+      assert_match(/ractor unsafe method called from not main ractor/, combined)
+    RUBY
+  end
+
+  def test_check_isolation_warns_on_outer_variable_capture
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      captured = []
+      OUTER_VARIABLE_WARNINGS = Thread::Queue.new
+      module CaptureOuterVariableWarnings
+        def warn(message, category: nil)
+          if category == :ractor_isolation
+            OUTER_VARIABLE_WARNINGS << Ractor.make_shareable(message)
+            return nil
+          end
+          super
+        end
+      end
+      Warning.singleton_class.prepend(CaptureOuterVariableWarnings)
+
+      result = Ractor.check_isolation { captured << :ran; captured }
+      assert_same captured, result
+      assert_equal [:ran], captured
+      messages = []
+      messages << OUTER_VARIABLE_WARNINGS.pop until OUTER_VARIABLE_WARNINGS.empty?
+      assert_match(/can not isolate a Proc because it accesses outer variables \(captured\)/,
+                   messages.join("\n"))
+    RUBY
+  end
+
+  def test_check_isolation_does_not_mark_an_invalid_proc_shareable
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      captured = []
+      callable = Ractor.check_isolation do
+        Ractor.shareable_proc { captured << :called; captured }
+      end
+
+      refute Ractor.shareable?(callable)
+      refute callable.frozen?
+      assert_same captured, callable.call
+      assert_equal [:called], captured
+    RUBY
+  end
+
+  def test_check_isolation_warns_and_executes_captured_define_method
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      captured = []
+      klass = Class.new
+      klass.define_method(:capture) { captured << :called; captured }
+      BMETHOD_WARNINGS = Thread::Queue.new
+      module CaptureBmethodWarnings
+        def warn(message, category: nil)
+          if category == :ractor_isolation && !Thread.current[:capturing_bmethod_warning]
+            Thread.current[:capturing_bmethod_warning] = true
+            begin
+              BMETHOD_WARNINGS << Ractor.make_shareable(message)
+            ensure
+              Thread.current[:capturing_bmethod_warning] = false
+            end
+            return nil
+          end
+          super
+        end
+      end
+      Warning.singleton_class.prepend(CaptureBmethodWarnings)
+
+      result = Ractor.check_isolation(klass) { |k| k.new.capture }
+      assert_same captured, result
+      assert_equal [:called], captured
+      messages = []
+      messages << BMETHOD_WARNINGS.pop until BMETHOD_WARNINGS.empty?
+      assert_match(/can not call method capture defined with an un-shareable Proc/,
+                   messages.join("\n"))
+    RUBY
+  end
+
+  def test_check_isolation_is_active_in_child_threads
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      class CheckIsolationChildThreadFixture
+        VALUE = []
+      end
+      CHILD_THREAD_WARNINGS = Thread::Queue.new
+      module CaptureChildThreadWarnings
+        def warn(message, category: nil)
+          if category == :ractor_isolation && !Thread.current[:capturing_child_thread_warning]
+            Thread.current[:capturing_child_thread_warning] = true
+            begin
+              CHILD_THREAD_WARNINGS << Ractor.make_shareable(message)
+            ensure
+              Thread.current[:capturing_child_thread_warning] = false
+            end
+            return nil
+          end
+          super
+        end
+      end
+      Warning.singleton_class.prepend(CaptureChildThreadWarnings)
+
+      value = Ractor.check_isolation do
+        Thread.new { CheckIsolationChildThreadFixture::VALUE }.value
+      end
+      assert_same CheckIsolationChildThreadFixture::VALUE, value
+      messages = []
+      messages << CHILD_THREAD_WARNINGS.pop until CHILD_THREAD_WARNINGS.empty?
+      assert_match(/non-shareable objects in constant CheckIsolationChildThreadFixture::VALUE/,
+                   messages.join("\n"))
+    RUBY
+  end
+
+  def test_ractor_new_still_enforces_isolation_after_check_isolation
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      nested_result = Ractor.check_isolation do
+        captured = Object.new
+        error = assert_raise(Ractor::IsolationError) do
+          Ractor.new { captured }
+        end
+        error.class
+      end
+      assert_equal Ractor::IsolationError, nested_result
+
+      captured = Object.new
+      assert_raise(Ractor::IsolationError) do
+        Ractor.new { captured }
+      end
+    RUBY
+  end
+
+  def test_check_isolation_warns_for_finalizers_on_foreign_objects
+    omit 'per-Ractor objspace semantics of the default GC' unless GC.config[:implementation] == 'default'
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      object = Object.new
+      finalizer = proc {}
+      FINALIZER_WARNINGS = Thread::Queue.new
+      module CaptureFinalizerWarnings
+        def warn(message, category: nil)
+          if category == :ractor_isolation && !Thread.current[:capturing_finalizer_warning]
+            Thread.current[:capturing_finalizer_warning] = true
+            begin
+              FINALIZER_WARNINGS << Ractor.make_shareable(message)
+            ensure
+              Thread.current[:capturing_finalizer_warning] = false
+            end
+            return nil
+          end
+          super
+        end
+      end
+      Warning.singleton_class.prepend(CaptureFinalizerWarnings)
+
+      defined, undefined = Ractor.check_isolation do
+        [ObjectSpace.define_finalizer(object, finalizer),
+         ObjectSpace.undefine_finalizer(object)]
+      end
+      assert_same finalizer, defined[1]
+      assert_same object, undefined
+
+      messages = []
+      messages << FINALIZER_WARNINGS.pop until FINALIZER_WARNINGS.empty?
+      combined = messages.join("\n")
+      assert_match(/can not define a finalizer for an object of another Ractor/, combined)
+      assert_match(/can not undefine a finalizer of an object of another Ractor/, combined)
+    RUBY
+  end
+
+  def test_check_isolation_reraises_block_exceptions
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      error = assert_raise(Ractor::RemoteError) do
+        Ractor.check_isolation { raise "boom" }
+      end
+      assert_equal "boom", error.cause.message
+    RUBY
+  end
+
+  def test_check_isolation_allows_dispatch_to_main
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      main_port = Ractor::Port.new
+      Thread.new do
+        callable, reply = main_port.receive
+        reply << callable.call
+      end
+
+      value = Ractor.check_isolation do
+        reply = Ractor::Port.new
+        main_port << [Ractor.shareable_proc { 40 + 2 }, reply]
+        reply.receive
+      end
+      assert_equal 42, value
+    RUBY
+  end
+
+  def test_check_isolation_emits_nonexclusive_advisory_once
+    assert_ractor(<<~'RUBY')
+      assert_warning(/Ractor.check_isolation: other Ractors can run in parallel/) do
+        Ractor.check_isolation { :first }
+      end
+      assert_no_warning(/other Ractors can run in parallel/) do
+        Ractor.check_isolation { :second }
+      end
+    RUBY
+  end
+
+  def test_check_isolation_first_called_from_an_ordinary_ractor
+    assert_ractor(<<~'RUBY')
+      ADVISORY_WARNINGS = Ractor::Port.new
+      module CaptureCheckIsolationAdvisory
+        def warn(message, **kwargs)
+          if message.include?("Ractor.check_isolation: other Ractors can run in parallel")
+            ADVISORY_WARNINGS << message
+            return nil
+          end
+          super
+        end
+      end
+      Warning.singleton_class.prepend(CaptureCheckIsolationAdvisory)
+
+      result = Ractor.new { Ractor.check_isolation { :ok } }.value
+
+      assert_equal :ok, result
+      assert_match(/Ractor.check_isolation: other Ractors can run in parallel/,
+                   ADVISORY_WARNINGS.receive)
+    RUBY
+  end
+
+  def test_check_isolation_blocks_other_ractors_in_exclusive_mode
+    assert_separately([{"RUBY_RACTOR_EXCLUSIVE" => "1"}, "-W:no-experimental"], <<~'RUBY', timeout: 30)
+      omit "M:N scheduling is not supported by this build" unless RUBY_DESCRIPTION.include?("+MN")
+
+      Warning[:ractor_isolation] = false
+      report = Ractor::Port.new
+      Thread.new do
+        report << :ready
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        loop do
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          break if now - t0 > 3.0
+          report << now
+          sleep 0.01
+        end
+        report << :done
+      end
+      assert_equal :ready, report.receive
+
+      start, finish = Ractor.check_isolation do
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        x = 0
+        x += 1 while Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0 < 1.0
+        [t0, Process.clock_gettime(Process::CLOCK_MONOTONIC)]
+      end
+
+      stamps = []
+      loop do
+        message = report.receive
+        break if message == :done
+        stamps << message
+      end
+      during = stamps.count { |time| time >= start && time <= finish }
+      assert_equal 0, during,
+        "expected no other Ractor to run during exclusive isolation check, observed #{during} ticks"
+    RUBY
+  end
+
   def assert_make_shareable(obj)
     refute Ractor.shareable?(obj), "object was already shareable"
     Ractor.make_shareable(obj)

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -121,7 +121,13 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err(%w(-We) + ['p $-W'], "", %w(2), [])
     assert_in_out_err(%w(-w -W0 -e) + ['p $-W'], "", %w(0), [])
 
-    categories = {deprecated: 1, experimental: 0, performance: 2, strict_unused_block: 3}
+    categories = {
+      deprecated: 1,
+      experimental: 0,
+      performance: 2,
+      strict_unused_block: 3,
+      ractor_isolation: 0,
+    }
     assert_equal categories.keys.sort, Warning.categories.sort
 
     categories.each do |category, level|

--- a/thread.c
+++ b/thread.c
@@ -625,7 +625,32 @@ thread_do_start_proc(rb_thread_t *th)
         VALUE self = rb_ractor_self(th->ractor);
         th->thgroup = th->ractor->thgroup_default = rb_obj_alloc(cThGroup);
 
-        VM_ASSERT(FIXNUM_P(args));
+        if (th->ractor->isolation_check) {
+            /* Isolation-check ractor (see thread_create_core): the block is not
+             * isolated and args were passed by reference as a real Array, so
+             * invoke the proc directly without going through the mailbox. Keep
+             * the proc's own self so closures over the enclosing scope keep
+             * working, mirroring the old inline Ractor.check_isolation block. */
+            args_len = RARRAY_LENINT(args);
+            if (args_len < 8) {
+                args_ptr = ALLOCA_N(VALUE, args_len);
+                MEMCPY((VALUE *)args_ptr, RARRAY_CONST_PTR(args), VALUE, args_len);
+                th->invoke_arg.proc.args = Qnil;
+            }
+            else {
+                args_ptr = RARRAY_CONST_PTR(args);
+            }
+            vm_check_ints_blocking(th->ec);
+
+            return rb_vm_invoke_proc(
+                th->ec, proc,
+                args_len, args_ptr,
+                th->invoke_arg.proc.kw_splat,
+                VM_BLOCK_HANDLER_NONE,
+                cref
+            );
+        }
+
         args_len = FIX2INT(args);
         args_ptr = ALLOCA_N(VALUE, args_len);
         rb_ractor_receive_parameters(th->ec, th->ractor, args_len, (VALUE *)args_ptr);
@@ -934,9 +959,19 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
         th->ractor = params->g;
         th->ec->ractor_id = rb_ractor_id(th->ractor);
         th->ractor->threads.main = th;
-        th->invoke_arg.proc.proc = rb_proc_isolate_bang(params->proc, Qnil);
-        th->invoke_arg.proc.args = INT2FIX(RARRAY_LENINT(params->args));
         th->invoke_arg.proc.kw_splat = rb_keyword_given_p();
+        if (th->ractor->isolation_check) {
+            /* This is a real non-main Ractor, but the Proc and arguments stay
+             * intact and are passed by reference. Report the Proc-isolation
+             * errors Ractor.new would raise, then run the original closure. */
+            rb_proc_check_isolation_warn(params->proc);
+            th->invoke_arg.proc.proc = params->proc;
+            th->invoke_arg.proc.args = params->args;
+        }
+        else {
+            th->invoke_arg.proc.proc = rb_proc_isolate_bang(params->proc, Qnil);
+            th->invoke_arg.proc.args = INT2FIX(RARRAY_LENINT(params->args));
+        }
         break;
 
       case thread_invoke_type_func:
@@ -984,7 +1019,9 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
         EC_PUSH_TAG(ec);
         if ((state = EC_EXEC_TAG()) == TAG_NONE) {
             rb_ractor_setup_default_port(params->g);
-            rb_ractor_send_parameters(ec, params->g, params->args);
+            if (!params->g->isolation_check) {
+                rb_ractor_send_parameters(ec, params->g, params->args);
+            }
         }
         EC_POP_TAG();
         if (state != TAG_NONE) {
@@ -1215,7 +1252,6 @@ rb_thread_create_ractor(rb_ractor_t *r, VALUE args, VALUE proc)
     }
     return thret;
 }
-
 
 struct join_arg {
     struct rb_waiting_list *waiter;

--- a/thread_sched.c
+++ b/thread_sched.c
@@ -1793,18 +1793,28 @@ thread_sched_atfork(struct rb_thread_sched *sched)
 #endif
 
 extern int ruby_mn_threads_enabled;
+extern int ruby_ractor_exclusive_enabled;
+
+static bool
+ractor_exclusive_env_p(void)
+{
+    const char *cstr = getenv("RUBY_RACTOR_EXCLUSIVE");
+    return cstr && atoi(cstr) > 0;
+}
 
 void
 ruby_mn_threads_params(void)
 {
     rb_vm_t *vm = GET_VM();
     rb_ractor_t *main_ractor = GET_RACTOR();
+    bool exclusive = USE_MN_THREADS && ractor_exclusive_env_p();
 
     const char *mn_threads_cstr = getenv("RUBY_MN_THREADS");
     bool enable_mn_threads = false;
 
-    if (USE_MN_THREADS && mn_threads_cstr && (enable_mn_threads = atoi(mn_threads_cstr) > 0)) {
+    if (USE_MN_THREADS && ((mn_threads_cstr && (enable_mn_threads = atoi(mn_threads_cstr) > 0)) || exclusive)) {
         // enabled
+        enable_mn_threads = true;
         ruby_mn_threads_enabled = 1;
     }
     main_ractor->threads.sched.enable_mn_threads = enable_mn_threads;
@@ -1817,6 +1827,13 @@ ruby_mn_threads_params(void)
         if (given_max_cpu > 0) {
             max_cpu = given_max_cpu;
         }
+    }
+
+    /* One shared native thread acts as a VM-wide GVL while still handing the
+     * run slot to another Ractor when the current one blocks. */
+    if (exclusive) {
+        max_cpu = 1;
+        ruby_ractor_exclusive_enabled = 1;
     }
 
     vm->ractor.sched.max_cpu = max_cpu;

--- a/variable.c
+++ b/variable.c
@@ -613,7 +613,7 @@ rb_find_global_entry(ID id)
     }
 
     if (UNLIKELY(!rb_ractor_main_p()) && (!entry || !entry->ractor_local)) {
-        rb_raise(rb_eRactorIsolationError, "can not access global variable %s from non-main Ractor", rb_id2name(id));
+        rb_ractor_isolation_violation("can not access global variable %s from non-main Ractor", rb_id2name(id));
     }
 
     return entry;
@@ -1150,7 +1150,7 @@ rb_f_global_variables(void)
     VALUE sym, backref = rb_backref_get();
 
     if (!rb_ractor_main_p()) {
-        rb_raise(rb_eRactorIsolationError, "can not access global variables from non-main Ractors");
+        rb_ractor_isolation_violation("can not access global variables from non-main Ractors");
     }
     /* gvar access (get/set) in boxes creates gvar entries globally */
 
@@ -1184,7 +1184,7 @@ rb_alias_variable(ID name1, ID name2)
     struct rb_id_table *gtbl = rb_global_tbl;
 
     if (!rb_ractor_main_p()) {
-        rb_raise(rb_eRactorIsolationError, "can not access global variables from non-main Ractors");
+        rb_ractor_isolation_violation("can not access global variables from non-main Ractors");
     }
 
     RB_VM_LOCKING() {
@@ -1217,7 +1217,7 @@ IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(ID id)
 {
     if (UNLIKELY(!rb_ractor_main_p())) {
         if (rb_is_instance_id(id)) { // check only normal ivars
-            rb_raise(rb_eRactorIsolationError, "can not set instance variables of classes/modules by non-main Ractors");
+            rb_ractor_isolation_violation("can not set instance variables of classes/modules by non-main Ractors");
         }
     }
 }
@@ -1226,7 +1226,9 @@ static void
 CVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(VALUE klass, ID id)
 {
     if (UNLIKELY(!rb_ractor_main_p())) {
-        rb_raise(rb_eRactorIsolationError, "can not set class variables from non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")", rb_id2str(id), klass);
+        /* See comment on the instance-variable warning below for why we
+         * pass rb_class_path() rather than the class itself. */
+        rb_ractor_isolation_violation("can not set class variables from non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")", rb_id2str(id), rb_class_path(klass));
     }
 }
 
@@ -1234,9 +1236,9 @@ static void
 cvar_read_ractor_check(VALUE klass, ID id, VALUE val)
 {
     if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
-        rb_raise(rb_eRactorIsolationError,
+        rb_ractor_isolation_violation(
                  "can not read non-shareable class variable %"PRIsVALUE" from non-main Ractors (%"PRIsVALUE")",
-                 rb_id2str(id), klass);
+                 rb_id2str(id), rb_class_path(klass));
     }
 }
 
@@ -1248,7 +1250,7 @@ ivar_ractor_check(VALUE obj, ID id)
         UNLIKELY(!rb_ractor_main_p()) &&
         UNLIKELY(rb_ractor_shareable_p(obj))) {
 
-        rb_raise(rb_eRactorIsolationError, "can not access instance variables of shareable objects from non-main Ractors");
+        rb_ractor_isolation_violation("can not access instance variables of shareable objects from non-main Ractors");
     }
 }
 
@@ -1561,12 +1563,13 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
 
     if (is_class && val != undef && rb_is_instance_id(id)) {
         if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
-            rb_raise(
-                rb_eRactorIsolationError,
+            /* Avoid calling a user-overridable to_s while reporting the
+             * violation; it may recurse through the same class ivar lookup. */
+            rb_ractor_isolation_violation(
                 "can not get unshareable values from instance variables of classes/modules from "
                 "non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")",
                 rb_id2str(id),
-                obj
+                rb_class_path(obj)
             );
         }
     }
@@ -1598,7 +1601,7 @@ rb_ivar_get_at(VALUE obj, attr_index_t index, ID id)
             VALUE val = rb_imemo_fields_ptr(fields_obj)[index];
 
             if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
-                rb_raise(rb_eRactorIsolationError,
+                rb_ractor_isolation_violation(
                         "can not get unshareable values from instance variables of classes/modules from non-main Ractors");
             }
 
@@ -3338,7 +3341,7 @@ rb_const_get_0(VALUE klass, ID id, int exclude, int recurse, int visibility)
     if (!UNDEF_P(c)) {
         if (UNLIKELY(!rb_ractor_main_p())) {
             if (!rb_ractor_shareable_p(c)) {
-                rb_raise(rb_eRactorIsolationError, "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main Ractor.", rb_class_path(found_in), rb_id2str(id));
+                rb_ractor_isolation_violation("can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main Ractor.", rb_class_path(found_in), rb_id2str(id));
             }
         }
         return c;
@@ -3847,7 +3850,7 @@ const_set(VALUE klass, ID id, VALUE val)
     }
 
     if (!rb_ractor_main_p() && !rb_ractor_shareable_p(val)) {
-        rb_raise(rb_eRactorIsolationError, "can not set constants with non-shareable objects by non-main Ractors");
+        rb_ractor_isolation_violation("can not set constants with non-shareable objects by non-main Ractors");
     }
 
     check_before_mod_set(klass, id, val, "constant");

--- a/version.c
+++ b/version.c
@@ -190,6 +190,11 @@ Init_version(void)
 
 int ruby_mn_threads_enabled;
 
+/* Set at boot (see ruby_mn_threads_params) when RUBY_RACTOR_EXCLUSIVE is
+ * truthy: the M:N scheduler runs with a single shared native thread so at
+ * most one thread executes Ruby VM-wide. Used by Ractor.check_isolation advisory. */
+int ruby_ractor_exclusive_enabled;
+
 #ifndef RB_DEFAULT_PARSER
 #define RB_DEFAULT_PARSER RB_DEFAULT_PARSER_PRISM
 #endif

--- a/vm.c
+++ b/vm.c
@@ -1463,8 +1463,19 @@ collect_outer_variable_names(ID id, VALUE val, void *ptr)
     return ID_TABLE_CONTINUE;
 }
 
+static void
+proc_isolation_violation_str(VALUE message, bool warn)
+{
+    if (warn) {
+        rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION, "%s", StringValueCStr(message));
+    }
+    else {
+        rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, message));
+    }
+}
+
 static const rb_env_t *
-env_copy(const VALUE *src_ep, VALUE read_only_variables)
+env_copy(const VALUE *src_ep, VALUE read_only_variables, bool warn, bool *valid)
 {
     const rb_env_t *src_env = (rb_env_t *)VM_ENV_ENVVAL(src_ep);
     VM_ASSERT(src_env->ep == src_ep);
@@ -1504,20 +1515,30 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
                         VALUE name = rb_id2str(id);
                         VALUE msg = rb_sprintf("cannot make a shareable Proc because "
                                                "the outer variable '%" PRIsVALUE "' may be reassigned.", name);
-                        rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, msg));
+                        proc_isolation_violation_str(msg, warn);
+                        *valid = false;
                     }
 
                     // check shareable
                     VALUE v = src_env->env[j];
                     if (!rb_ractor_shareable_p(v)) {
                         VALUE name = rb_id2str(id);
-                        VALUE msg = rb_sprintf("cannot make a shareable Proc because it can refer"
-                                               " unshareable object %+" PRIsVALUE " from ", v);
+                        VALUE msg;
+                        if (warn) {
+                            msg = rb_sprintf("cannot make a shareable Proc because it can refer "
+                                             "an unshareable object of class %+" PRIsVALUE " from ",
+                                             rb_class_of(v));
+                        }
+                        else {
+                            msg = rb_sprintf("cannot make a shareable Proc because it can refer"
+                                             " unshareable object %+" PRIsVALUE " from ", v);
+                        }
                         if (name)
                             rb_str_catf(msg, "variable '%" PRIsVALUE "'", name);
                         else
                             rb_str_cat_cstr(msg, "a hidden variable");
-                        rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, msg));
+                        proc_isolation_violation_str(msg, warn);
+                        *valid = false;
                     }
                     RB_OBJ_WRITE((VALUE)copied_env, &env_body[j], v);
                     rb_ary_delete_at(read_only_variables, i);
@@ -1529,7 +1550,7 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
 
     if (!VM_ENV_LOCAL_P(src_ep)) {
         const VALUE *prev_ep = VM_ENV_PREV_EP(src_env->ep);
-        const rb_env_t *new_prev_env = env_copy(prev_ep, read_only_variables);
+        const rb_env_t *new_prev_env = env_copy(prev_ep, read_only_variables, warn, valid);
         ep[VM_ENV_DATA_INDEX_SPECVAL] = VM_GUARDED_PREV_EP(new_prev_env->ep);
         RB_OBJ_WRITTEN(copied_env, Qundef, new_prev_env);
         VM_ENV_FLAGS_UNSET(ep, VM_ENV_FLAG_LOCAL);
@@ -1538,21 +1559,26 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
         ep[VM_ENV_DATA_INDEX_SPECVAL] = VM_BLOCK_HANDLER_NONE;
     }
 
-    RB_OBJ_SET_SHAREABLE((VALUE)copied_env);
+    if (*valid) {
+        RB_OBJ_SET_SHAREABLE((VALUE)copied_env);
+    }
     return copied_env;
 }
 
-static void
-proc_isolate_env(VALUE self, rb_proc_t *proc, VALUE read_only_variables)
+static bool
+proc_isolate_env(VALUE self, rb_proc_t *proc, VALUE read_only_variables, bool warn, bool valid)
 {
     const struct rb_captured_block *captured = &proc->block.as.captured;
-    const rb_env_t *env = env_copy(captured->ep, read_only_variables);
+    const rb_env_t *env = env_copy(captured->ep, read_only_variables, warn, &valid);
+    if (!valid) return false;
+
     *((const VALUE **)&proc->block.as.captured.ep) = env->ep;
     RB_OBJ_WRITTEN(self, Qundef, env);
+    return true;
 }
 
 static VALUE
-proc_shared_outer_variables(struct rb_id_table *outer_variables, bool isolate, const char *message)
+proc_shared_outer_variables(struct rb_id_table *outer_variables, bool isolate, const char *message, bool warn, bool *valid)
 {
     struct collect_outer_variable_name_data data = {
         .isolate = isolate,
@@ -1575,10 +1601,13 @@ proc_shared_outer_variables(struct rb_id_table *outer_variables, bool isolate, c
         }
         if (*sep == ',') rb_str_cat_cstr(str, ")");
         rb_str_cat_cstr(str, data.yield ? " and uses 'yield'." : ".");
-        rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, str));
+        proc_isolation_violation_str(str, warn);
+        if (valid) *valid = false;
     }
     else if (data.yield) {
-        rb_raise(rb_eRactorIsolationError, "can not %s because it uses 'yield'.", message);
+        VALUE str = rb_sprintf("can not %s because it uses 'yield'.", message);
+        proc_isolation_violation_str(str, warn);
+        if (valid) *valid = false;
     }
 
     return data.read_only;
@@ -1600,10 +1629,10 @@ rb_proc_isolate_bang(VALUE self, VALUE replace_self)
         }
 
         if (ISEQ_BODY(iseq)->outer_variables) {
-            proc_shared_outer_variables(ISEQ_BODY(iseq)->outer_variables, true, "isolate a Proc");
+            proc_shared_outer_variables(ISEQ_BODY(iseq)->outer_variables, true, "isolate a Proc", false, NULL);
         }
 
-        proc_isolate_env(self, proc, Qfalse);
+        if (!proc_isolate_env(self, proc, Qfalse, false, true)) return self;
         proc->header.is_isolated = TRUE;
         RB_OBJ_WRITE(self, &proc->block.as.captured.self, Qnil);
     }
@@ -1620,34 +1649,52 @@ rb_proc_isolate(VALUE self)
     return dst;
 }
 
+/* Report the Proc-isolation checks performed by Ractor.new without mutating
+ * the Proc, so Ractor.check_isolation can execute the original closure. */
+void
+rb_proc_check_isolation_warn(VALUE self)
+{
+    const rb_iseq_t *iseq = vm_proc_iseq(self);
+
+    if (iseq) {
+        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
+        if (proc->block.type == block_type_iseq && ISEQ_BODY(iseq)->outer_variables) {
+            proc_shared_outer_variables(ISEQ_BODY(iseq)->outer_variables, true, "isolate a Proc", true, NULL);
+        }
+    }
+}
+
 VALUE
 rb_proc_ractor_make_shareable(VALUE self, VALUE replace_self)
 {
     const rb_iseq_t *iseq = vm_proc_iseq(self);
+    bool warn = rb_ractor_isolation_check_p();
 
     if (iseq) {
         rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
 
         if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
-        if (!UNDEF_P(replace_self)) {
-            RB_OBJ_WRITE(self, &proc->block.as.captured.self, replace_self);
-        }
-
-        if (!rb_ractor_shareable_p(vm_block_self(&proc->block))) {
-            rb_raise(rb_eRactorIsolationError,
-                     "Proc's self is not shareable: %" PRIsVALUE,
-                     self);
+        bool valid = true;
+        VALUE proc_self = UNDEF_P(replace_self) ? vm_block_self(&proc->block) : replace_self;
+        if (!rb_ractor_shareable_p(proc_self)) {
+            VALUE message = rb_sprintf("Proc's self is not shareable: %" PRIsVALUE, self);
+            proc_isolation_violation_str(message, warn);
+            valid = false;
         }
 
         VALUE read_only_variables = Qfalse;
 
         if (ISEQ_BODY(iseq)->outer_variables) {
             read_only_variables =
-                proc_shared_outer_variables(ISEQ_BODY(iseq)->outer_variables, false, "make a Proc shareable");
+                proc_shared_outer_variables(ISEQ_BODY(iseq)->outer_variables, false,
+                                            "make a Proc shareable", warn, &valid);
         }
 
-        proc_isolate_env(self, proc, read_only_variables);
+        if (!proc_isolate_env(self, proc, read_only_variables, warn, valid)) return self;
+        if (!UNDEF_P(replace_self)) {
+            RB_OBJ_WRITE(self, &proc->block.as.captured.self, replace_self);
+        }
         proc->header.is_isolated = TRUE;
     }
     else {
@@ -1656,9 +1703,9 @@ rb_proc_ractor_make_shareable(VALUE self, VALUE replace_self)
 
         VALUE proc_self = vm_block_self(block);
         if (!rb_ractor_shareable_p(proc_self)) {
-            rb_raise(rb_eRactorIsolationError,
-                     "Proc's self is not shareable: %" PRIsVALUE,
-                     self);
+            VALUE message = rb_sprintf("Proc's self is not shareable: %" PRIsVALUE, self);
+            proc_isolation_violation_str(message, warn);
+            if (warn) return self;
         }
     }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1394,6 +1394,7 @@ const rb_cref_t *rb_proc_refinements_cref_for_call(VALUE procval);
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_proc_isolate(VALUE self);
 VALUE rb_proc_isolate_bang(VALUE self, VALUE replace_self);
+void rb_proc_check_isolation_warn(VALUE self);
 VALUE rb_proc_ractor_make_shareable(VALUE proc, VALUE replace_self);
 RUBY_SYMBOL_EXPORT_END
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1144,7 +1144,7 @@ vm_get_ev_const(rb_execution_context_t *ec, VALUE orig_klass, ID id, bool allow_
                         else {
                             if (UNLIKELY(!rb_ractor_main_p())) {
                                 if (!rb_ractor_shareable_p(val)) {
-                                    rb_raise(rb_eRactorIsolationError,
+                                    rb_ractor_isolation_violation(
                                              "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main ractor.", rb_class_path(klass), rb_id2str(id));
                                 }
                             }
@@ -1262,6 +1262,9 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
                 // and modules. So we can skip locking.
                 // Second, other ractors need to check the shareability of the
                 // values returned from the class ivars.
+                //
+                // Ractor.check_isolation also routes here so the isolation
+                // checks in the general path get a chance to fire.
 
                 if (default_value == Qundef) { // defined?
                     return rb_ivar_defined(obj, id) ? Qtrue : Qundef;
@@ -1429,6 +1432,8 @@ static VALUE
 vm_setivar_class(VALUE obj, VALUE val, rb_setivar_cache cache)
 {
     if (UNLIKELY(!rb_ractor_main_p())) {
+        // Bail out of the inline cache fast path so the slow path can run
+        // the isolation check (also fires under Ractor.check_isolation).
         return Qundef;
     }
 
@@ -3545,9 +3550,21 @@ vm_call_iseq_setup_tailcall(rb_execution_context_t *ec, rb_control_frame_t *cfp,
 static void
 ractor_unsafe_check(void)
 {
-    if (!rb_ractor_main_p()) {
-        rb_raise(rb_eRactorUnsafeError, "ractor unsafe method called from not main ractor");
+    if (LIKELY(rb_ractor_main_p())) return;
+
+    if (rb_ractor_isolation_check_p()) {
+        // Ractor.check_isolation: downgrade to a :ractor_isolation warning so
+        // the sweep can keep going. We deliberately route through the same
+        // category as the IsolationError downgrades because from the caller's
+        // point of view both mean "this code would not work in a Ractor".
+        rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION,
+                         "ractor unsafe method called from not main ractor");
+        return;
     }
+
+    // Real non-main Ractor: preserve the existing UnsafeError behaviour so
+    // user code that rescues Ractor::UnsafeError specifically keeps working.
+    rb_raise(rb_eRactorUnsafeError, "ractor unsafe method called from not main ractor");
 }
 
 static VALUE
@@ -4105,6 +4122,36 @@ vm_call_attrset(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
     return vm_call_attrset_direct(ec, cfp, calling->cc, calling->recv);
 }
 
+// True if a bmethod's Proc may not be invoked from the current Ractor: it is
+// not shareable and was defined in a different Ractor.
+static inline bool
+vm_bmethod_proc_uncallable_p(rb_execution_context_t *ec, const rb_callable_method_entry_t *cme, VALUE procv)
+{
+    return !RB_OBJ_SHAREABLE_P(procv) &&
+        cme->def->body.bmethod.defined_ractor_id != rb_ec_ractor_id(ec);
+}
+
+// A method defined with a genuinely non-shareable Proc (e.g. define_method with
+// a Proc capturing unshareable state) can normally only be called from the
+// Ractor that defined it; calling it elsewhere raises. Under
+// Ractor.check_isolation we downgrade that to a :ractor_isolation warning and
+// fall through to invoke it anyway. RUBY_RACTOR_EXCLUSIVE makes this
+// race-free; without that scheduler mode the public wrapper emits an advisory.
+// Continuing lets a real-Ractor sweep collect the violations that follow
+// instead of dying on the first bmethod call.
+static void
+vm_bmethod_unshareable_proc_violation(rb_execution_context_t *ec, const rb_callable_method_entry_t *cme)
+{
+    if (rb_ractor_isolation_check_p()) {
+        rb_category_warn(RB_WARN_CATEGORY_RACTOR_ISOLATION,
+                         "can not call method %"PRIsVALUE" defined with an un-shareable Proc from a different Ractor",
+                         rb_id2str(cme->called_id));
+    }
+    else {
+        rb_raise(rb_eRuntimeError, "defined with an un-shareable Proc in a different Ractor");
+    }
+}
+
 static inline VALUE
 vm_call_bmethod_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv)
 {
@@ -4114,9 +4161,8 @@ vm_call_bmethod_body(rb_execution_context_t *ec, struct rb_calling_info *calling
     const rb_callable_method_entry_t *cme = vm_cc_cme(cc);
     VALUE procv = cme->def->body.bmethod.proc;
 
-    if (!RB_OBJ_SHAREABLE_P(procv) &&
-        cme->def->body.bmethod.defined_ractor_id != rb_ec_ractor_id(ec)) {
-        rb_raise(rb_eRuntimeError, "defined with an un-shareable Proc in a different Ractor");
+    if (vm_bmethod_proc_uncallable_p(ec, cme, procv)) {
+        vm_bmethod_unshareable_proc_violation(ec, cme);
     }
 
     /* control block frame */
@@ -4137,9 +4183,8 @@ vm_call_iseq_bmethod(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct
     const rb_callable_method_entry_t *cme = vm_cc_cme(cc);
     VALUE procv = cme->def->body.bmethod.proc;
 
-    if (!RB_OBJ_SHAREABLE_P(procv) &&
-        cme->def->body.bmethod.defined_ractor_id != rb_ec_ractor_id(ec)) {
-        rb_raise(rb_eRuntimeError, "defined with an un-shareable Proc in a different Ractor");
+    if (vm_bmethod_proc_uncallable_p(ec, cme, procv)) {
+        vm_bmethod_unshareable_proc_violation(ec, cme);
     }
 
     rb_proc_t *proc;


### PR DESCRIPTION
Run the block in a real non-main Ractor while preserving its closure and argument identities. Downgrade isolation violations to categorized warnings so applications can sweep worker-Ractor compatibility without stopping at the first failure.

Support an exclusive scheduler mode for race-free checks and cover the isolation gates, fast paths, messaging, and thread inheritance.