### PR TITLE
ZJIT: Implement load-aaron-optimizations

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -140,6 +140,8 @@ class << RubyVM::ZJIT
       :caller_splat_optimized,
     ], buf:, stats:, right_align: true, base: :send_count)
     print_counters([
+      :aaron_count,
+      :aaron_length_count,
       :dynamic_setivar_count,
       :dynamic_getivar_count,
       :dynamic_definedivar_count,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6445,6 +6445,67 @@ impl Function {
     }
 
 
+    fn optimize_load_aaron(&mut self) {
+        for block in self.reverse_post_order() {
+            let mut compile_time_heap: HashMap<InsnId, usize>  = HashMap::new();
+            let old_insns = std::mem::take(&mut self.blocks[block].insns);
+            let mut new_insns = Vec::with_capacity(old_insns.len());
+            for insn_id in old_insns {
+                let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
+                    Insn::NewArray { elements, .. } => {
+                        compile_time_heap.insert(self.find_id(insn_id), elements.len());
+                        insn_id
+                    },
+                    Insn::ArrayLength { array, .. } => {
+                        if let Some(size) = compile_time_heap.get(&self.find_id(*array)) {
+                            let new_insn_id = self.new_insn(Insn::Const { val: Const::CInt64(*size as i64) });
+                            self.insn_types[new_insn_id] = self.infer_type(new_insn_id);
+                            new_insns.push(self.new_insn(Insn::IncrCounter(Counter::aaron_length_count)));
+                            self.make_equal_to(insn_id, new_insn_id);
+                            new_insn_id
+                        } else {
+                            insn_id
+                        }
+                    },
+                    Insn::ArrayAref { array, index } => {
+                        if let Some(size) = compile_time_heap.get(&self.find_id(*array)) {
+                            let size = *size;
+                            let array = *array;
+
+                            if let Insn::Const { val: Const::CInt64(index_const) } = self.resolve(*index).insn(self) {
+                                let index_const = *index_const;
+                                if index_const >= 0 && index_const < size as i64 {
+                                    if let Insn::NewArray { elements, .. } = self.resolve(array).insn(self) {
+                                        let new_insn_id = elements[index_const as usize];
+                                        self.make_equal_to(insn_id, new_insn_id);
+                                        self.new_insn(Insn::IncrCounter(Counter::aaron_count))
+                                    } else {
+                                        insn_id
+                                    }
+                                } else {
+                                    insn_id
+                                }
+                            } else {
+                                insn_id
+                            }
+                        } else {
+                            insn_id
+                        }
+                    },
+                    insn => {
+                        if insn.effects_of().includes(Effect::write(abstract_heaps::Memory)) {
+                            compile_time_heap.clear();
+                        }
+                        insn_id
+                    }
+                };
+
+                new_insns.push(replacement_insn);
+            }
+            self.blocks[block].insns = new_insns;
+        }
+    }
+
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
             let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
@@ -7429,6 +7490,7 @@ impl Function {
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
             (remove_trivial_block_params) => { Counter::compile_hir_remove_trivial_block_params_time_ns };
+            (optimize_load_aaron) => { Counter::compile_hir_optimize_load_store_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -7481,6 +7543,7 @@ impl Function {
             };
             run_pass!(convert_no_profile_sends);
             run_pass!(remove_trivial_block_params);
+            run_pass!(optimize_load_aaron);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -473,6 +473,9 @@ make_counters! {
     load_field_count,
     store_field_count,
 
+    aaron_count,
+    aaron_length_count,
+
     invokeblock_handler_monomorphic_iseq,
     invokeblock_handler_monomorphic_ifunc,
     invokeblock_handler_monomorphic_other,


### PR DESCRIPTION
For this Ruby code:

```ruby
class Foo
  def initialize a, b, c
    @a, @b, @c = a, b, c
  end
end

5.times { Foo.new(1, 2, 3) }
```

This PR converts this HIR:

```
Optimized HIR:
fn block in <main>@test.rb:8:
bb1():
  EntryPoint interpreter
  v1:BasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:BasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:BasicObject):
  v10:NilClass = Const Value(nil)
  PatchPoint StableConstantNames(0x862d29308, Foo)
  v13:ClassSubclass[Foo@0x1042fc060] = Const Value(VALUE(0x1042fc060))
  v15:Fixnum[1] = Const Value(1)
  v17:Fixnum[2] = Const Value(2)
  v19:Fixnum[3] = Const Value(3)
  PatchPoint MethodRedefined(Foo@0x1042fc060, new@0x1271, cme:0x104284448)
  v51:ObjectSubclass[class_exact:Foo] = ObjectAllocClass Foo:VALUE(0x1042fc060)
  PatchPoint NoSingletonClass(Foo@0x1042fc060)
  PatchPoint MethodRedefined(Foo@0x1042fc060, initialize@0xcb1, cme:0x1043568f8)
  PushInlineFrame :initialize, v51 (0x1042a5520), num_args=3
  v70:ArrayExact = NewArray v15, v17, v19
  v74:CInt64 = ArrayLength v70
  v75:CInt64[3] = Const CInt64(3)
  v76:CInt64 = GuardGreaterEq v74, v75
  v77:CInt64[2] = Const CInt64(2)
  v78:BasicObject = ArrayAref v70, v77
  v79:CInt64[1] = Const CInt64(1)
  v80:BasicObject = ArrayAref v70, v79
  v81:CInt64[0] = Const CInt64(0)
  v82:BasicObject = ArrayAref v70, v81
  PatchPoint SingleRactorMode
  v86:CShape = LoadField v51, :shape_id@0x4
  v87:CShape[0x180000] = GuardBitEquals v86, CShape(0x180000) recompile
  StoreField v51, :@a@0x10, v82
  WriteBarrier v51, v82
  v90:CShape[0x180009] = Const CShape(0x180009)
  StoreField v51, :shape_id@0x4, v90
  PatchPoint SingleRactorMode
  StoreField v51, :@b@0x18, v80
  WriteBarrier v51, v80
  v100:CShape[0x18000a] = Const CShape(0x18000a)
  StoreField v51, :shape_id@0x4, v100
  PatchPoint SingleRactorMode
  StoreField v51, :@c@0x20, v78
  WriteBarrier v51, v78
  v110:CShape[0x18000b] = Const CShape(0x18000b)
  StoreField v51, :shape_id@0x4, v110
  CheckInterrupts
  PopInlineFrame
  Return v51
```

To this HIR:

```
Optimized HIR:
fn block in <main>@test.rb:8:
bb1():
  EntryPoint interpreter
  v1:BasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:BasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:BasicObject):
  v10:NilClass = Const Value(nil)
  PatchPoint StableConstantNames(0xae2d35f88, Foo)
  v13:ClassSubclass[Foo@0x106f0c060] = Const Value(VALUE(0x106f0c060))
  v15:Fixnum[1] = Const Value(1)
  v17:Fixnum[2] = Const Value(2)
  v19:Fixnum[3] = Const Value(3)
  PatchPoint MethodRedefined(Foo@0x106f0c060, new@0x1271, cme:0x106e94448)
  v51:ObjectSubclass[class_exact:Foo] = ObjectAllocClass Foo:VALUE(0x106f0c060)
  PatchPoint NoSingletonClass(Foo@0x106f0c060)
  PatchPoint MethodRedefined(Foo@0x106f0c060, initialize@0xcb1, cme:0x106f668f8)
  PushInlineFrame :initialize, v51 (0x106eb5520), num_args=3
  v70:ArrayExact = NewArray v15, v17, v19
  PatchPoint SingleRactorMode
  v86:CShape = LoadField v51, :shape_id@0x4
  v87:CShape[0x180000] = GuardBitEquals v86, CShape(0x180000) recompile
  StoreField v51, :@a@0x10, v15
  v90:CShape[0x180009] = Const CShape(0x180009)
  StoreField v51, :shape_id@0x4, v90
  PatchPoint SingleRactorMode
  StoreField v51, :@b@0x18, v17
  v100:CShape[0x18000a] = Const CShape(0x18000a)
  StoreField v51, :shape_id@0x4, v100
  PatchPoint SingleRactorMode
  StoreField v51, :@c@0x20, v19
  v110:CShape[0x18000b] = Const CShape(0x18000b)
  StoreField v51, :shape_id@0x4, v110
  CheckInterrupts
  PopInlineFrame
  Return v51
```

When an array length is known at compile time, we can fold away guards, and in the case of multi-assignment pull the vregs to the assignment rather than reading back out of the array.

We did this optimization today at the pairing session just to see if we could do it. Unfortunately we found it wasn't very effective.  Not many people seem to use this pattern.  It might be interesting to fold this in to an optimization pass that does similar walks on the CFG, but this particular optimization pass didn't seem to do much.